### PR TITLE
Ensure that arrays of strings have the correct shape

### DIFF
--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -149,7 +149,7 @@ class BaseProxy(object):
         size = int(np.prod(shape))
 
         if self.dtype == np.byte:
-            return np.fromstring(data[:size], 'B')
+            return np.fromstring(data[:size], 'B').reshape(shape)
         elif self.dtype.char in 'SU':
             out = []
             for word in range(size):

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -157,7 +157,8 @@ class BaseProxy(object):
                 data = data[4:]
                 out.append(data[:n])
                 data = data[n + (-n % 4):]
-            return np.array([text_type(x.decode('ascii')) for x in out], 'S')
+            return np.array([text_type(x.decode('ascii'))
+                             for x in out], 'S').reshape(shape)
         else:
             try:
                 return np.fromstring(data, self.dtype).reshape(shape)

--- a/src/pydap/tests/test_handlers_dap.py
+++ b/src/pydap/tests/test_handlers_dap.py
@@ -414,3 +414,22 @@ class TestStringBaseType(unittest.TestCase):
         """Test the ``__getitem__`` method."""
         np.testing.assert_array_equal(self.data[:],
                                       np.array("This is a test", dtype='S'))
+
+
+class TestArrayStringBaseType(unittest.TestCase):
+
+    """Regression test for an array of unicode base type."""
+
+    def setUp(self):
+        """Create a WSGI app with array data"""
+        dataset = DatasetType("test")
+        self.original_data = np.array([["This ", "is "], ["a ", "test"]],
+                                      dtype='<U5')
+        dataset["s"] = BaseType("s", self.original_data)
+        self.app = BaseHandler(dataset)
+
+        self.data = DAPHandler("http://localhost:8001/",  self.app).dataset.s
+
+    def test_getitem(self):
+        """Test the ``__getitem__`` method."""
+        np.testing.assert_array_equal(self.data[:], self.original_data)


### PR DESCRIPTION
This fixes #41. @taehold was right that a ``reshape`` was missing.