### PR TITLE
Fix a bug with ESGF OPENDAP servers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
     - pip install -e .[testing,functions,tests]
 
 script:
-    - python setup.py nosetests
+    - python setup.py nosetests -a '!auth'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
     - pip install -e .[testing,functions,tests]
 
 script:
-    - python setup.py nosetests -a '!auth'
+    - python setup.py nosetests

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -138,6 +138,18 @@ Instead of indexes we can also subset the data using its maps, in a more natural
     [-9. -7. -5. -3. -1.  1.  3.  5.  7.  9.]
     [ 321.  323.  325.  327.]
 
+Older Servers
+^^^^^^^^^^^^^
+Some servers using a very old OPeNDAP application might run of of memory when attempting to retrieve both the data and
+the coordinate axes of a variable. The work around is to simply disable the retrieval of coordinate axes by using the
+``output_grid`` option to open url:
+
+.. doctest::
+
+    >>> from pydap.client import open_url
+    >>> dataset = open_url('http://test.opendap.org/dap/data/nc/coads_climatology.nc', output_grid=False)
+
+
 Accessing sequential data
 -------------------------
 

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -54,9 +54,14 @@ from pydap.parsers.dds import build_dataset
 from pydap.parsers.das import parse_das, add_attributes
 
 
-def open_url(url, application=None, session=None):
-    """Open a remote URL, returning a dataset."""
-    dataset = DAPHandler(url, application, session).dataset
+def open_url(url, application=None, session=None, output_grid=True):
+    """
+    Open a remote URL, returning a dataset.
+   
+    set output_grid to False to retrieve only main arrays and
+    never retrieve coordinate axes.
+    """
+    dataset = DAPHandler(url, application, session, output_grid).dataset
 
     # attach server-side functions
     dataset.functions = Functions(url, application, session)

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -12,6 +12,7 @@ import pprint
 import copy
 import re
 from itertools import chain
+import warnings
 
 # handlers should be set by the application
 # http://docs.python.org/2/howto/logging.html#configuring-logging-for-a-library
@@ -42,7 +43,7 @@ class DAPHandler(BaseHandler):
 
     """Build a dataset from a DAP base URL."""
 
-    def __init__(self, url, application=None, session=None):
+    def __init__(self, url, application=None, session=None, output_grid=True):
         # download DDS/DAS
         scheme, netloc, path, query, fragment = urlsplit(url)
 
@@ -90,6 +91,9 @@ class DAPHandler(BaseHandler):
                 elif isinstance(target, SequenceType):
                     target.data.slice = index
 
+        # retrieve only main variable for grid types:
+        for var in walk(self.dataset, GridType):
+            var.set_output_grid(output_grid)
 
 class BaseProxy(object):
 
@@ -143,18 +147,29 @@ class BaseProxy(object):
             int(np.ceil((s.stop-s.start)/float(s.step))) for s in index)
         size = int(np.prod(shape))
 
-        if self.dtype == np.byte:
-            return np.fromstring(data[:size], 'B')
-        elif self.dtype.char in 'SU':
-            out = []
-            for word in range(size):
-                n = np.fromstring(data[:4], '>I')  # read length
-                data = data[4:]
-                out.append(data[:n])
-                data = data[n + (-n % 4):]
-            return np.array([ text_type(x.decode('ascii')) for x in out ], 'S')
-        else:
-            return np.fromstring(data, self.dtype).reshape(shape)
+        try:
+            if self.dtype == np.byte:
+                return np.fromstring(data[:size], 'B')
+            elif self.dtype.char in 'SU':
+                out = []
+                for word in range(size):
+                    n = np.fromstring(data[:4], '>I')  # read length
+                    data = data[4:]
+                    out.append(data[:n])
+                    data = data[n + (-n % 4):]
+                return np.array([ text_type(x.decode('ascii')) for x in out ], 'S')
+            else:
+                return np.fromstring(data, self.dtype).reshape(shape)
+        except ValueError as e:
+            if str(e) == 'total size of new array must be unchanged':
+                # server-side failure. do not fail. instead, return NaNs
+                # it is expected that the user should be mindful of this:
+                raise RuntimeError('varirable {0} could not be properly '.format(quote(self.id)) +
+                                   'retrieved. '
+                                   'To avoid this '
+                                   'error consider using open_url(..., output_grid=False).')
+            else:
+                raise
 
     def __len__(self):
         return self.shape[0]

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -555,6 +555,9 @@ class GridType(StructureType):
 
         # Return a new `GridType` with part of the data.
         else:
