### PR TITLE
A method for ESGF / URS authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
     - pip install -e .[testing,functions,tests]
 
 script:
-    - python setup.py nosetests
+    - python setup.py nosetests -a '!auth'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
     - pip install -e .[testing,functions,tests]
 
 script:
-    - python setup.py nosetests -a '!auth'
+    - python setup.py nosetests

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -331,96 +331,49 @@ CAS
 
 The `Central Authentication Service <http://en.wikipedia.org/wiki/Central_Authentication_Service>`_ (CAS) is a single sign-on protocol for the web, usually involving a web browser and cookies. Nevertheless it's possible to use Pydap with an OPeNDAP server behind a CAS. The function ``install_cas_client`` below replaces Pydap's default HTTP function with a new version able to submit authentication data to an HTML form and store credentials in cookies. (In this particular case, the server uses Javascript to redirect the browser to a new location, so the client has to parse the location from the Javascript code; other CAS would require a tweaked function.)
 
-To use it, just call the function before any requests:
+To use it, just attach a web browsing ``session`` with authentication cookies:
 
 .. code-block:: python
 
-    >>> install_cas_client()
-    >>> from pydap.client import open_url  # this function is now monkeypatched
+    >>> from pydap.client import open_url  
+    >>> from pydap.cas.get_cookies import setup_session 
+    >>> session = setup_session(authentication_url, username, password)
+    >>> dataset = open_url('http://server.example.com/path/to/dataset', session=session)
 
-And here is the function. It depends on the `BeautifulSoup <http://www.crummy.com/software/BeautifulSoup/>`_ module to parse the HTML.
+This method could work but each CAS is slightly different and might require a specifically designed
+``setup_session`` instance. Two CAS are however explicitly supported by ``pydap``:
+
+URS NASA EARTHDATA
+^^^^^^^^^^^^^^^^^^
+Authentication is done through a ``username`` and a ``password``:
 
 .. code-block:: python
 
-    import cookielib
-    import urllib
-    import urllib2
-    from urlparse import urlparse
-    import re
-    import os
+    >>> from pydap.client import open_url  
+    >>> from pydap.cas.urs import setup_session 
+    >>> session = setup_session(username, password)
+    >>> dataset = open_url('http://server.example.com/path/to/dataset', session=session)
 
-    from BeautifulSoup import BeautifulSoup
+Earth System Grid Federation (ESGF)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Authentication is done through an ``openid`` and a ``password``:
 
-    import pydap.lib
-    from pydap.exceptions import ClientError
+.. code-block:: python
 
+    >>> from pydap.client import open_url  
+    >>> from pydap.cas.esgf import setup_session 
+    >>> session = setup_session(openid, password)
+    >>> dataset = open_url('http://server.example.com/path/to/dataset', session=session)
 
-    def install_cas_client(username_field='username', password_field='password'):
-        # Create special opener with support for Cookies.
-        cj = cookielib.CookieJar()
-        opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
-        opener.addheaders = [('User-agent', pydap.lib.USER_AGENT)]
-        urllib2.install_opener(opener)
+If your ``openid`` contains contains the
+string ``ceda.ac.uk`` authentication requires an additional ``username`` argument:
 
-        def new_request(url):
-            # Remove username/password from url.
-            netloc = '%s:%s' % (url.hostname, url.port or 80)
-            url = urlunsplit((
-                    url.scheme, netloc, url.path, url.query, url.fragment
-                    )).rstrip('?&')
+.. code-block:: python
 
-            log = logging.getLogger('pydap')
-            log.INFO('Opening %s' % url)
-            r = urllib2.urlopen(url)
-
-            # Detect redirection.
-            if r.url != url:
-                data = r.read()
-                code = BeautifulSoup(data)
-
-                # Check if we need to authenticate:
-                if code.find('form'):
-                    # Ok, we need to authenticate. Let's get the location
-                    # where we need to POST the information.
-                    post_location = code.find('form').get('action', r.url)
-
-                    # Do a post, passing our credentials.
-                    inputs = code.find('form').findAll('input')
-                    params = dict([(el['name'], el['value']) for el in inputs
-                                     if el['type']=='hidden'])
-                    params[username_field] = url.username
-                    params[password_field] = url.password
-                    params = urllib.urlencode(params)
-                    req = urllib2.Request(post_location, params)
-                    r = urllib2.urlopen(req)
-
-                    # Parse the response.
-                    data = r.read()
-                    code = BeautifulSoup(data)
-
-                # Get the location from the Javascript code. Depending on the
-                # CAS this code has to be changed. Ideally, the server would
-                # redirect with HTTP headers and this wouldn't be necessary.
-                script = code.find('script').string
-                redirect = re.search('window.location.href="(.*)"', script).group(1)
-                r = urllib2.urlopen(redirect)
-
-            resp = r.headers.dict
-            resp['status'] = str(r.code)
-            data = r.read()
-
-            # When an error is returned, we parse the error message from the
-            # server and return it in a ``ClientError`` exception.
-            if resp.get("content-description") == "dods_error":
-                m = re.search('code = (?P<code>\d+);\s*message = "(?P<msg>.*)"',
-                        data, re.DOTALL | re.MULTILINE)
-                msg = 'Server error %(code)s: "%(msg)s"' % m.groupdict()
-                raise ClientError(msg)
-
-            return resp, data
-
-        from pydap.util import http
-        http.request = new_request
+    >>> from pydap.client import open_url  
+    >>> from pydap.cas.esgf import setup_session 
+    >>> session = setup_session(openid, password, username=username)
+    >>> dataset = open_url('http://server.example.com/path/to/dataset', session=session)
 
 Advanced features
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,6 @@ install_requires = [
     'Jinja2',
     'docopt',
     'gunicorn',
-    'mechanicalsoup',
-    'requests',
     'six >= 1.4.0',
 ]
 
