### PR TITLE
Auth tests fail when credentials are not specified.

### DIFF
--- a/src/pydap/tests/test_cas_esgf.py
+++ b/src/pydap/tests/test_cas_esgf.py
@@ -20,6 +20,7 @@ class TestESGF(unittest.TestCase):
            'DMI-HIRHAM5/v1/day/pr/v20131119/'
            'pr_EUR-11_ICHEC-EC-EARTH_historical_r3i1p1_'
            'DMI-HIRHAM5_v1_day_19960101-20001231.nc')
+    test_url = url + '.dods?pr[0:1:0][0:1:5][0:1:5]'
 
     def test_registration_esgf_auth(self):
         """
@@ -48,19 +49,23 @@ class TestESGF(unittest.TestCase):
         session = esgf.setup_session(os.environ.get('OPENID_ESGF'),
                                      os.environ.get('PASSWORD_ESGF'),
                                      check_url=self.url)
-        test_url = self.url + '.dods?pr[0:1:0][0:1:5][0:1:5]'
-        res = requests.get(test_url, cookies=session.cookies,
+        res = requests.get(self.test_url, cookies=session.cookies,
                            verify=False)
         assert(res.status_code == 200)
         res.close()
 
-        res = pydap.net.follow_redirect(test_url, session=session)
+        res = pydap.net.follow_redirect(self.test_url, session=session)
         assert(res.status_code == 200)
 
     def test_dimension_esgf_query(self):
         session = esgf.setup_session(os.environ.get('OPENID_ESGF'),
                                      os.environ.get('PASSWORD_ESGF'),
                                      check_url=self.url)
+
+        # Ensure authentication:
+        res = pydap.net.follow_redirect(self.test_url, session=session)
+        assert(res.status_code == 200)
+
         dataset = open_url(self.url, session=session)
         data = dataset['time'][:10]
         expected_data = np.array([16832.5, 16833.5, 16834.5, 16835.5, 16836.5,
@@ -71,10 +76,10 @@ class TestESGF(unittest.TestCase):
         session = esgf.setup_session(os.environ.get('OPENID_ESGF'),
                                      os.environ.get('PASSWORD_ESGF'),
                                      check_url=self.url)
-        # This server does not access retrieval of grid coordinates.
-        # The option output_grid disables this, reverting to
-        # pydap 3.1.1 behavior. For older OPeNDAP servers (i.e. ESGF),
-        # this appears necessary.
+        # Ensure authentication:
+        res = pydap.net.follow_redirect(self.test_url, session=session)
+        assert(res.status_code == 200)
+
         dataset = open_url(self.url, session=session, output_grid=False)
         data = dataset['pr'][0, 200:205, 100:105]
         expected_data = [[[5.23546005e-05,  5.48864300e-05,

--- a/src/pydap/tests/test_cas_esgf.py
+++ b/src/pydap/tests/test_cas_esgf.py
@@ -33,6 +33,8 @@ class TestESGF(unittest.TestCase):
         environment variables. These must be associated with credentials
         where no group was selected.
         """