+            if not self.output_grid:
+                return self.array[key]
+
             if not isinstance(key, tuple):
                 key = (key,)
 
@@ -562,6 +565,16 @@ class GridType(StructureType):
             for var, slice_ in zip(out.children(), [key] + list(key)):
                 var.data = self[var.name].data[slice_]
             return out
+
+    @property
+    def output_grid(self):
+        if hasattr(self, '_output_grid'):
+            return self._output_grid
+        else:
+            return True
+
+    def set_output_grid(self, key):
+        self._output_grid = bool(key)
 
     @property
     def array(self):

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -543,6 +543,10 @@ class GridType(StructureType):
 
     """
 
+    def __init__(self, name, attributes=None, **kwargs):
+        StructureType.__init__(self, name, attributes, **kwargs)
+        self._output_grid = True
+
     def __repr__(self):
         return '<%s with array %s and maps %s>' % (
             self.__class__.__name__,
@@ -568,10 +572,7 @@ class GridType(StructureType):
 
     @property
     def output_grid(self):
-        if hasattr(self, '_output_grid'):
-            return self._output_grid
-        else:
-            return True
+        return self._output_grid
 
     def set_output_grid(self, key):
         self._output_grid = bool(key)

--- a/src/pydap/tests/test_cas_esgf.py
+++ b/src/pydap/tests/test_cas_esgf.py
@@ -67,13 +67,15 @@ class TestESGF(unittest.TestCase):
                                   16837.5, 16838.5, 16839.5, 16840.5, 16841.5])
         assert(np.isclose(data, expected_data).all())
 
-    @unittest.skip("This test should work but does not. "
-                   "An issue should be raised.")
     def test_variable_esgf_query(self):
         session = esgf.setup_session(os.environ.get('OPENID_ESGF'),
                                      os.environ.get('PASSWORD_ESGF'),
                                      check_url=self.url)
-        dataset = open_url(self.url, session=session)
+        # This server does not access retrieval of grid coordinates.
+        # The option output_grid disables this, reverting to 
+        # pydap 3.1.1 behavior. For older OPeNDAP servers (i.e. ESGF),
+        # this appears necessary. 
+        dataset = open_url(self.url, session=session, output_grid=False)
         data = dataset['pr'][0, 200:205, 100:105]
         expected_data = [[[5.23546005e-05,  5.48864300e-05,
                            5.23546005e-05,  6.23914966e-05,

--- a/src/pydap/tests/test_cas_urs.py
+++ b/src/pydap/tests/test_cas_urs.py
@@ -42,7 +42,6 @@ class TestUrs(unittest.TestCase):
         session = urs.setup_session(os.environ.get('USERNAME_URS'),
                                     os.environ.get('PASSWORD_URS'),
                                     check_url=self.url)
-        assert session.auth
         dataset = open_url(self.url, session=session)
         expected_data = [[[99066.15625, 99066.15625, 99066.15625,
                            99066.15625, 99066.15625],


### PR DESCRIPTION
This PR solves a bug on ESGF servers whereas retrieving coordinates of grid variables would  uncover a memory leak on the OPENDAP server. The solution proposed here is to provide a boolean option ``open_url(..., output_grid=False)`` that disables the retrieval of these coordinates. This essentially reverts to the behavior of ``pydap 3.1.1`` and is more akin to the behavior of ``netcdf4-python``. 

Considering that many use cases for ``pydap`` involve the ESGF, I would consider this bug fix high priority (it certainly is for me: without it ``pydap 3.2.0`` is essentially useless for me). I am open to a different approach / another name for ``output_grid``, as long as there is a high level method to disable the grid retrieval.