### PR TITLE
fixed use of deprecated string.strip

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -28,7 +28,7 @@ bandwidth and time. The module also comes with a robust-but-lightweight
 Opendap server, implemented as a WSGI application.
         ''',
         keywords='opendap dods dap data science climate oceanography meteorology',
-        classifiers=filter(None, map(string.strip, '''
+        classifiers=filter(None, map(lambda x: x.strip(), '''
             Development Status :: 5 - Production/Stable
             Environment :: Console
             Environment :: Web Environment


### PR DESCRIPTION
I was having some problems with the use of the string module in Python 3.3. I fixed it with a lambda.