+        assert(os.environ.get('OPENID_ESGF_NO_REG') is not None)
+        assert(os.environ.get('PASSWORD_ESGF_NO_REG') is not None)
         with self.assertRaises(UserWarning):
             esgf.setup_session(os.environ.get('OPENID_ESGF_NO_REG'),
                                os.environ.get('PASSWORD_ESGF_NO_REG'),
@@ -40,15 +42,18 @@ class TestESGF(unittest.TestCase):
 
     def test_basic_esgf_auth(self):
         """
-        Set up PyDAP to use the URS request() function.
+        Set up PyDAP to use the ESGF request() function.
 
         The intent here is to ensure that pydap.net is able to
         open and url if and only if requests is able to
         open the same url.
         """
+        assert(os.environ.get('OPENID_ESGF') is not None)
+        assert(os.environ.get('PASSWORD_ESGF') is not None)
         session = esgf.setup_session(os.environ.get('OPENID_ESGF'),
                                      os.environ.get('PASSWORD_ESGF'),
                                      check_url=self.url)
+
         res = requests.get(self.test_url, cookies=session.cookies,
                            verify=False)
         assert(res.status_code == 200)
@@ -58,6 +63,8 @@ class TestESGF(unittest.TestCase):
         assert(res.status_code == 200)
 
     def test_dimension_esgf_query(self):
+        assert(os.environ.get('OPENID_ESGF') is not None)
+        assert(os.environ.get('PASSWORD_ESGF') is not None)
         session = esgf.setup_session(os.environ.get('OPENID_ESGF'),
                                      os.environ.get('PASSWORD_ESGF'),
                                      check_url=self.url)
@@ -73,6 +80,8 @@ class TestESGF(unittest.TestCase):
         assert(np.isclose(data, expected_data).all())
 
     def test_variable_esgf_query(self):
+        assert(os.environ.get('OPENID_ESGF') is not None)
+        assert(os.environ.get('PASSWORD_ESGF') is not None)
         session = esgf.setup_session(os.environ.get('OPENID_ESGF'),
                                      os.environ.get('PASSWORD_ESGF'),
                                      check_url=self.url)

--- a/src/pydap/tests/test_cas_urs.py
+++ b/src/pydap/tests/test_cas_urs.py
@@ -27,6 +27,8 @@ class TestUrs(unittest.TestCase):
         open and url if and only if requests is able to
         open the same url.
         """
+        assert(os.environ.get('OPENID_URS') is not None)
+        assert(os.environ.get('PASSWORD_URS') is not None)
         session = urs.setup_session(os.environ.get('USERNAME_URS'),
                                     os.environ.get('PASSWORD_URS'),
                                     check_url=self.url)
@@ -39,6 +41,8 @@ class TestUrs(unittest.TestCase):
         assert(res.status_code == 200)
 
     def test_basic_urs_query(self):
+        assert(os.environ.get('OPENID_URS') is not None)
+        assert(os.environ.get('PASSWORD_URS') is not None)
         session = urs.setup_session(os.environ.get('USERNAME_URS'),
                                     os.environ.get('PASSWORD_URS'),
                                     check_url=self.url)

--- a/src/pydap/tests/test_cas_urs.py
+++ b/src/pydap/tests/test_cas_urs.py
@@ -17,6 +17,7 @@ class TestUrs(unittest.TestCase):
     url = ('https://goldsmr3.gesdisc.eosdis.nasa.gov/opendap/'
            'MERRA_MONTHLY/MAIMCPASM.5.2.0/1979/'
            'MERRA100.prod.assim.instM_3d_asm_Cp.197901.hdf')
+    test_url = url + '.dods?SLP[0:1:0][0:1:10][0:1:10]'
 
     def test_basic_urs_auth(self):
         """
@@ -30,18 +31,20 @@ class TestUrs(unittest.TestCase):
                                     os.environ.get('PASSWORD_URS'),
                                     check_url=self.url)
 
-        test_url = self.url + '.dods?SLP[0:1:0][0:1:10][0:1:10]'
-        res = requests.get(test_url, cookies=session.cookies)
+        res = requests.get(self.test_url, cookies=session.cookies)
         assert(res.status_code == 200)
         res.close()
 
-        res = pydap.net.follow_redirect(test_url, session=session)
+        res = pydap.net.follow_redirect(self.test_url, session=session)
         assert(res.status_code == 200)
 
     def test_basic_urs_query(self):
         session = urs.setup_session(os.environ.get('USERNAME_URS'),
                                     os.environ.get('PASSWORD_URS'),
                                     check_url=self.url)
+        # Ensure authentication:
+        res = pydap.net.follow_redirect(self.test_url, session=session)
+        assert(res.status_code == 200)
         dataset = open_url(self.url, session=session)
         expected_data = [[[99066.15625, 99066.15625, 99066.15625,
                            99066.15625, 99066.15625],


### PR DESCRIPTION
This PR makes the auth fail when the credential environment variables are not set.

The method used here tests whether a test_url gives a 200 response.