### PR TITLE
Merging netCDF handlers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ addons:
       - netcdf-bin
       - libnetcdf-dev
 install:
-    - export USE_NCONFIG=1
-    - pip install netCDF4
+    - nc-config --all
+    - export USE_NCONFIG=1; pip install netcdf4
     - travis_wait 30 pip install scipy
     - pip install -e .[testing,functions,tests]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
       - netcdf-bin
       - libnetcdf-dev
 install:
-    - USE_SETUPCFG=0 HDF5_INCDIR=/usr/include/hdf5/serial HDF5_LIBDIR=/usr/lib/x86_64-linux-gnu/hdf5/serial pip install netcdf4-python
+    - USE_SETUPCFG=0 HDF5_INCDIR=/usr/include/hdf5/serial HDF5_LIBDIR=/usr/lib/x86_64-linux-gnu/hdf5/serial pip install netcdf4
     # Continue typical install:
     - travis_wait 30 pip install scipy
     - pip install -e .[testing,functions,tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,7 @@ addons:
       - netcdf-bin
       - libnetcdf-dev
 install:
-    # Install netcdf4-python from github. pip install does not
-    # appear to be working:
-    - pip install ordereddict
-    - git clone https://github.com/Unidata/netcdf4-python.git
-    - cd netcdf4-python
-    - python setup.py build
-    - python setup.py install
-    - cd ..
-    - rm -rf netcdf4-python
+    - USE_SETUPCFG=0 HDF5_INCDIR=/usr/include/hdf5/serial HDF5_LIBDIR=/usr/lib/x86_64-linux-gnu/hdf5/serial pip install netcdf4-python
     # Continue typical install:
     - travis_wait 30 pip install scipy
     - pip install -e .[testing,functions,tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,12 @@ addons:
       - netcdf-bin
       - libnetcdf-dev
 install:
-    - nc-config --all
-    - export USE_NCONFIG=1; pip install netcdf4
+    - pip install ordereddict
+    - git clone https://github.com/Unidata/netcdf4-python.git
+    - cd netcdf4-python
+    - python setup.py build
+    - python setup.py install
+    - cd ..
     - travis_wait 30 pip install scipy
     - pip install -e .[testing,functions,tests]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,20 @@ addons:
       - libblas-dev
       - liblapack-dev
       - cython
+      # The following as required for netcdf files:
       - libhdf5-serial-dev
       - netcdf-bin
       - libnetcdf-dev
 install:
+    # Install netcdf4-python from github. pip install does not
+    # appear to be working:
     - pip install ordereddict
     - git clone https://github.com/Unidata/netcdf4-python.git
     - cd netcdf4-python
     - python setup.py build
     - python setup.py install
     - cd ..
+    # Continue typical install:
     - travis_wait 30 pip install scipy
     - pip install -e .[testing,functions,tests]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ addons:
       - libblas-dev
       - liblapack-dev
       - cython
+      - libhdf5-dev
+      - libnetcdf-dev
 install:
     - travis_wait 30 pip install scipy
     - pip install -e .[testing,functions,tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
     - python setup.py build
     - python setup.py install
     - cd ..
+    - rm -r netcdf4-python
     # Continue typical install:
     - travis_wait 30 pip install scipy
     - pip install -e .[testing,functions,tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
       - libblas-dev
       - liblapack-dev
       - cython
-      - libhdf5-dev
       - libnetcdf-dev
 install:
     - travis_wait 30 pip install scipy

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
       - libblas-dev
       - liblapack-dev
       - cython
+      - libhdf5-dev
       - libnetcdf-dev
 install:
     - travis_wait 30 pip install scipy

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
       - libblas-dev
       - liblapack-dev
       - cython
-      - libhdf5-dev
+      - libhdf5-serial-dev
       - libnetcdf-dev
 install:
     - travis_wait 30 pip install scipy

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,11 @@ addons:
 install:
     # Install netcdf4-python from github. pip install does not
     # appear to be working:
-    - pip install ordereddict
+    - if [ "${TRAVIS_PYTHON_VERSION}" == 2.6 ]; then pip install ordereddict; fi
     - git clone https://github.com/Unidata/netcdf4-python.git
     - cd netcdf4-python
+    # Use the last python 2.6-compatible commit:
+    - if [ "${TRAVIS_PYTHON_VERSION}" == 2.6 ]; then git checkout 02870031d9b783ba153406f046d24890468db85f; fi
     - python setup.py build
     - python setup.py install
     - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ addons:
       - netcdf-bin
       - libnetcdf-dev
 install:
+    - export USE_NCONFIG=1
+    - pip install netCDF4
     - travis_wait 30 pip install scipy
     - pip install -e .[testing,functions,tests]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
     - python setup.py build
     - python setup.py install
     - cd ..
-    - rm -r netcdf4-python
+    - rm -rf netcdf4-python
     # Continue typical install:
     - travis_wait 30 pip install scipy
     - pip install -e .[testing,functions,tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,15 @@ addons:
       - netcdf-bin
       - libnetcdf-dev
 install:
-    - USE_SETUPCFG=0 HDF5_INCDIR=/usr/include/hdf5/serial HDF5_LIBDIR=/usr/lib/x86_64-linux-gnu/hdf5/serial pip install netcdf4
+    # Install netcdf4-python from github. pip install does not
+    # appear to be working:
+    - pip install ordereddict
+    - git clone https://github.com/Unidata/netcdf4-python.git
+    - cd netcdf4-python
+    - python setup.py build
+    - python setup.py install
+    - cd ..
+    - rm -rf netcdf4-python
     # Continue typical install:
     - travis_wait 30 pip install scipy
     - pip install -e .[testing,functions,tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
       - liblapack-dev
       - cython
       - libhdf5-serial-dev
+      - netcdf-bin
       - libnetcdf-dev
 install:
     - travis_wait 30 pip install scipy

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ cas_extras = [
 
 hdl_netcdf_extras = [
     'scipy',
-    'netCDF4'
+    'netCDF4',
+    'ordereddict'
     ]
     
 tests_require = (functions_extras + cas_extras + 

--- a/setup.py
+++ b/setup.py
@@ -40,12 +40,11 @@ hdl_netcdf_extras = [
     ]
 
 tests_require = (functions_extras + cas_extras + server_extras +
-                 hdl_netcdf_extras + [
-    'WebTest',
-    'beautifulsoup4',
-    'scipy',
-    'flake8'
-])
+                 hdl_netcdf_extras +
+                 ['WebTest',
+                  'beautifulsoup4',
+                  'scipy',
+                  'flake8'])
 
 testing_extras = tests_require + [
     'nose',

--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,18 @@ docs_extras = [
 cas_extras = [
     'requests'
     ]
+
+hdl_netcdf_extras = [
+    'scipy',
+    'netCDF4'
+    ]
     
-tests_require = functions_extras + cas_extras + [
+tests_require = (functions_extras + cas_extras + 
+                hdl_netcdf_extras +[
     'WebTest',
     'beautifulsoup4',
     'scipy'
-]
+])
 
 testing_extras = tests_require + [
     'nose',
@@ -80,7 +86,8 @@ setup(name='Pydap',
         'testing': testing_extras,
         'docs': docs_extras,
         'tests': tests_require,
-        'cas': cas_extras
+        'cas': cas_extras,
+        'handlers.netcdf': hdl_netcdf_extras
     },
     test_suite="pydap.tests",
     entry_points="""

--- a/src/pydap/handlers/netcdf/__init__.py
+++ b/src/pydap/handlers/netcdf/__init__.py
@@ -1,0 +1,185 @@
+"""Pydap handler for NetCDF3/4 files."""
+
+import os
+import re
+import time
+from stat import ST_MTIME
+from email.utils import formatdate
+from collections import OrderedDict
+import numpy as np
+
+from pkg_resources import get_distribution
+
+from pydap.model import DatasetType, GridType, BaseType
+from pydap.handlers.lib import BaseHandler
+from pydap.exceptions import OpenFileError
+
+try:
+    from netCDF4 import Dataset as netcdf_file
+
+    def attrs(var):
+        return {k: getattr(var, k) for k in var.ncattrs()}
+except ImportError:
+    from scipy.io.netcdf import netcdf_file
+
+    def attrs(var):
+        return var._attributes
+
+
+class NetCDFHandler(BaseHandler):
+
+    """A simple handler for NetCDF files.
+    Here's a standard dataset for testing sequential data:
+    """
+
+    __version__ = get_distribution("pydap").version
+    extensions = re.compile(r"^.*\.(nc|cdf)$", re.IGNORECASE)
+
+    def __init__(self, filepath):
+        BaseHandler.__init__(self)
+
+        self.filepath = filepath
+        try:
+            with netcdf_file(self.filepath, 'r') as source:
+                self.additional_headers.append(('Last-modified',
+                                               (formatdate(
+                                                time.mktime(
+                                                    time.localtime(
+                                                        os.stat(filepath)
+                                                        [ST_MTIME])
+                                                        )))))
+
+                # shortcuts
+                vars = source.variables
+                dims = source.dimensions
+
+                # build dataset
+                name = os.path.split(filepath)[1]
+                self.dataset = DatasetType(name,
+                                           attributes=dict(
+                                                      NC_GLOBAL=attrs(source)))
+                for dim in dims:
+                    if dims[dim] is None:
+                        self.dataset.attributes['DODS_EXTRA'] = {
+                            'Unlimited_Dimension': dim,
+                        }
+                        break
+
+                # add grids
+                grids = [var for var in vars if var not in dims]
+                for grid in grids:
+                    self.dataset[grid] = GridType(grid, attrs(vars[grid]))
+                    # add array
+                    self.dataset[grid][grid] = BaseType(grid,
+                                                        LazyVariable(
+                                                            source,
+                                                            grid,
+                                                            grid,
+                                                            self.filepath),
+                                                        vars[grid].dimensions,
+                                                        attrs(vars[grid]))
+                    # add maps
+                    for dim in vars[grid].dimensions:
+                        self.dataset[grid][dim] = BaseType(dim, vars[dim][:],
+                                                           None,
+                                                           attrs(vars[dim]))
+
+                # add dims
+                for dim in dims:
+                    self.dataset[dim] = BaseType(dim, vars[dim][:], None,
+                                                 attrs(vars[dim]))
+        except Exception as exc:
+            raise
+            message = 'Unable to open file %s: %s' % (filepath, exc)
+            raise OpenFileError(message)
+
+
+class LazyVariable:
+    def __init__(self, source, name, path, filepath):
+        self.filepath = filepath
+        self.path = path
+        var = source[self.path]
+        self.dimensions = var._getdims()
+        self.dtype = np.dtype(var.dtype)
+        self.datatype = var.dtype
+        self.ndim = len(var.dimensions)
+        self._shape = var.shape
+        self._reshape = var.shape
+        self.scale = True
+        self.name = name
+        self.size = np.prod(self.shape)
+        self._attributes = {attr: var.getncattr(attr)
+                            for attr in var.ncattrs()}
+        return
+
+    def chunking(self):
+        return 'contiguous'
+
+    def filters(self):
+        return None
+
+    def get_var_chunk_cache(self):
+        raise NotImplementedError('get_var_chunk_cache is not implemented')
+        return
+
+    def ncattrs(self):
+        return self._attributes
+
+    def getncattr(self, attr):
+        return self._attributes[attr]
+
+    def __getattr__(self, name):
+        # from netcdf4-python
+        # if name in _private_atts, it is stored at the python
+        # level and not in the netCDF file.
+        if name.startswith('__') and name.endswith('__'):
+            # if __dict__ requested, return a dict with netCDF attributes.
+            if name == '__dict__':
+                names = self.ncattrs()
+                values = []
+                for name in names:
+                    values.append(self._attributes[name])
+                return OrderedDict(zip(names, values))
+            else:
+                raise AttributeError
+        else:
+            return self.getncattr(name)
+
+    def getValue(self):
+        return self[...]
+
+    def __array__(self):
+        return self[...]
+
+    def __getitem__(self, key):
+        with netcdf_file(self.filepath, 'r') as source:
+            return (np.asarray(source[self.path][key])
+                    .astype(self.dtype).reshape(self._reshape))
+
+    def reshape(self, *args):
+        if len(args) > 1:
+            self._reshape = args
+        else:
+            self._reshape = args
+        return self
+
+    @property
+    def shape(self):
+        return self._shape
+
+    def __len__(self):
+        if not self.shape:
+            raise TypeError('len() of unsized object')
+        else:
+            return self.shape[0]
+
+    def _getdims(self):
+        return self.dimensions
+
+
+if __name__ == "__main__":
+    import sys
+    from werkzeug.serving import run_simple
+
+    application = NetCDFHandler(sys.argv[1])
+    run_simple('localhost', 8001, application, use_reloader=True)

--- a/src/pydap/handlers/netcdf/__init__.py
+++ b/src/pydap/handlers/netcdf/__init__.py
@@ -18,7 +18,7 @@ try:
     from netCDF4 import Dataset as netcdf_file
 
     def attrs(var):
-        return {k: getattr(var, k) for k in var.ncattrs()}
+        return dict((k, getattr(var, k)) for k in var.ncattrs())
 except ImportError:
     from scipy.io.netcdf import netcdf_file
 

--- a/src/pydap/handlers/netcdf/__init__.py
+++ b/src/pydap/handlers/netcdf/__init__.py
@@ -5,7 +5,6 @@ import re
 import time
 from stat import ST_MTIME
 from email.utils import formatdate
-from collections import OrderedDict
 import numpy as np
 
 from pkg_resources import get_distribution
@@ -14,6 +13,13 @@ from pydap.model import DatasetType, GridType, BaseType
 from pydap.handlers.lib import BaseHandler
 from pydap.exceptions import OpenFileError
 
+# Python 2.6 compatibility:
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
+
+# Check for netCDF4 presence:
 try:
     from netCDF4 import Dataset as netcdf_file
 

--- a/src/pydap/handlers/netcdf/__init__.py
+++ b/src/pydap/handlers/netcdf/__init__.py
@@ -108,8 +108,8 @@ class LazyVariable:
         self.scale = True
         self.name = name
         self.size = np.prod(self.shape)
-        self._attributes = {attr: var.getncattr(attr)
-                            for attr in var.ncattrs()}
+        self._attributes = dict((attr, var.getncattr(attr))
+                                for attr in var.ncattrs())
         return
 
     def chunking(self):

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -252,7 +252,8 @@ class BaseType(DapType):
 
     # Implement the sequence and iter protocols.
     def __getitem__(self, index):
-        if hasattr(self.data, 'dtype') and self.data.dtype.char == 'S':
+        if (hasattr(self.data, 'dtype') and
+           np.dtype(self.data.dtype).char == 'S'):
             return np.vectorize(decode_np_strings)(self.data[index])
         else:
             return self.data[index]

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -23,7 +23,7 @@ def GET(url, application=None, session=None):
 def raise_for_status(response):
     if response.status_code >= 400:
         raise HTTPError(
-            detail=response.status,
+            detail=response.status+'\n'+response.text,
             headers=response.headers,
             comment=response.body
         )

--- a/src/pydap/tests/test_handlers_netcdf.py
+++ b/src/pydap/tests/test_handlers_netcdf.py
@@ -1,0 +1,120 @@
+"""Test the DAP handler, which forms the core of the client."""
+
+import sys
+from netCDF4 import Dataset
+import tempfile
+import multiprocessing
+import os
+import time
+import numpy as np
+
+from pydap.handlers.netcdf import NetCDFHandler
+from pydap.handlers.dap import DAPHandler
+from werkzeug.serving import run_simple
+from pydap.wsgi.ssf import ServerSideFunctions
+from pydap.client import open_url
+
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+class TestNetCDFHandler(unittest.TestCase):
+
+    """Test that the handler creates the correct dataset from a URL."""
+    data = [(10, 15.2, 'Diamond_St'),
+            (11, 13.1, 'Blacktail_Loop'),
+            (12, 13.3, 'Platinum_St'),
+            (13, 12.1, 'Kodiak_Trail')]
+
+    def setUp(self):
+        """Create WSGI apps"""
+
+        # Create tempfile:
+        fileno, self.test_file = tempfile.mkstemp(suffix='.nc')
+        # must close file number:
+        os.close(fileno)
+        with Dataset(self.test_file, 'w') as output:
+            output.createDimension('index', None)
+            temp = output.createVariable('index', '<i4', ('index',))
+            split_data = zip(*self.data)
+            temp[:] = next(split_data)
+            temp = output.createVariable('temperature', '<f8', ('index',))
+            temp[:] = next(split_data)
+            temp = output.createVariable('station', 'S40', ('index',))
+            for item_id, item in enumerate(next(split_data)):
+                temp[item_id] = item
+
+    def test_handler_direct(self):
+        """Test that dataset has the correct data proxies for grids."""
+        dataset = NetCDFHandler(self.test_file).dataset
+        dtype = [('index', '<i4'),
+                 ('temperature', '<f8'),
+                 ('station', 'S40')]
+        retrieved_data = list(zip(dataset['index'][:],
+                                  dataset['temperature'].array[:],
+                                  dataset['station'].array[:]))
+        np.testing.assert_array_equal(np.array(retrieved_data, dtype=dtype),
+                                      np.array(self.data, dtype=dtype))
+
+    def tearDown(self):
+        os.remove(self.test_file)
+
+
+class TestNetCDFHandlerServer(unittest.TestCase):
+
+    """Test that the handler creates the correct dataset from a URL."""
+    data = [(10, 15.2, 'Diamond_St'),
+            (11, 13.1, 'Blacktail_Loop'),
+            (12, 13.3, 'Platinum_St'),
+            (13, 12.1, 'Kodiak_Trail')]
+
+    def setUp(self):
+        """Create WSGI apps"""
+
+        # Create tempfile:
+        fileno, self.test_file = tempfile.mkstemp(suffix='.nc')
+        # must close file number:
+        os.close(fileno)
+        with Dataset(self.test_file, 'w') as output:
+            output.createDimension('index', None)
+            temp = output.createVariable('index', '<i4', ('index',))
+            split_data = zip(*self.data)
+            temp[:] = next(split_data)
+            temp = output.createVariable('temperature', '<f8', ('index',))
+            temp[:] = next(split_data)
+            temp = output.createVariable('station', 'S40', ('index',))
+            for item_id, item in enumerate(next(split_data)):
+                temp[item_id] = item
+
+        #def run_simple_server(test_file):
+        #    application = NetCDFHandler(test_file)
+        #    application = ServerSideFunctions(application)
+        #    run_simple('localhost', 8001, application,
+        #               use_reloader=True)
+        #self.server_process = multiprocessing.Process(target=run_simple_server,
+        #                                              args=(self.test_file,))
+        #self.server_process.start()
+        #time.sleep(1000)
+
+    def test_open(self):
+        """Test that NetCDFHandler can be read through open_url."""
+        handler = NetCDFHandler(self.test_file)
+        application = ServerSideFunctions(handler)
+        dataset = DAPHandler("http://localhost:8001/", application).dataset
+        dtype = [('index', '<i4'),
+                 ('temperature', '<f8'),
+                 ('station', 'S40')]
+        retrieved_data = list(zip(dataset['index'][:],
+                                  dataset['temperature'].array[:],
+                                  dataset['station'].array[:]))
+        np.testing.assert_array_equal(np.array(retrieved_data, dtype=dtype),
+                                      np.array(self.data, dtype=dtype))
+
+    def tearDown(self):
+        #self.server_process.terminate()
+        #self.server_process.join()
+        #del(self.server_process)
+        os.remove(self.test_file)

--- a/src/pydap/tests/test_handlers_netcdf.py
+++ b/src/pydap/tests/test_handlers_netcdf.py
@@ -3,16 +3,12 @@
 import sys
 from netCDF4 import Dataset
 import tempfile
-import multiprocessing
 import os
-import time
 import numpy as np
 
 from pydap.handlers.netcdf import NetCDFHandler
 from pydap.handlers.dap import DAPHandler
-from werkzeug.serving import run_simple
 from pydap.wsgi.ssf import ServerSideFunctions
-from pydap.client import open_url
 
 
 if sys.version_info < (2, 7):
@@ -89,16 +85,6 @@ class TestNetCDFHandlerServer(unittest.TestCase):
             for item_id, item in enumerate(next(split_data)):
                 temp[item_id] = item
 
-        #def run_simple_server(test_file):
-        #    application = NetCDFHandler(test_file)
-        #    application = ServerSideFunctions(application)
-        #    run_simple('localhost', 8001, application,
-        #               use_reloader=True)
-        #self.server_process = multiprocessing.Process(target=run_simple_server,
-        #                                              args=(self.test_file,))
-        #self.server_process.start()
-        #time.sleep(1000)
-
     def test_open(self):
         """Test that NetCDFHandler can be read through open_url."""
         handler = NetCDFHandler(self.test_file)
@@ -114,7 +100,4 @@ class TestNetCDFHandlerServer(unittest.TestCase):
                                       np.array(self.data, dtype=dtype))
 
     def tearDown(self):
-        #self.server_process.terminate()
-        #self.server_process.join()
-        #del(self.server_process)
         os.remove(self.test_file)

--- a/src/pydap/tests/test_handlers_netcdf.py
+++ b/src/pydap/tests/test_handlers_netcdf.py
@@ -5,16 +5,11 @@ from netCDF4 import Dataset
 import tempfile
 import os
 import numpy as np
+from six.moves import zip
 
 from pydap.handlers.netcdf import NetCDFHandler
 from pydap.handlers.dap import DAPHandler
 from pydap.wsgi.ssf import ServerSideFunctions
-
-# Python 2 and 3: option 2
-try:
-    import itertools.izip as zip
-except ImportError:
-    pass
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest

--- a/src/pydap/tests/test_handlers_netcdf.py
+++ b/src/pydap/tests/test_handlers_netcdf.py
@@ -10,6 +10,11 @@ from pydap.handlers.netcdf import NetCDFHandler
 from pydap.handlers.dap import DAPHandler
 from pydap.wsgi.ssf import ServerSideFunctions
 
+# Python 2 and 3: option 2
+try:
+    import itertools.izip as zip
+except ImportError:
+    pass
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest


### PR DESCRIPTION
This PR merges the previously disjoint netCDF handler into the main distribution.

As in #34 , the main goal here to provide a handler so that one could implement more advanced unit tests that would cover a more extensive array of use cases. One of my goal here is to provide a good testing environment to develop a ``netCDF4``-like client API for pydap as in [netcdf4_pydap](github/laliberte/netcdf4_pydap).

Unlike in #34, this PR introduces a major dependency, namely ``netCDF4``. However, I feel that since it is an optional pre-requisite it might not cause too much trouble.

I hope this can be useful to someone other myself.