### PR TITLE
Update boostrap and list of all available responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ python:
   - "2.7"
 install:
   - "pip install -e .[testing] --use-mirrors"
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libatlas-dev libatlas-base-dev liblapack-dev gfortran
+
 script: nosetests
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
 install:
   - "pip install -e .[testing] --use-mirrors"
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libatlas-dev libatlas-base-dev liblapack-dev gfortran
-  - pip install -qq scipy
+  - sudo apt-get install python-numpy python-scipy
 
 script: nosetests
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libatlas-dev libatlas-base-dev liblapack-dev gfortran
+  - pip install -qq scipy
 
 script: nosetests
 branches:

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (c) 2006 Zope Corporation and Contributors.
+# Copyright (c) 2006 Zope Foundation and Contributors.
 # All Rights Reserved.
 #
 # This software is subject to the provisions of the Zope Public License,
@@ -16,98 +16,163 @@
 Simply run this script in a directory containing a buildout.cfg.
 The script accepts buildout command-line options, so you can
 use the -c option to specify an alternate configuration file.
-
-$Id: bootstrap.py 102545 2009-08-06 14:49:47Z chrisw $
 """
 
-import os, shutil, sys, tempfile, urllib2
+import os
+import shutil
+import sys
+import tempfile
+
 from optparse import OptionParser
 
 tmpeggs = tempfile.mkdtemp()
 
-is_jython = sys.platform.startswith('java')
+usage = '''\
+[DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
 
-# parsing arguments
-parser = OptionParser()
-parser.add_option("-v", "--version", dest="version",
-                          help="use a specific zc.buildout version")
-parser.add_option("-d", "--distribute",
-                   action="store_true", dest="distribute", default=True,
-                   help="Use Disribute rather than Setuptools.")
+Bootstraps a buildout-based project.
+
+Simply run this script in a directory containing a buildout.cfg, using the
+Python that you want bin/buildout to use.
+
+Note that by using --find-links to point to local resources, you can keep 
+this script from going over the network.
+'''
+
+parser = OptionParser(usage=usage)
+parser.add_option("-v", "--version", help="use a specific zc.buildout version")
+
+parser.add_option("-t", "--accept-buildout-test-releases",
+                  dest='accept_buildout_test_releases',
+                  action="store_true", default=False,
+                  help=("Normally, if you do not specify a --version, the "
+                        "bootstrap script and buildout gets the newest "
+                        "*final* versions of zc.buildout and its recipes and "
+                        "extensions for you.  If you use this flag, "
+                        "bootstrap and buildout will get the newest releases "
+                        "even if they are alphas or betas."))
+parser.add_option("-c", "--config-file",
+                  help=("Specify the path to the buildout configuration "
+                        "file to be used."))
+parser.add_option("-f", "--find-links",
+                  help=("Specify a URL to search for buildout releases"))
+parser.add_option("--allow-site-packages",
+                  action="store_true", default=False,
+                  help=("Let bootstrap.py use existing site packages"))
+
 
 options, args = parser.parse_args()
 
-if options.version is not None:
-    VERSION = '==%s' % options.version
-else:
-    VERSION = ''
+######################################################################
+# load/install setuptools
 
-USE_DISTRIBUTE = options.distribute
-args = args + ['bootstrap']
-
-to_reload = False
 try:
-    import pkg_resources
-    if not hasattr(pkg_resources, '_distribute'):
-        to_reload = True
-        raise ImportError
-except ImportError:
-    ez = {}
-    if USE_DISTRIBUTE:
-        exec urllib2.urlopen('http://python-distribute.org/distribute_setup.py'
-                         ).read() in ez
-        ez['use_setuptools'](to_dir=tmpeggs, download_delay=0, no_fake=True)
-    else:
-        exec urllib2.urlopen('http://peak.telecommunity.com/dist/ez_setup.py'
-                             ).read() in ez
-        ez['use_setuptools'](to_dir=tmpeggs, download_delay=0)
-
-    if to_reload:
-        reload(pkg_resources)
-    else:
+    if options.allow_site_packages:
+        import setuptools
         import pkg_resources
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
 
-if sys.platform == 'win32':
-    def quote(c):
-        if ' ' in c:
-            return '"%s"' % c # work around spawn lamosity on windows
-        else:
-            return c
-else:
-    def quote (c):
-        return c
+ez = {}
+exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
 
-cmd = 'from setuptools.command.easy_install import main; main()'
-ws  = pkg_resources.working_set
+if not options.allow_site_packages:
+    # ez_setup imports site, which adds site packages
+    # this will remove them from the path to ensure that incompatible versions 
+    # of setuptools are not in the path
+    import site
+    # inside a virtualenv, there is no 'getsitepackages'. 
+    # We can't remove these reliably
+    if hasattr(site, 'getsitepackages'):
+        for sitepackage_path in site.getsitepackages():
+            sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
 
-if USE_DISTRIBUTE:
-    requirement = 'distribute'
-else:
-    requirement = 'setuptools'
+setup_args = dict(to_dir=tmpeggs, download_delay=0)
+ez['use_setuptools'](**setup_args)
+import setuptools
+import pkg_resources
 
-if is_jython:
-    import subprocess
+# This does not (always?) update the default working set.  We will
+# do it.
+for path in sys.path:
+    if path not in pkg_resources.working_set.entries:
+        pkg_resources.working_set.add_entry(path)
 
-    assert subprocess.Popen([sys.executable] + ['-c', quote(cmd), '-mqNxd',
-           quote(tmpeggs), 'zc.buildout' + VERSION],
-           env=dict(os.environ,
-               PYTHONPATH=
-               ws.find(pkg_resources.Requirement.parse(requirement)).location
-               ),
-           ).wait() == 0
+######################################################################
+# Install buildout
 
-else:
-    assert os.spawnle(
-        os.P_WAIT, sys.executable, quote (sys.executable),
-        '-c', quote (cmd), '-mqNxd', quote (tmpeggs), 'zc.buildout' + VERSION,
-        dict(os.environ,
-            PYTHONPATH=
-            ws.find(pkg_resources.Requirement.parse(requirement)).location
-            ),
-        ) == 0
+ws = pkg_resources.working_set
+
+cmd = [sys.executable, '-c',
+       'from setuptools.command.easy_install import main; main()',
+       '-mZqNxd', tmpeggs]
+
+find_links = os.environ.get(
+    'bootstrap-testing-find-links',
+    options.find_links or
+    ('http://downloads.buildout.org/'
+     if options.accept_buildout_test_releases else None)
+    )
+if find_links:
+    cmd.extend(['-f', find_links])
+
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+requirement = 'zc.buildout'
+version = options.version
+if version is None and not options.accept_buildout_test_releases:
+    # Figure out the most recent final version of zc.buildout.
+    import setuptools.package_index
+    _final_parts = '*final-', '*final'
+
+    def _final_version(parsed_version):
+        for part in parsed_version:
+            if (part[:1] == '*') and (part not in _final_parts):
+                return False
+        return True
+    index = setuptools.package_index.PackageIndex(
+        search_path=[setuptools_path])
+    if find_links:
+        index.add_find_links((find_links,))
+    req = pkg_resources.Requirement.parse(requirement)
+    if index.obtain(req) is not None:
+        best = []
+        bestv = None
+        for dist in index[req.project_name]:
+            distv = dist.parsed_version
+            if _final_version(distv):
+                if bestv is None or distv > bestv:
+                    best = [dist]
+                    bestv = distv
+                elif distv == bestv:
+                    best.append(dist)
+        if best:
+            best.sort()
+            version = best[-1].version
+if version:
+    requirement = '=='.join((requirement, version))
+cmd.append(requirement)
+
+import subprocess
+if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=setuptools_path)) != 0:
+    raise Exception(
+        "Failed to execute command:\n%s" % repr(cmd)[1:-1])
+
+######################################################################
+# Import and run buildout
 
 ws.add_entry(tmpeggs)
-ws.require('zc.buildout' + VERSION)
+ws.require(requirement)
 import zc.buildout.buildout
+
+if not [a for a in args if '=' not in a]:
+    args.append('bootstrap')
+
+# if -c was provided, we push it back into args for buildout' main function
+if options.config_file is not None:
+    args[0:0] = ['-c', options.config_file]
+
 zc.buildout.buildout.main(args)
 shutil.rmtree(tmpeggs)

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ if sys.version_info < (2, 7):
 
 functions_extras = [
     'gsw',
+    'scipy', # dependency from gsw
     'coards',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ install_requires = [
     'docopt',
     'gunicorn',
     'PasteDeploy',
-    'wsgi_intercept',
     'six',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ install_requires = [
     'docopt',
     'gunicorn',
     'PasteDeploy',
+    'wsgi_intercept',
     'six',
 ]
 

--- a/src/pydap/wsgi/app.py
+++ b/src/pydap/wsgi/app.py
@@ -32,6 +32,7 @@ from six import string_types
 
 from pydap.lib import __version__
 from pydap.handlers.lib import get_handler, load_handlers
+from pydap.responses.lib import load_responses
 from pydap.exceptions import ExtensionNotSupportedError
 from pydap.wsgi.ssf import ServerSideFunctions
 
@@ -97,10 +98,9 @@ class DapServer(object):
             "name": os.path.split(path)[1],
             "size": os.path.getsize(path),
             "last_modified": datetime.fromtimestamp(os.path.getmtime(path)),
-            "supported": supported(path, self.handlers),
+            "supported": supported(path, self.handlers)
         } for path in content if os.path.isfile(path)]
         files.sort(key=lambda d: alphanum_key(d["name"]))
-
         directories = [{
             "name": os.path.split(path)[1],
             "last_modified": datetime.fromtimestamp(os.path.getmtime(path)),
@@ -113,6 +113,8 @@ class DapServer(object):
             "title": token,
         } for i, token in enumerate(tokens) if token]
 
+        responses = load_responses()
+
         context = {
             "root": req.application_url,
             "location": req.path_url,
@@ -120,6 +122,7 @@ class DapServer(object):
             "directories": directories,
             "files": files,
             "version": __version__,
+            "responses": responses
         }
         template = self.env.get_template("index.html")
         return Response(
@@ -250,7 +253,8 @@ def main():  # pragma: no cover
         host=arguments["--bind"],
         port=int(arguments["--port"]),
         workers=workers,
-        worker_class=arguments["--worker-class"])
+        worker_class=arguments["--worker-class"]
+    )
 
 
 if __name__ == "__main__":

--- a/src/pydap/wsgi/templates/index.html
+++ b/src/pydap/wsgi/templates/index.html
@@ -42,8 +42,9 @@
             <td><i class="icon-globe icon-fixed-width"></i>
             <a title="Inspect and filter data" href="{{ file.name }}.html">{{ file.name }}</a>
             <span class="dap">
-            <a title="View the DDS response" href="{{ file.name }}.dds">dds</a> |
-            <a title="View the DAS response" href="{{ file.name }}.das">das</a>
+              {% for response in responses %}
+              <a title="View the {{response}} response" href="{{ file.name }}.{{response}}">{{response}}</a> |
+              {% endfor %}
             </span>
             </td>
             {% elif file.name.endswith(".html") %}


### PR DESCRIPTION
I updated the bootstrap.py script to the latest version. It gave me some problems with setuptools/distutils.
The source is http://downloads.buildout.org/2/bootstrap.py as documented in https://pypi.python.org/pypi/zc.buildout/2.2.1. 

The other thing I changed is the list of responses in the index.html. I added the full list of available responses to the index page. 

The gsw package is listed as a dependency and gsw is dependent on scipy (loadmat). The gsw is missing scipy in the setup.py. So I had to (temporary) add scipy as a dependency to setup.py and the blas/atlas package to the travis build script, otherwise scipy won't be found. 
~~The travis build is now quite slow. You can use the version that pacificclimate made:
https://github.com/pacificclimate/pydap/commit/707b15b855c6f662deb927c2fe0383ab4661b662
That drops build support for python2.6.~~
I had to use the system scipy. It does not build under travis. Because there is no system version of scipy for python 2.6 I had to disable 2.6 in travis. 
