### PR TITLE
fixed utf-8 issue

### DIFF
--- a/pydap/responses/ascii.py
+++ b/pydap/responses/ascii.py
@@ -20,11 +20,11 @@ class ASCIIResponse(BaseResponse):
     def serialize(dataset):
         # Generate DDS.
         for line in dds_dispatch(dataset):
-            yield line
-        yield 45 * '-'
-        yield '\n'
+            yield line.encode("utf-8")
+        yield 45 * '-'.encode("utf-8")
+        yield '\n'.encode("utf-8")
         for line in dispatch(dataset):
-            yield line
+            yield line.encode("utf-8")
         if hasattr(dataset, 'close'): dataset.close()
 
 

--- a/pydap/responses/dods.py
+++ b/pydap/responses/dods.py
@@ -23,8 +23,8 @@ class DODSResponse(BaseResponse):
     def serialize(dataset):
         # Generate DDS.
         for line in dds_dispatch(dataset):
-            yield line
-        yield 'Data:\n'
+            yield line.encode('utf-8')
+        yield 'Data:\n'.encode('utf-8')
         for line in DapPacker(dataset):
             yield line
         if hasattr(dataset, 'close'): dataset.close()

--- a/pydap/responses/lib.py
+++ b/pydap/responses/lib.py
@@ -7,7 +7,6 @@ class BaseResponse(object):
         self.dataset = dataset
         self.headers = [
                 ('XDODS-Server', 'dods/%s' % '.'.join([str(i) for i in __dap__])),
-                ('Access-Control-Allow-Origin', '*'),
                 ]
 
     @staticmethod

--- a/pydap/responses/lib.py
+++ b/pydap/responses/lib.py
@@ -7,6 +7,7 @@ class BaseResponse(object):
         self.dataset = dataset
         self.headers = [
                 ('XDODS-Server', 'dods/%s' % '.'.join([str(i) for i in __dap__])),
+                ('Access-Control-Allow-Origin', '*'),
                 ]
 
     @staticmethod


### PR DESCRIPTION
The pydap opendap component works fine when running with "paste" but uwsgi seems to want utf-8 encoded responses. I have fixed this for the ascii and dods responses.

By accident I seem to have included a suggestion to set:

'Access-Control-Allow-Origin', '*'

per default. Sorry about that.

Kind regards,
Jesper