### PR TITLE
A bug fix in fix_slices

### DIFF
--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -87,6 +87,7 @@ def fix_slice(slice_, shape):
                 j = n
             elif j < 0:
                 j += n
+            j = min(j, n)
 
             out.append(slice(i, j, k))
 

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -87,7 +87,7 @@ def fix_slice(slice_, shape):
                 j = n
             elif j < 0:
                 j += n
-            j = min(j, n)
+            j = min(j, n + 1)
 
             out.append(slice(i, j, k))
 

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -83,11 +83,11 @@ def fix_slice(slice_, shape):
                 i += n
 
             j = s.stop
-            if j is None:
+            if (j is None or
+                j > n):
                 j = n
             elif j < 0:
                 j += n
-            j = min(j, n + 1)
 
             out.append(slice(i, j, k))
 

--- a/src/pydap/tests/test_handlers_dap.py
+++ b/src/pydap/tests/test_handlers_dap.py
@@ -76,7 +76,7 @@ class TestDapHandler(unittest.TestCase):
         dataset = DAPHandler("http://localhost:8001/?x[1:1:2]", self.app1).dataset
 
         self.assertEqual(dataset.x.data.shape, (2,))
-        self.assertEqual(dataset.x.data.slice, (slice(1, 3, 1),))
+        self.assertEqual(dataset.x.data.slice, (slice(1, 2, 1),))
 
     def test_grid_array_with_projection(self):
         """Test that a grid array can be properly pre sliced."""

--- a/src/pydap/tests/test_handlers_dap.py
+++ b/src/pydap/tests/test_handlers_dap.py
@@ -164,6 +164,14 @@ class TestBaseProxy(unittest.TestCase):
         """Test the ``__getitem__`` method."""
         np.testing.assert_array_equal(self.data[:], np.arange(5))
 
+    def test_getitem_out_of_bound(self):
+        """
+        Test the ``__getitem__`` method with out of bounds
+        slices.
+        The same result as numpy is expected.
+        """
+        np.testing.assert_array_equal(self.data[:10], np.arange(5)[:10])
+
     def test_inexact_division(self):
         """Test data retrieval when step > 1 and division inexact."""
         np.testing.assert_array_equal(self.data[0:3:2], np.arange(5)[0:3:2])


### PR DESCRIPTION
This PR fixes a bug that arises when a ``pydap`` array is sliced and the ``slice.stop`` integer is larger than the dimension length.