@@ -31,7 +29,12 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
-tests_require = functions_extras + [
+cas_extras = [
+    'mechanicalsoup',
+    'requests'
+    ]
+    
+tests_require = functions_extras + cas_extras + [
     'WebTest',
     'beautifulsoup4',
     'scipy'

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ install_requires = [
     'docopt',
     'gunicorn',
     'six >= 1.4.0',
+    'mechanicalsoup',
 ]
 
 if sys.version_info < (2, 7):
@@ -30,7 +31,6 @@ docs_extras = [
 ]
 
 cas_extras = [
-    'mechanicalsoup',
     'requests'
     ]
     

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,8 @@ setup(name='Pydap',
         'functions': functions_extras,
         'testing': testing_extras,
         'docs': docs_extras,
-        'tests': tests_require
+        'tests': tests_require,
+        'cas': cas_extras
     },
     test_suite="pydap.tests",
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ tests_require = functions_extras + cas_extras + [
 testing_extras = tests_require + [
     'nose',
     'coverage',
+    'requests'
 ]
 
 if sys.version_info < (2, 7):

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ install_requires = [
     'Jinja2',
     'docopt',
     'gunicorn',
+    'mechanicalsoup',
+    'requests',
     'six >= 1.4.0',
 ]
 

--- a/src/pydap/cas/esgf.py
+++ b/src/pydap/cas/esgf.py
@@ -28,10 +28,13 @@ def _uri(openid):
     def generate_url(dest_url):
         dest_node = _get_node(dest_url)
 
-        url = (dest_node +
-               '/esg-orp/j_spring_openid_security_check.htm?'
-               'openid_identifier=' +
-               quote_plus(openid))
+        try:
+            url = (dest_node +
+                   '/esg-orp/j_spring_openid_security_check.htm?'
+                   'openid_identifier=' +
+                   quote_plus(openid))
+        except TypeError:
+            raise UserWarning('OPENID was not set. ESGF connection cannot succeed.')
         if _get_node(openid) == 'https://ceda.ac.uk':
             return [url, None]
         else:

--- a/src/pydap/cas/esgf.py
+++ b/src/pydap/cas/esgf.py
@@ -1,0 +1,38 @@
+from six.moves.urllib.parse import quote_plus
+from . import get_cookies
+
+
+def setup_session(openid, password, username=None, check_url=None):
+    """
+    A special call to get_cookies.setup_session that is tailored for
+    ESGF credentials.
+
+    username should only be necessary for a CEDA openid.
+    """
+    return get_cookies.setup_session(_uri(openid), username, password,
+                                     check_url=check_url,
+                                     verify=False)
+
+
+def _uri(openid):
+    '''
+    Create ESGF authentication url.
+    This function might be sensitive to a
+    future evolution of the ESGF security.
+    '''
+    def generate_url(dest_url):
+        dest_node = _get_node(dest_url)
+
+        url = (dest_node +
+               '/esg-orp/j_spring_openid_security_check.htm?'
+               'openid_identifier=' +
+               quote_plus(openid))
+        if _get_node(openid) == 'https://ceda.ac.uk':
+            return [url, None]
+        else:
+            return url
+    return generate_url
+
+
+def _get_node(url):
+        return '/'.join(url.split('/')[:3]).replace('http:', 'https:')

--- a/src/pydap/cas/esgf.py
+++ b/src/pydap/cas/esgf.py
@@ -2,15 +2,20 @@ from six.moves.urllib.parse import quote_plus
 from . import get_cookies
 
 
-def setup_session(openid, password, username=None, check_url=None):
+def setup_session(openid, password, username=None,
+                  check_url=None,
+                  session=None):
     """
     A special call to get_cookies.setup_session that is tailored for
     ESGF credentials.
 
     username should only be necessary for a CEDA openid.
     """
-    return get_cookies.setup_session(_uri(openid), username, password,
+    return get_cookies.setup_session(_uri(openid),
+                                     username=username,
+                                     password=password,
                                      check_url=check_url,
+                                     session=session,
                                      verify=False)
 
 

--- a/src/pydap/cas/get_cookies.py
+++ b/src/pydap/cas/get_cookies.py
@@ -5,10 +5,9 @@ from requests.packages.urllib3.exceptions import (InsecureRequestWarning,
                                                   InsecurePlatformWarning)
 import copy
 import pydap.lib
-import pydap.net
 
 ssl_verify_categories = [InsecureRequestWarning,
-                         InsecurePlatformWarning] 
+                         InsecurePlatformWarning]
 
 
 def setup_session(uri, username, password, check_url=None,
@@ -61,8 +60,8 @@ def setup_session(uri, username, password, check_url=None,
             # This error will usually occur with
             # ESGF authentication.
             for category in ssl_verify_categories:
-               warnings.filterwarnings("ignore",
-                                       category=category)
+                warnings.filterwarnings("ignore",
+                                        category=category)
 
         response = mechanicalsoup_login(br, url, username, password,
                                         username_field=username_field,

--- a/src/pydap/cas/get_cookies.py
+++ b/src/pydap/cas/get_cookies.py
@@ -101,10 +101,22 @@ def raise_if_form_exists(url, session):
     """
     This function raises a UserWarning if the link has forms
     """
+    # This is important for the python 2.6 build:
+    try:
+        from html.parser import HTMLParseError
+    except ImportError as e:
+        # HTMLParseError is removed in Python 3.5. Since it can never be
+        # thrown in 3.5, we can just define our own class as a placeholder.
+        class HTMLParseError(Exception):
+            pass
+
     br = mechanicalsoup.Browser(session=session)
-    login_page = br.get(url)
-    if (hasattr(login_page, 'soup') and
-       len(login_page.soup.select('form')) > 0):
+    try:
+        login_page = br.get(url)
+        if (hasattr(login_page, 'soup') and
+           len(login_page.soup.select('form')) > 0):
+            raise UserWarning()
+    except (HTMLParseError, UserWarning):
         raise UserWarning('Navigate to {0}, login and follow instructions. '.format(url) +
                           'It is likely that you have to perform some one-time'
                           'registration steps before acessing this data.')

--- a/src/pydap/cas/get_cookies.py
+++ b/src/pydap/cas/get_cookies.py
@@ -1,33 +1,14 @@
 import mechanicalsoup
 import warnings
 import requests
-from requests.packages.urllib3.exceptions import InsecureRequestWarning, InsecurePlatformWarning
+from requests.packages.urllib3.exceptions import (InsecureRequestWarning,
+                                                  InsecurePlatformWarning)
 import copy
 import pydap.lib
 import pydap.net
 
-#ssl_verify_msg = [("Unverified HTTPS request is "
-#                   "being made. "
-#                   "Adding certificate verification "
-#                   "is strongly advised. "
-#                   "See: https://urllib3.readthedocs.io/"
-#                   "en/latest/security.html"),
-#                  ("Unverified HTTPS request is "
-#                   "being made. "
-#                   "Adding certificate verification "
-#                   "is strongly advised. "
-#                   "See: https://urllib3.readthedocs.io/"
-#                   "en/latest/advanced-usage.html#ssl-warnings"),
-#                   ("A true SSLContext object is not available. "
-#                    "This prevents urllib3 from configuring SSL "
-#                    "appropriately and may cause certain SSL "
-#                    "connections to fail. You can upgrade to a "
-#                    "newer version of Python to solve this. "
-#                    "For more information, see https://"
-#                    "urllib3.readthedocs.io/en/latest/"
-#                    "advanced-usage.html#ssl-warnings")]
-
-ssl_verify_category = [InsecureRequestWarning, InsecurePlatformWarning] 
+ssl_verify_categories = [InsecureRequestWarning,
+                         InsecurePlatformWarning] 
 
 
 def setup_session(uri, username, password, check_url=None,
@@ -72,11 +53,14 @@ def setup_session(uri, username, password, check_url=None,
 
     with warnings.catch_warnings():
         if not verify:
-            #for message in ssl_verify_msg:
-            #    warnings.filterwarnings("ignore",
-            #                            message=message,
-            #                            append=True)
-            for category in ssl_verify_category:
+            # Catch warnings. It is assumed that the
+            # user that explicitly uses verify=False
+            # is either fully aware of the risks
+            # or cannot avoid the risks because of
+            # an improperly configured server.
+            # This error will usually occur with
+            # ESGF authentication.
+            for category in ssl_verify_categories:
                warnings.filterwarnings("ignore",
                                        category=category)
 

--- a/src/pydap/cas/get_cookies.py
+++ b/src/pydap/cas/get_cookies.py
@@ -1,22 +1,33 @@
 import mechanicalsoup
 import warnings
 import requests
+from requests.packages.urllib3.exceptions import InsecureRequestWarning, InsecurePlatformWarning
 import copy
 import pydap.lib
 import pydap.net
 
-ssl_verify_msg = [("Unverified HTTPS request is "
-                   "being made. "
-                   "Adding certificate verification "
-                   "is strongly advised. "
-                   "See: https://urllib3.readthedocs.io/"
-                   "en/latest/security.html"),
-                  ("Unverified HTTPS request is "
-                   "being made. "
-                   "Adding certificate verification "
-                   "is strongly advised. "
-                   "See: https://urllib3.readthedocs.io/"
-                   "en/latest/advanced-usage.html#ssl-warnings")]
+#ssl_verify_msg = [("Unverified HTTPS request is "
+#                   "being made. "
+#                   "Adding certificate verification "
+#                   "is strongly advised. "
+#                   "See: https://urllib3.readthedocs.io/"
+#                   "en/latest/security.html"),
+#                  ("Unverified HTTPS request is "
+#                   "being made. "
+#                   "Adding certificate verification "
+#                   "is strongly advised. "
+#                   "See: https://urllib3.readthedocs.io/"
+#                   "en/latest/advanced-usage.html#ssl-warnings"),
+#                   ("A true SSLContext object is not available. "
+#                    "This prevents urllib3 from configuring SSL "
+#                    "appropriately and may cause certain SSL "
+#                    "connections to fail. You can upgrade to a "
+#                    "newer version of Python to solve this. "
+#                    "For more information, see https://"
+#                    "urllib3.readthedocs.io/en/latest/"
+#                    "advanced-usage.html#ssl-warnings")]
+
+ssl_verify_category = [InsecureRequestWarning, InsecurePlatformWarning] 
 
 
 def setup_session(uri, username, password, check_url=None,
@@ -61,10 +72,13 @@ def setup_session(uri, username, password, check_url=None,
 
     with warnings.catch_warnings():
         if not verify:
-            for message in ssl_verify_msg:
-                warnings.filterwarnings("ignore",
-                                        message=message,
-                                        append=True)
+            #for message in ssl_verify_msg:
+            #    warnings.filterwarnings("ignore",
+            #                            message=message,
+            #                            append=True)
+            for category in ssl_verify_category:
+               warnings.filterwarnings("ignore",
+                                       category=category)
 
         response = mechanicalsoup_login(br, url, username, password,
                                         username_field=username_field,

--- a/src/pydap/cas/get_cookies.py
+++ b/src/pydap/cas/get_cookies.py
@@ -10,8 +10,12 @@ ssl_verify_categories = [InsecureRequestWarning,
                          InsecurePlatformWarning]
 
 
-def setup_session(uri, username, password, check_url=None,
-                  session=None, verify=True,
+def setup_session(uri,
+                  username=None,
+                  password=None,
+                  check_url=None,
+                  session=None,
+                  verify=True,
                   username_field='username',
                   password_field='password'):
     '''
@@ -80,7 +84,7 @@ def setup_session(uri, username, password, check_url=None,
             res = session.get(check_url, auth=(username, password))
             if res.status_code == 401:
                 res = session.get(res.url, auth=(username, password))
-        res.close()
+            res.close()
     if not verify:
         session.verify = verify_flag
     return session

--- a/src/pydap/cas/get_cookies.py
+++ b/src/pydap/cas/get_cookies.py
@@ -101,25 +101,31 @@ def raise_if_form_exists(url, session):
     """
     This function raises a UserWarning if the link has forms
     """
+
+    user_warning = ('Navigate to {0}, login and follow instructions. '.format(url) +
+                    'It is likely that you have to perform some one-time'
+                    'registration steps before acessing this data.')
+
     # This is important for the python 2.6 build:
     try:
-        from html.parser import HTMLParseError
+        from six.moves.html_parser import HTMLParseError
     except ImportError as e:
         # HTMLParseError is removed in Python 3.5. Since it can never be
         # thrown in 3.5, we can just define our own class as a placeholder.
+        # *from bs4/builder/_htmlparser.py
         class HTMLParseError(Exception):
             pass
 
     br = mechanicalsoup.Browser(session=session)
     try:
         login_page = br.get(url)
-        if (hasattr(login_page, 'soup') and
-           len(login_page.soup.select('form')) > 0):
-            raise UserWarning()
-    except (HTMLParseError, UserWarning):
-        raise UserWarning('Navigate to {0}, login and follow instructions. '.format(url) +
-                          'It is likely that you have to perform some one-time'
-                          'registration steps before acessing this data.')
+    except HTMLParseError:
+        # This is important for the python 2.6 build:
+        raise UserWarning(user_warning)
+
+    if ((hasattr(login_page, 'soup') and
+       len(login_page.soup.select('form')) > 0)):
+        raise UserWarning(user_warning)
 
 
 def mechanicalsoup_login(br, url, username, password,

--- a/src/pydap/cas/get_cookies.py
+++ b/src/pydap/cas/get_cookies.py
@@ -95,6 +95,9 @@ def mechanicalsoup_login(br, url, username, password,
                          password_field='password'):
     login_page = br.get(url)
 
+    if not hasattr(login_page, 'soup'):
+        return login_page
+
     login_form = login_page.soup.select('form')[0]
 
     try:

--- a/src/pydap/cas/get_cookies.py
+++ b/src/pydap/cas/get_cookies.py
@@ -5,6 +5,19 @@ import copy
 import pydap.lib
 import pydap.net
 
+ssl_verify_msg = [("Unverified HTTPS request is "
+                   "being made. "
+                   "Adding certificate verification "
+                   "is strongly advised. "
+                   "See: https://urllib3.readthedocs.io/"
+                   "en/latest/security.html"),
+                  ("Unverified HTTPS request is "
+                   "being made. "
+                   "Adding certificate verification "
+                   "is strongly advised. "
+                   "See: https://urllib3.readthedocs.io/"
+                   "en/latest/advanced-usage.html#ssl-warnings")]
+
 
 def setup_session(uri, username, password, check_url=None,
                   session=None, verify=True,
@@ -47,13 +60,11 @@ def setup_session(uri, username, password, check_url=None,
         url = full_url[0]
 
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore",
-                                message=("Unverified HTTPS request is "
-                                         "being made. "
-                                         "Adding certificate verification "
-                                         "is strongly advised. "
-                                         "See: https://urllib3.readthedocs.io/"
-                                         "en/latest/security.html"))
+        if not verify:
+            for message in ssl_verify_msg:
+                warnings.filterwarnings("ignore",
+                                        message=message,
+                                        append=True)
 
         response = mechanicalsoup_login(br, url, username, password,
                                         username_field=username_field,

--- a/src/pydap/cas/get_cookies.py
+++ b/src/pydap/cas/get_cookies.py
@@ -1,0 +1,112 @@
+import mechanicalsoup
+import warnings
+import requests
+import copy
+import pydap.lib
+import pydap.net
+
+
+def setup_session(uri, username, password, check_url=None,
+                  session=None, verify=True,
+                  username_field='username',
+                  password_field='password'):
+    '''
+    A general function to set-up requests session with cookies
+    using mechanicalsoup and by calling the right url.
+    '''
+
+    if session is None:
+        headers = [('User-agent', pydap.lib.__version__)]
+        session = requests.Session()
+        session.headers.update(headers)
+
+    if uri is None:
+        return session
+
+    if not verify:
+        verify_flag = session.verify
+        session.verify = False
+    br = mechanicalsoup.Browser(session=session)
+
+    if isinstance(uri, str):
+        url = uri
+    else:
+        url = uri(check_url)
+
+    if password is None or password == '':
+        warnings.warn('password was not set. '
+                      'this was likely unintentional '
+                      'but will result is much fewer datasets.')
+        if not verify:
+            session.verify = verify_flag
+        return session
+
+    # Allow for several subsequent security layers:
+    full_url = copy.copy(uri)
+    if isinstance(full_url, list):
+        url = full_url[0]
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore",
+                                message=("Unverified HTTPS request is "
+                                         "being made. "
+                                         "Adding certificate verification "
+                                         "is strongly advised. "
+                                         "See: https://urllib3.readthedocs.io/"
+                                         "en/latest/security.html"))
+
+        response = mechanicalsoup_login(br, url, username, password,
+                                        username_field=username_field,
+                                        password_field=password_field)
+        if (isinstance(full_url, list) and
+           len(full_url) > 1):
+            # If there are further security levels:
+            for url in full_url[1:]:
+                response = mechanicalsoup_login(br, response.url,
+                                                username, password,
+                                                username_field=username_field,
+                                                password_field=password_field)
+        response.close()
+
+        if check_url:
+            res = session.get(check_url, auth=(username, password))
+            if res.status_code == 401:
+                res = session.get(res.url, auth=(username, password))
+        res.close()
+    if not verify:
+        session.verify = verify_flag
+    return session
+
+
+def mechanicalsoup_login(br, url, username, password,
+                         username_field='username',
+                         password_field='password'):
+    login_page = br.get(url)
+
+    login_form = login_page.soup.select('form')[0]
+
+    try:
+        login_form.select('#' + username_field)[0]['value'] = username
+    except IndexError:
+        pass
+
+    try:
+        login_form.select('#' + password_field)[0]['value'] = password
+    except IndexError:
+        pass
+    #    if url is not None:
+    #        br.close()
+        raise Exception('Navigate to {0}. '
+                        'If you are unable to '
+                        'login, you must either '
+                        'wait or use authentication '
+                        'from another service.'
+                        .format(url))
+    #    else:
+    #        pass
+
+    try:
+        login_form.find("remember").items[0].selected = True
+    except AttributeError:
+        pass
+    return br.submit(login_form, login_page.url)

--- a/src/pydap/cas/urs.py
+++ b/src/pydap/cas/urs.py
@@ -1,13 +1,15 @@
 from . import get_cookies
 
 
-def setup_session(username, password, check_url=None):
+def setup_session(username, password, check_url=None,
+                  session=None):
     """
     A special call to get_cookies.setup_session that is tailored for
     URS EARTHDATA at NASA credentials.
 
     """
     return get_cookies.setup_session('https://urs.earthdata.nasa.gov',
-                                     username,
-                                     password,
+                                     username=username,
+                                     password=password,
+                                     session=session,
                                      check_url=check_url)

--- a/src/pydap/cas/urs.py
+++ b/src/pydap/cas/urs.py
@@ -1,0 +1,13 @@
+from . import get_cookies
+
+
+def setup_session(username, password, check_url=None):
+    """
+    A special call to get_cookies.setup_session that is tailored for
+    URS EARTHDATA at NASA credentials.
+
+    """
+    return get_cookies.setup_session('https://urs.earthdata.nasa.gov',
+                                     username,
+                                     password,
+                                     check_url=check_url)

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -77,10 +77,7 @@ def raise_for_ssl_error(url, session=None):
     br = mechanicalsoup.Browser(session=session)
     login_page = br.get(url)
     if len(login_page.soup.select('form')) > 0:
-        import warnings
-        with warnings.catch_warnings():
-            warnings.filterwarnings('error')
-            warnings.warn('Navigate to {0}, login and follow instructions. '.format(url) +
+        raise UserWarning('Navigate to {0}, login and follow instructions. '.format(url) +
                           'It is likely that you have to perform some one-time'
                           'registration steps before acessing this data.')
     else:

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -53,35 +53,15 @@ from pydap.handlers.dap import DAPHandler, unpack_data, StreamReader
 from pydap.parsers.dds import build_dataset
 from pydap.parsers.das import parse_das, add_attributes
 
-from ssl import SSLError
-
 
 def open_url(url, application=None, session=None):
     """Open a remote URL, returning a dataset."""
-    try:
-        dataset = DAPHandler(url, application, session).dataset
-    except SSLError:
-        raise_for_ssl_error(url, session=session)
+    dataset = DAPHandler(url, application, session).dataset
 
     # attach server-side functions
     dataset.functions = Functions(url, application, session)
 
     return dataset
-
-def raise_for_ssl_error(url, session=None):
-    if session is None:
-        raise
-
-    import mechanicalsoup
-    session.verify = False
-    br = mechanicalsoup.Browser(session=session)
-    login_page = br.get(url)
-    if len(login_page.soup.select('form')) > 0:
-        raise UserWarning('Navigate to {0}, login and follow instructions. '.format(url) +
-                          'It is likely that you have to perform some one-time'
-                          'registration steps before acessing this data.')
-    else:
-        raise
 
 
 def open_file(dods, das=None):

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -42,18 +42,17 @@ class DAPHandler(BaseHandler):
 
     """Build a dataset from a DAP base URL."""
 
-    def __init__(self, url, application=None):
+    def __init__(self, url, application=None, session=None):
         # download DDS/DAS
         scheme, netloc, path, query, fragment = urlsplit(url)
 
         ddsurl = urlunsplit((scheme, netloc, path + '.dds', query, fragment))
-        r = GET(ddsurl, application)
+        r = GET(ddsurl, application, session)
         raise_for_status(r)
         dds = r.text
 
-
         dasurl = urlunsplit((scheme, netloc, path + '.das', query, fragment))
-        r = GET(dasurl, application)
+        r = GET(dasurl, application, session)
         raise_for_status(r)
         das = r.text
 
@@ -67,10 +66,13 @@ class DAPHandler(BaseHandler):
 
         # now add data proxies
         for var in walk(self.dataset, BaseType):
-            var.data = BaseProxy(url, var.id, var.dtype, var.shape, application=application)
+            var.data = BaseProxy(url, var.id, var.dtype, var.shape,
+                                 application=application,
+                                 session=session)
         for var in walk(self.dataset, SequenceType):
             template = copy.copy(var)
-            var.data = SequenceProxy(url, template, application=application)
+            var.data = SequenceProxy(url, template, application=application,
+                                     session=session)
 
         # apply projections
         for var in projection:
@@ -98,13 +100,15 @@ class BaseProxy(object):
 
     """
 
-    def __init__(self, baseurl, id, dtype, shape, slice_=None, application=None):
+    def __init__(self, baseurl, id, dtype, shape, slice_=None,
+                 application=None, session=None):
         self.baseurl = baseurl
         self.id = id
         self.dtype = dtype
         self.shape = shape
         self.slice = slice_ or tuple(slice(None) for s in self.shape)
         self.application = application
+        self.session = session
 
     def __repr__(self):
         return 'BaseProxy(%s)' % ', '.join(
@@ -122,7 +126,7 @@ class BaseProxy(object):
 
         # download and unpack data
         logger.info("Fetching URL: %s" % url)
-        r = GET(url, self.application)
+        r = GET(url, self.application, self.session)
         raise_for_status(r)
         dds, data = r.body.split(b'\nData:\n', 1)
         dds = dds.decode(r.content_encoding or 'ascii')
@@ -191,12 +195,14 @@ class SequenceProxy(object):
 
     shape = ()
 
-    def __init__(self, baseurl, template, selection=None, slice_=None, application=None):
+    def __init__(self, baseurl, template, selection=None, slice_=None,
+                 application=None, session=None):
         self.baseurl = baseurl
         self.template = template
         self.selection = selection or []
         self.slice = slice_ or (slice(None),)
         self.application = application
+        self.session = session
 
         # this variable is true when only a subset of the children are selected
         self.sub_children = False
@@ -263,7 +269,7 @@ class SequenceProxy(object):
 
     def __iter__(self):
         # download and unpack data
-        r = GET(self.url, self.application)
+        r = GET(self.url, self.application, self.session)
         raise_for_status(r)
 
         i = r.app_iter

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -3,7 +3,8 @@ from webob.exc import HTTPError
 
 from six.moves.urllib.parse import urlsplit, urlunsplit
 
-def GET(url, application=None):
+
+def GET(url, application=None, session=None):
     """Open a remote URL returning a webob.response.Response object
 
     Optionally open a URL to a local WSGI application
@@ -11,7 +12,9 @@ def GET(url, application=None):
     if application:
         _, _, path, query, fragment = urlsplit(url)
         url = urlunsplit(('', '', path, query, fragment))
-    return Request.blank(url).get_response(application)
+
+    return follow_redirect(url, application=application, session=session)
+
 
 def raise_for_status(response):
     if response.status_code >= 400:
@@ -20,3 +23,47 @@ def raise_for_status(response):
             headers=response.headers,
             comment=response.body
         )
+
+
+def follow_redirect(url, application=None, session=None,
+                    cookies_dict=None):
+    """
+    This function essentially performs the following command:
+    >>> Request.blank(url).get_response(application)
+
+    It however makes sure that the request possesses the same cookies and
+    headers as the passed session.
+
+    It recursively follows 302 redirects.
+    """
+    req = Request.blank(url)
+
+    if session is not None:
+        # Get cookies from session:
+        if cookies_dict is None:
+            cookies_dict = session.cookies.get_dict()
+
+        # Set request cookies to the session cookies:
+        req.headers['Cookie'] = ','.join(name + '=' + cookies_dict[name]
+                                         for name in cookies_dict)
+        # Set the headers to the session headers:
+        for item in session.headers:
+            req.headers[item] = session.headers[item]
+
+    res = req.get_response(application)
+
+    if res.status_code == 302:
+        # Follow redirect:
+        new_cookies = {item.split(';')[0].split('=')[0]:
+                       item.split(';')[0].split('=')[1]
+                       for name, item in res.headerlist
+                       if name == 'Set-Cookie'}
+        if len(new_cookies) > 0:
+            # If new cookies, keep only these ones:
+            cookies_dict = new_cookies
+        return follow_redirect(res.location,
+                               application=application,
+                               session=session,
+                               cookies_dict=cookies_dict)
+    else:
+        return res

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -54,10 +54,9 @@ def follow_redirect(url, application=None, session=None,
 
     if res.status_code == 302:
         # Follow redirect:
-        new_cookies = {item.split(';')[0].split('=')[0]:
-                       item.split(';')[0].split('=')[1]
-                       for name, item in res.headerlist
-                       if name == 'Set-Cookie'}
+        new_cookies = dict(item.split(';')[0].split('=')
+                           for name, item in res.headerlist
+                           if name == 'Set-Cookie')
         if len(new_cookies) > 0:
             # If new cookies, keep only these ones:
             cookies_dict = new_cookies

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -7,6 +7,10 @@ from six.moves.urllib.parse import urlsplit, urlunsplit
 def GET(url, application=None, session=None):
     """Open a remote URL returning a webob.response.Response object
 
+    Optional parameters:
+    session: a requests.Session() object (potentially) containing
+             authentication cookies.
+
     Optionally open a URL to a local WSGI application
     """
     if application:

--- a/src/pydap/tests/test_cas_esgf.py
+++ b/src/pydap/tests/test_cas_esgf.py
@@ -22,7 +22,13 @@ class TestESGF(unittest.TestCase):
            'DMI-HIRHAM5_v1_day_19960101-20001231.nc')
 
     def test_basic_esgf_auth(self):
-        """Set up PyDAP to use the URS request() function"""
+        """
+        Set up PyDAP to use the URS request() function.
+
+        The intent here is to ensure that pydap.net is able to
+        open and url if and only if requests is able to
+        open the same url.
+        """
         session = esgf.setup_session(os.environ['OPENID_ESGF'],
                                      os.environ['PASSWORD_ESGF'],
                                      check_url=self.url)

--- a/src/pydap/tests/test_cas_esgf.py
+++ b/src/pydap/tests/test_cas_esgf.py
@@ -45,7 +45,8 @@ class TestESGF(unittest.TestCase):
                                   16837.5, 16838.5, 16839.5, 16840.5, 16841.5])
         assert(np.isclose(data, expected_data).all())
 
-    @unittest.skip("This test should work but does not. Issue raised.")
+    @unittest.skip("This test should work but does not. "
+                   "An issue should be raised.")
     def test_variable_esgf_query(self):
         session = esgf.setup_session(os.environ['OPENID_ESGF'],
                                      os.environ['PASSWORD_ESGF'],

--- a/src/pydap/tests/test_cas_esgf.py
+++ b/src/pydap/tests/test_cas_esgf.py
@@ -22,6 +22,23 @@ class TestESGF(unittest.TestCase):
            'pr_EUR-11_ICHEC-EC-EARTH_historical_r3i1p1_'
            'DMI-HIRHAM5_v1_day_19960101-20001231.nc')
 
+    def test_resgistration_esgf_auth(self):
+        """
+        Attempt to access a ESGF OPENDAP link for which
+        the user has not yet selected a registration group.
+        This procedure has to be completed only once per project
+        over the lifetime of an ESGF OPENID
+
+        Requires OPENID_ESGF_NO_REG and PASSWORD_ESGF_NO_REG
+        environment variables. These must be associated with credentials
+        where no group was selected.
+        """
+        session = esgf.setup_session(os.environ.get('OPENID_ESGF_NO_REG'),
+                                     os.environ.get('PASSWORD_ESGF_NO_REG'),
+                                     check_url=self.url)
+        with self.assertRaises(UserWarning):
+            open_url(self.url, session=session)
+
     def test_basic_esgf_auth(self):
         """
         Set up PyDAP to use the URS request() function.
@@ -35,7 +52,8 @@ class TestESGF(unittest.TestCase):
                                      check_url=self.url)
         test_url = self.url + '.dods?pr[0:1:0][0:1:5][0:1:5]'
         try:
-            res = requests.get(test_url, cookies=session.cookies)
+            res = requests.get(test_url, cookies=session.cookies,
+                               verify=False)
         except SSLError:
             raise_for_ssl_error(test_url, session=session) 
         assert(res.status_code == 200)

--- a/src/pydap/tests/test_cas_esgf.py
+++ b/src/pydap/tests/test_cas_esgf.py
@@ -1,12 +1,12 @@
-from pydap.client import open_url, raise_for_ssl_error
+from pydap.client import open_url
 import pydap.net
 from pydap.cas import esgf
+from pydap.cas.get_cookies import raise_if_form_exists
 import requests
 import numpy as np
 import os
 from nose.plugins.attrib import attr
 import sys
-from requests.exceptions import SSLError
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
@@ -22,7 +22,7 @@ class TestESGF(unittest.TestCase):
            'pr_EUR-11_ICHEC-EC-EARTH_historical_r3i1p1_'
            'DMI-HIRHAM5_v1_day_19960101-20001231.nc')
 
-    def test_resgistration_esgf_auth(self):
+    def test_registration_esgf_auth(self):
         """
         Attempt to access a ESGF OPENDAP link for which
         the user has not yet selected a registration group.
@@ -33,11 +33,10 @@ class TestESGF(unittest.TestCase):
         environment variables. These must be associated with credentials
         where no group was selected.
         """
-        session = esgf.setup_session(os.environ.get('OPENID_ESGF_NO_REG'),
-                                     os.environ.get('PASSWORD_ESGF_NO_REG'),
-                                     check_url=self.url)
         with self.assertRaises(UserWarning):
-            open_url(self.url, session=session)
+            session = esgf.setup_session(os.environ.get('OPENID_ESGF_NO_REG'),
+                                         os.environ.get('PASSWORD_ESGF_NO_REG'),
+                                         check_url=self.url)
 
     def test_basic_esgf_auth(self):
         """
@@ -51,11 +50,8 @@ class TestESGF(unittest.TestCase):
                                      os.environ.get('PASSWORD_ESGF'),
                                      check_url=self.url)
         test_url = self.url + '.dods?pr[0:1:0][0:1:5][0:1:5]'
-        try:
-            res = requests.get(test_url, cookies=session.cookies,
-                               verify=False)
-        except SSLError:
-            raise_for_ssl_error(test_url, session=session) 
+        res = requests.get(test_url, cookies=session.cookies,
+                           verify=False)
         assert(res.status_code == 200)
         res.close()
 

--- a/src/pydap/tests/test_cas_esgf.py
+++ b/src/pydap/tests/test_cas_esgf.py
@@ -1,0 +1,70 @@
+from pydap.client import open_url
+import pydap.net
+from pydap.cas import esgf
+import requests
+import numpy as np
+import os
+import logging
+
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+logging.basicConfig(filename='cas_esgf_test.log', level=logging.DEBUG)
+
+
+class TestESGF(unittest.TestCase):
+    url = ('http://cordexesg.dmi.dk/thredds/dodsC/cordex_general/'
+           'cordex/output/EUR-11/DMI/ICHEC-EC-EARTH/historical/r3i1p1/'
+           'DMI-HIRHAM5/v1/day/pr/v20131119/'
+           'pr_EUR-11_ICHEC-EC-EARTH_historical_r3i1p1_'
+           'DMI-HIRHAM5_v1_day_19960101-20001231.nc')
+
+    def test_basic_esgf_auth(self):
+        """Set up PyDAP to use the URS request() function"""
+        session = esgf.setup_session(os.environ['OPENID_ESGF'],
+                                     os.environ['PASSWORD_ESGF'],
+                                     check_url=self.url)
+        test_url = self.url + '.dods?pr[0:1:0][0:1:5][0:1:5]'
+        res = requests.get(test_url, cookies=session.cookies)
+        assert(res.status_code == 200)
+        res.close()
+
+        res = pydap.net.follow_redirect(test_url, session=session)
+        assert(res.status_code == 200)
+
+    def test_dimension_esgf_query(self):
+        session = esgf.setup_session(os.environ['OPENID_ESGF'],
+                                     os.environ['PASSWORD_ESGF'],
+                                     check_url=self.url)
+        dataset = open_url(self.url, session=session)
+        data = dataset['time'][:10]
+        expected_data = np.array([16832.5, 16833.5, 16834.5, 16835.5, 16836.5,
+                                  16837.5, 16838.5, 16839.5, 16840.5, 16841.5])
+        assert(np.isclose(data, expected_data).all())
+
+    @unittest.skip("This test should work but does not. Issue raised.")
+    def test_variable_esgf_query(self):
+        session = esgf.setup_session(os.environ['OPENID_ESGF'],
+                                     os.environ['PASSWORD_ESGF'],
+                                     check_url=self.url)
+        dataset = open_url(self.url, session=session)
+        data = dataset['pr'][0, 200:205, 100:105]
+        expected_data = [[[5.23546005e-05,  5.48864300e-05,
+                           5.23546005e-05,  6.23914966e-05,
+                           6.26627589e-05],
+                          [5.45247385e-05,  5.67853021e-05,
+                           5.90458621e-05,  6.51041701e-05,
+                           6.23914966e-05],
+                          [5.57906533e-05,  5.84129048e-05,
+                           6.37478297e-05,  5.99500854e-05,
+                           5.85033267e-05],
+                          [5.44343166e-05,  5.45247385e-05,
+                           5.60619228e-05,  5.58810752e-05,
+                           4.91898136e-05],
+                          [5.09982638e-05,  4.77430549e-05,
+                           4.97323490e-05,  5.43438946e-05,
+                           5.26258664e-05]]]
+        assert(np.isclose(data, expected_data).all())

--- a/src/pydap/tests/test_cas_esgf.py
+++ b/src/pydap/tests/test_cas_esgf.py
@@ -29,8 +29,8 @@ class TestESGF(unittest.TestCase):
         open and url if and only if requests is able to
         open the same url.
         """
-        session = esgf.setup_session(os.environ['OPENID_ESGF'],
-                                     os.environ['PASSWORD_ESGF'],
+        session = esgf.setup_session(os.environ.get('OPENID_ESGF'),
+                                     os.environ.get('PASSWORD_ESGF'),
                                      check_url=self.url)
         test_url = self.url + '.dods?pr[0:1:0][0:1:5][0:1:5]'
         res = requests.get(test_url, cookies=session.cookies)
@@ -41,8 +41,8 @@ class TestESGF(unittest.TestCase):
         assert(res.status_code == 200)
 
     def test_dimension_esgf_query(self):
-        session = esgf.setup_session(os.environ['OPENID_ESGF'],
-                                     os.environ['PASSWORD_ESGF'],
+        session = esgf.setup_session(os.environ.get('OPENID_ESGF'),
+                                     os.environ.get('PASSWORD_ESGF'),
                                      check_url=self.url)
         dataset = open_url(self.url, session=session)
         data = dataset['time'][:10]
@@ -53,8 +53,8 @@ class TestESGF(unittest.TestCase):
     @unittest.skip("This test should work but does not. "
                    "An issue should be raised.")
     def test_variable_esgf_query(self):
-        session = esgf.setup_session(os.environ['OPENID_ESGF'],
-                                     os.environ['PASSWORD_ESGF'],
+        session = esgf.setup_session(os.environ.get('OPENID_ESGF'),
+                                     os.environ.get('PASSWORD_ESGF'),
                                      check_url=self.url)
         dataset = open_url(self.url, session=session)
         data = dataset['pr'][0, 200:205, 100:105]

--- a/src/pydap/tests/test_cas_esgf.py
+++ b/src/pydap/tests/test_cas_esgf.py
@@ -4,17 +4,16 @@ from pydap.cas import esgf
 import requests
 import numpy as np
 import os
-import logging
-
+from nose.plugins.attrib import attr
 import sys
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest
 
-logging.basicConfig(filename='cas_esgf_test.log', level=logging.DEBUG)
 
-
+@attr('auth')
+@attr('prod_url')
 class TestESGF(unittest.TestCase):
     url = ('http://cordexesg.dmi.dk/thredds/dodsC/cordex_general/'
            'cordex/output/EUR-11/DMI/ICHEC-EC-EARTH/historical/r3i1p1/'

--- a/src/pydap/tests/test_cas_esgf.py
+++ b/src/pydap/tests/test_cas_esgf.py
@@ -1,4 +1,4 @@
-from pydap.client import open_url
+from pydap.client import open_url, raise_for_ssl_error
 import pydap.net
 from pydap.cas import esgf
 import requests
@@ -6,6 +6,7 @@ import numpy as np
 import os
 from nose.plugins.attrib import attr
 import sys
+from requests.exceptions import SSLError
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
@@ -33,7 +34,10 @@ class TestESGF(unittest.TestCase):
                                      os.environ.get('PASSWORD_ESGF'),
                                      check_url=self.url)
         test_url = self.url + '.dods?pr[0:1:0][0:1:5][0:1:5]'
-        res = requests.get(test_url, cookies=session.cookies)
+        try:
+            res = requests.get(test_url, cookies=session.cookies)
+        except SSLError:
+            raise_for_ssl_error(test_url, session=session) 
         assert(res.status_code == 200)
         res.close()
 

--- a/src/pydap/tests/test_cas_urs.py
+++ b/src/pydap/tests/test_cas_urs.py
@@ -19,7 +19,13 @@ class TestUrs(unittest.TestCase):
            'MERRA100.prod.assim.instM_3d_asm_Cp.197901.hdf')
 
     def test_basic_urs_auth(self):
-        """Set up PyDAP to use the URS request() function"""
+        """
+        Set up PyDAP to use the URS request() function.
+
+        The intent here is to ensure that pydap.net is able to
+        open and url if and only if requests is able to
+        open the same url.
+        """
         session = urs.setup_session(os.environ['USERNAME_URS'],
                                     os.environ['PASSWORD_URS'],
                                     check_url=self.url)

--- a/src/pydap/tests/test_cas_urs.py
+++ b/src/pydap/tests/test_cas_urs.py
@@ -4,15 +4,15 @@ import pydap.net
 import requests
 import os
 import sys
-import logging
+from nose.plugins.attrib import attr
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest
 
-logging.basicConfig(filename='cas_urs_test.log', level=logging.DEBUG)
 
-
+@attr('auth')
+@attr('prod_url')
 class TestUrs(unittest.TestCase):
     url = ('https://goldsmr3.gesdisc.eosdis.nasa.gov/opendap/'
            'MERRA_MONTHLY/MAIMCPASM.5.2.0/1979/'

--- a/src/pydap/tests/test_cas_urs.py
+++ b/src/pydap/tests/test_cas_urs.py
@@ -1,0 +1,50 @@
+from pydap.client import open_url
+from pydap.cas import urs
+import pydap.net
+import requests
+import os
+import sys
+import logging
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+logging.basicConfig(filename='cas_urs_test.log', level=logging.DEBUG)
+
+
+class TestUrs(unittest.TestCase):
+    url = ('https://goldsmr3.gesdisc.eosdis.nasa.gov/opendap/'
+           'MERRA_MONTHLY/MAIMCPASM.5.2.0/1979/'
+           'MERRA100.prod.assim.instM_3d_asm_Cp.197901.hdf')
+
+    def test_basic_urs_auth(self):
+        """Set up PyDAP to use the URS request() function"""
+        session = urs.setup_session(os.environ['USERNAME_URS'],
+                                    os.environ['PASSWORD_URS'],
+                                    check_url=self.url)
+
+        test_url = self.url + '.dods?SLP[0:1:0][0:1:10][0:1:10]'
+        res = requests.get(test_url, cookies=session.cookies)
+        assert(res.status_code == 200)
+        res.close()
+
+        res = pydap.net.follow_redirect(test_url, session=session)
+        assert(res.status_code == 200)
+
+    def test_basic_urs_query(self):
+        session = urs.setup_session(os.environ['USERNAME_URS'],
+                                    os.environ['PASSWORD_URS'],
+                                    check_url=self.url)
+        dataset = open_url(self.url, session=session)
+        expected_data = [[[99066.15625, 99066.15625, 99066.15625,
+                           99066.15625, 99066.15625],
+                          [98868.15625, 98870.15625, 98872.15625,
+                           98874.15625, 98874.15625],
+                          [98798.15625, 98810.15625, 98820.15625,
+                           98832.15625, 98844.15625],
+                          [98856.15625, 98828.15625, 98756.15625,
+                           98710.15625, 98776.15625],
+                          [99070.15625, 99098.15625, 99048.15625,
+                           98984.15625, 99032.15625]]]
+        assert((dataset['SLP'][0, :5, :5] == expected_data).all())

--- a/src/pydap/tests/test_cas_urs.py
+++ b/src/pydap/tests/test_cas_urs.py
@@ -26,8 +26,8 @@ class TestUrs(unittest.TestCase):
         open and url if and only if requests is able to
         open the same url.
         """
-        session = urs.setup_session(os.environ['USERNAME_URS'],
-                                    os.environ['PASSWORD_URS'],
+        session = urs.setup_session(os.environ.get('USERNAME_URS'),
+                                    os.environ.get('PASSWORD_URS'),
                                     check_url=self.url)
 
         test_url = self.url + '.dods?SLP[0:1:0][0:1:10][0:1:10]'
@@ -39,8 +39,8 @@ class TestUrs(unittest.TestCase):
         assert(res.status_code == 200)
 
     def test_basic_urs_query(self):
-        session = urs.setup_session(os.environ['USERNAME_URS'],
-                                    os.environ['PASSWORD_URS'],
+        session = urs.setup_session(os.environ.get('USERNAME_URS'),
+                                    os.environ.get('PASSWORD_URS'),
                                     check_url=self.url)
         dataset = open_url(self.url, session=session)
         expected_data = [[[99066.15625, 99066.15625, 99066.15625,


### PR DESCRIPTION
This PR is a solution to #20. It uses a very different approach that avoids monkey patching. At the moment this method provides facilities for both URS NASA EARTHDATA authentication and ESGF authentication.

A variant of this PR has been actively used in [laliberte/netcdf4_pydap](https://github.com/laliberte/netcdf4_pydap) and stress tested with [laliberte/cdb-query](https://github.com/laliberte/cdb-query). The idea is to use a ``requests.Session()`` object to carry around cookies from the authentication service. It has many advantages:

1. The ``requests.Session()`` object is thread safe.
2. The ``requests.Session()`` object can be used in other applications, for example if one simply wants to ``wget`` the file using the same authentication. This is a natural workflow with the THREDDS Server of the ESGF.
3. The ``requests.Session()`` object can be easily manipulated with high-level libraries. This is illustrated by the use of the ``mechanicalsoup`` library to parse and submit authentication forms.
4. The ``requests`` library is widely used and ``requests``-based authentication methods will most likely be easier to maintain in the future (this is speculation but maintaining [laliberte/netcdf4_pydap](https://github.com/laliberte/netcdf4_pydap) has shown me that this has been mostly true).

I have run extensive testing and everything seems to work pretty well. There however remains one major issue. After authenticating with the ESGF, fetching data brings out a bug whereas the time dimension cannot be retrieved. I have highlighted this issue in a currently-skipped test in ``test_cas_esgf.py``. If this PR is kept, then I could raise an issue to solve this bug.

Any comments?