### PR TITLE
Fix tests and prevent unintended behaviour in numpy DeprecationWarning

### DIFF
--- a/src/pydap/__init__.py
+++ b/src/pydap/__init__.py
@@ -1,2 +1,5 @@
-"""Declare the namespace ``pydap`` here."""
+'''
+Declare the namespace ``pydap`` here.
+'''
+
 __import__('pkg_resources').declare_namespace(__name__)

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -504,8 +504,8 @@ class SequenceType(StructureType):
             out = SequenceType(self.name, self.data, self.attributes.copy())
             for name in key:
                 out[name] = copy.copy(StructureType.__getitem__(self, name))
-            # copy.copy() is necessary here because a view will be returned in the
-            # future:
+            # copy.copy() is necessary here because a view will be returned in
+            # the future:
             out.data = copy.copy(self.data[list(key)])
             return out
 

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -504,7 +504,9 @@ class SequenceType(StructureType):
             out = SequenceType(self.name, self.data, self.attributes.copy())
             for name in key:
                 out[name] = copy.copy(StructureType.__getitem__(self, name))
-            out.data = self.data[list(key)]
+            # copy.copy() is necessary here because a view will be returned in the
+            # future:
+            out.data = copy.copy(self.data[list(key)])
             return out
 
         # Else return a new `SequenceType` with the data sliced.

--- a/src/pydap/tests/test_pydap.py
+++ b/src/pydap/tests/test_pydap.py
@@ -11,5 +11,3 @@ class TestNamespace(unittest.TestCase):
     def test_namespace(self):
         """Test the namespace."""
         self.assertEqual(pydap.__name__, "pydap")
-        self.assertEqual(
-            pydap.__doc__, "Declare the namespace ``pydap`` here.")


### PR DESCRIPTION
This PR makes two minor fixes that are necessary to ensure tests are working:

1. Makes a copy of ``data`` when a structure is sliced with multiple names. This prevents the FutureDeprecationWarning from affecting ``pydap``.

2. Removes test for ``__doc__``. After extensive testing, it seems that python 3.5 always returns ``None``. For this reason and because it prevents a successful build I think it should be removed. It would also fix #45 