### PR TITLE
Added support for NASA/URS SSO service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+/.settings/
+/urs_test.log

--- a/README.auth
+++ b/README.auth
@@ -1,0 +1,4 @@
+LDAP/Basic https://130.56.244.153/opendap/data/nc/coads_climatology.nc, tesla, password
+URS/OAuth2 https://52.1.74.222/opendap/data/hdf4/S3096277.HDF.dds,
+	uat.urs.earthdata.nasa.gov, '...', '...')
+	urs.earthdata.nasa.gov,  ...

--- a/ldap_test.py
+++ b/ldap_test.py
@@ -1,0 +1,13 @@
+
+# Set up PyDAP to use the URS request() function
+
+from pydap.util.urs import install_basic_client
+
+import logging
+logging.basicConfig(filename='urs_test.log',level=logging.DEBUG)
+
+install_basic_client('130.56.244.153','tesla', 'password')
+
+from pydap.client import open_url
+
+d = open_url('https://130.56.244.153/opendap/data/nc/coads_climatology.nc')

--- a/pydap/lib.py
+++ b/pydap/lib.py
@@ -31,6 +31,10 @@ TIMEOUT = None
 # >>> pydap.lib.PROXY = httplib2.ProxyInfo(pydap.util.socks.PROXY_TYPE_HTTP, 'localhost', 8000)
 PROXY = None
 
+# Should HTTPS require a valid certificate? Setting this to True will cause
+# sites with self-signed certificates to fail; False will enable HTTPS to 
+#  work with those sites. jhrg 4/22/15
+SSL_VALIDATE = True
 
 def isiterable(obj):
     """

--- a/pydap/util/http.py
+++ b/pydap/util/http.py
@@ -25,7 +25,8 @@ def request(url):
     """
     h = httplib2.Http(cache=pydap.lib.CACHE,
             timeout=pydap.lib.TIMEOUT,
-            proxy_info=pydap.lib.PROXY)
+            proxy_info=pydap.lib.PROXY,
+            disable_ssl_certificate_validation= not pydap.lib.SSL_VALIDATE) # jhrg 4/21/15
     scheme, netloc, path, query, fragment = urlsplit(url)
     if '@' in netloc:
         credentials, netloc = netloc.split('@', 1)  # remove credentials from netloc

--- a/pydap/util/urs.py
+++ b/pydap/util/urs.py
@@ -1,0 +1,102 @@
+"""
+LGPL License
+Copyright (c) 2015
+All rights reserved.
+
+PyDAP extension to enable access to OpenDAP servers that 
+require login using NASA URS. This code will actually provide
+credentials to any server that uses a 401 response to ask for
+them. Of course, HTTP Basic authentication sends the information
+in the clear, so HTTPS should always be used by the server.
+
+@author: James Gallagher <jgallagher@opendap.org>
+
+"""
+
+import cookielib
+import netrc
+import urllib2
+import re
+
+import pydap.lib
+from pydap.exceptions import ClientError
+
+import logging
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+# Set the debug level for urllib2.
+debuglevel=1
+
+def install_basic_client(uri='', user='', passwd='', use_netrc=True):
+    """
+    Based on the CAS authentication example at
+    http://pydap.org/client.html#authentication
+
+    Handle URS/OAuth2, and HTTP Basic authentication over https.
+    
+    To use this, you must run this function before importing the open_url()
+    function contained in pydap.client. One run, the pydap.http.request()
+    function will search a password manager for username/password pairs using
+    information passed to this function and/or from the caller's .netrc file.
+    When a HTTP request returns a authentication challenge response (401 
+    response code), this new request() function will search for credentials
+    that match the request's hostname (i.e., 'uri').
+    
+    This code knows how to follow the redirects associated with the NASA URS
+    system, an implementation of OAuth2.
+
+    :param uri: If all of uri, user and passwd are not empty, add them to the password manager.
+    :param user: See uri
+    :param passwd: See uri
+    :param netrc: If True, the default, read login credentials from the .netrc file
+    
+    """
+
+    # Create special opener with support for Cookies
+    cj = cookielib.CookieJar()
+    
+    # Create the password manager and load with the credentials using 
+    pwMgr = urllib2.HTTPPasswordMgrWithDefaultRealm()
+
+    # Get passwords from the .netrc file nless use_netrc is False    
+    if use_netrc:
+        logins = netrc.netrc()
+        accounts = logins.hosts # a dist of hosts and tuples
+        for host, info in accounts.iteritems():
+            login, account, password = info
+            log.debug('Host: %s; login: %s; account: %s; password: %s' % (host, login, account, password))
+            pwMgr.add_password(None, host, login, password)
+        
+    if uri and user and passwd:
+        pwMgr.add_password(None, uri, user, passwd)
+    
+    opener = urllib2.build_opener(urllib2.HTTPBasicAuthHandler(pwMgr),
+                                  urllib2.HTTPCookieProcessor(cj))
+    
+    opener.addheaders = [('User-agent', pydap.lib.USER_AGENT)]
+
+    urllib2.install_opener(opener)
+
+    def new_request(url):
+        log.debug('Opening %s (install_basic_client)' % url)
+        r = urllib2.urlopen(url)
+        
+        resp = r.headers.dict
+        resp['status'] = str(r.code)
+        data = r.read()
+
+        # When an error is returned, we parse the error message from the
+        # server and return it in a ``ClientError`` exception.
+        if resp.get("content-description") == "dods_error":
+            m = re.search('code = (?P<code>\d+);\s*message = "(?P<msg>.*)"',
+                    data, re.DOTALL | re.MULTILINE)
+            msg = 'Server error %(code)s: "%(msg)s"' % m.groupdict()
+            raise ClientError(msg)
+
+        return resp, data
+
+    from pydap.util import http
+    http.request = new_request
+

--- a/urs_test.py
+++ b/urs_test.py
@@ -1,0 +1,13 @@
+
+# Set up PyDAP to use the URS request() function
+
+from pydap.util.urs import install_basic_client
+
+import logging
+logging.basicConfig(filename='urs_test.log',level=logging.DEBUG)
+
+install_basic_client()
+
+from pydap.client import open_url
+
+d = open_url('https://52.1.74.222/opendap/data/hdf4/S3096277.HDF')


### PR DESCRIPTION
Roberto,

I added support for the NASA/URS SSO service (which uses OAuth2 but requires that you login using their login page; it does not support Facebook, Google, ..., logins). Also, In the process I added support for site that use things like LDAP in combination with HTTP/S and Basic Auth. My install_basic_client() function reads URIs, usernames and passwords from a .netrc file as well as taking one set as params to the function. I think this code will actually be used by NASA and some of the folks down under (ANU/NCI). 

Also added support for a new constant: pydap.lib.SSL_VALIDATE that can be used with sites that take username:password info but use self-signed certs. By default httplib2 does not work with self signed certs.

Anyway, this is my first attempt at python, I tried to make the comments decent...

Can you merge this?

Thanks and hope all is well!
James
