### PR TITLE
Convert all imports to explicit relative imports

### DIFF
--- a/src/pydap/__init__.py
+++ b/src/pydap/__init__.py
@@ -1,2 +1,5 @@
-"""Declare the namespace ``pydap`` here."""
+'''
+Declare the namespace ``pydap`` here.
+'''
+
 __import__('pkg_resources').declare_namespace(__name__)

--- a/src/pydap/cas/get_cookies.py
+++ b/src/pydap/cas/get_cookies.py
@@ -24,7 +24,7 @@ def setup_session(uri,
     '''
 
     if session is None:
-        headers = [('User-agent', pydap.lib.__version__)]
+        headers = [('User-agent', lib.__version__)]
         session = requests.Session()
         session.headers.update(headers)
 

--- a/src/pydap/cas/get_cookies.py
+++ b/src/pydap/cas/get_cookies.py
@@ -4,7 +4,7 @@ import requests
 from requests.packages.urllib3.exceptions import (InsecureRequestWarning,
                                                   InsecurePlatformWarning)
 import copy
-import pydap.lib
+from .. import lib
 
 ssl_verify_categories = [InsecureRequestWarning,
                          InsecurePlatformWarning]

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -46,12 +46,12 @@ lazy mechanism for function call, supporting any function. Eg, to call the
 from io import open, BytesIO
 from six.moves.urllib.parse import urlsplit, urlunsplit
 
-from pydap.model import DapType
-from pydap.lib import encode
-from pydap.net import GET
-from pydap.handlers.dap import DAPHandler, unpack_data, StreamReader
-from pydap.parsers.dds import build_dataset
-from pydap.parsers.das import parse_das, add_attributes
+from .model import DapType
+from .lib import encode
+from .net import GET
+from .handlers.dap import DAPHandler, unpack_data, StreamReader
+from .parsers.dds import build_dataset
+from .parsers.das import parse_das, add_attributes
 
 
 def open_url(url, application=None, session=None, output_grid=True):

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -23,14 +23,14 @@ from six import text_type, string_types, next
 from pydap.model import (BaseType,
                          SequenceType, StructureType,
                          GridType)
-from pydap.net import GET, raise_for_status
-from pydap.lib import (
+from ..net import GET, raise_for_status
+from ..lib import (
     encode, combine_slices, fix_slice, hyperslab,
     START_OF_SEQUENCE, walk)
-from pydap.handlers.lib import ConstraintExpression, BaseHandler, IterData
-from pydap.parsers.dds import build_dataset
-from pydap.parsers.das import parse_das, add_attributes
-from pydap.parsers import parse_ce
+from .lib import ConstraintExpression, BaseHandler, IterData
+from ..parsers.dds import build_dataset
+from ..parsers.das import parse_das, add_attributes
+from ..parsers import parse_ce
 logger = logging.getLogger('pydap')
 logger.addHandler(logging.NullHandler())
 

--- a/src/pydap/handlers/lib.py
+++ b/src/pydap/handlers/lib.py
@@ -51,14 +51,14 @@ def load_handlers(working_set=pkg_resources.working_set):
 
     """
     # Relative import of handlers:
-    subpackage = 'pydap.handlers'
+    package = 'pydap'
     entry_points = 'pydap.handler'
-    base_dict = dict(load_from_entry_point_relative(r, subpackage)
+    base_dict = dict(load_from_entry_point_relative(r, package)
                      for r in working_set.iter_entry_points(entry_points)
-                     if r.module_name.startswith(subpackage))
+                     if r.module_name.startswith(package))
     opts_dict = dict((r.name, r.load())
                      for r in working_set.iter_entry_points(entry_points)
-                     if not r.module_name.startswith(subpackage))
+                     if not r.module_name.startswith(package))
     base_dict.update(opts_dict)
     return base_dict.values()
 

--- a/src/pydap/handlers/lib.py
+++ b/src/pydap/handlers/lib.py
@@ -22,15 +22,15 @@ from numpy.lib.arrayterator import Arrayterator
 from six.moves import filter, map
 from six import string_types, next
 
-from pydap.responses.lib import load_responses
-from pydap.responses.error import ErrorResponse
-from pydap.parsers import parse_ce, parse_selection
-from pydap.exceptions import (
+from ..responses.lib import load_responses
+from ..responses.error import ErrorResponse
+from ..parsers import parse_ce, parse_selection
+from ..exceptions import (
     ConstraintExpressionError, ExtensionNotSupportedError)
-from pydap.lib import walk, fix_shorthand, get_var, encode
-from pydap.model import (DatasetType, BaseType,
-                         SequenceType, StructureType,
-                         GridType)
+from ..lib import walk, fix_shorthand, get_var, encode
+from ..model import (DatasetType, BaseType,
+                     SequenceType, StructureType,
+                     GridType)
 
 
 # buffer size in bytes, for streaming data

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -6,7 +6,7 @@ from six.moves.urllib.parse import quote as quote_
 from six.moves import reduce, zip_longest
 from six import binary_type, MAXSIZE
 
-from pydap.exceptions import ConstraintExpressionError
+from .exceptions import ConstraintExpressionError
 
 
 __dap__ = '2.15'

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -189,10 +189,10 @@ def decode_np_strings(numpy_var):
         return numpy_var
 
 
-def load_from_entry_point_relative(r, subpackage):
+def load_from_entry_point_relative(r, package):
     try:
         loaded = getattr(__import__(r.module_name
-                                    .replace(subpackage + '.', '', 1),
+                                    .replace(package + '.', '', 1),
                                     globals(), None, [r.attrs[0]], 1),
                          r.attrs[0])
         return r.name, loaded

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -199,4 +199,3 @@ def load_from_entry_point_relative(r, subpackage):
     except ImportError:
         # This is only used in handlers testing:
         return r.name, r.load()
-        

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -187,3 +187,16 @@ def decode_np_strings(numpy_var):
         return numpy_var.tostring().decode('utf-8')
     else:
         return numpy_var
+
+
+def load_from_entry_point_relative(r, subpackage):
+    try:
+        loaded = getattr(__import__(r.module_name
+                                    .replace(subpackage + '.', '', 1),
+                                    globals(), None, [r.attrs[0]], 1),
+                         r.attrs[0])
+        return r.name, loaded
+    except ImportError:
+        # This is only used in handlers testing:
+        return r.name, r.load()
+        

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -118,8 +118,9 @@ import copy
 from six.moves import reduce, map
 from six import string_types, binary_type
 import numpy as np
-from pydap.lib import quote, decode_np_strings
 from collections import OrderedDict
+
+from .lib import quote, decode_np_strings
 
 
 __all__ = [

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -504,8 +504,8 @@ class SequenceType(StructureType):
             out = SequenceType(self.name, self.data, self.attributes.copy())
             for name in key:
                 out[name] = copy.copy(StructureType.__getitem__(self, name))
-            # copy.copy() is necessary here because a view will be returned in the
-            # future:
+            # copy.copy() is necessary here because a view will be returned in
+            # the future:
             out.data = copy.copy(self.data[list(key)])
             return out
 

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -504,7 +504,9 @@ class SequenceType(StructureType):
             out = SequenceType(self.name, self.data, self.attributes.copy())
             for name in key:
                 out[name] = copy.copy(StructureType.__getitem__(self, name))
-            out.data = self.data[list(key)]
+            # copy.copy() is necessary here because a view will be returned in the
+            # future:
+            out.data = copy.copy(self.data[list(key)])
             return out
 
         # Else return a new `SequenceType` with the data sliced.

--- a/src/pydap/parsers/__init__.py
+++ b/src/pydap/parsers/__init__.py
@@ -12,8 +12,8 @@ import ast
 from six.moves.urllib.parse import unquote
 from six.moves import map
 
-from pydap.exceptions import ConstraintExpressionError
-from pydap.lib import get_var
+from ..exceptions import ConstraintExpressionError
+from ..lib import get_var
 
 
 def parse_projection(input):

--- a/src/pydap/parsers/das.py
+++ b/src/pydap/parsers/das.py
@@ -12,8 +12,8 @@ import operator
 
 from six.moves import reduce
 
-from pydap.parsers import SimpleParser
-from pydap.lib import walk
+from . import SimpleParser
+from ..lib import walk
 
 
 atomic = ('byte', 'int', 'uint', 'int16', 'uint16', 'int32', 'uint32',

--- a/src/pydap/parsers/dds.py
+++ b/src/pydap/parsers/dds.py
@@ -4,11 +4,11 @@ import re
 
 import numpy as np
 
-from pydap.parsers import SimpleParser
-from pydap.model import (DatasetType, BaseType,
-                         SequenceType, StructureType,
-                         GridType)
-from pydap.lib import quote, STRING
+from . import SimpleParser
+from ..model import (DatasetType, BaseType,
+                     SequenceType, StructureType,
+                     GridType)
+from ..lib import quote, STRING
 
 
 typemap = {

--- a/src/pydap/responses/ascii.py
+++ b/src/pydap/responses/ascii.py
@@ -14,11 +14,11 @@ import copy
 import numpy as np
 from six.moves import zip
 
-from pydap.model import (BaseType,
-                         SequenceType, StructureType)
-from pydap.lib import encode, __version__
-from pydap.responses.lib import BaseResponse
-from pydap.responses.dds import dds
+from ..model import (BaseType,
+                     SequenceType, StructureType)
+from ..lib import encode, __version__
+from .lib import BaseResponse
+from .dds import dds
 
 
 class ASCIIResponse(BaseResponse):

--- a/src/pydap/responses/das.py
+++ b/src/pydap/responses/das.py
@@ -16,12 +16,12 @@ from collections import Iterable
 from six import string_types, integer_types
 from six.moves import map
 
-from pydap.model import (DatasetType, BaseType,
-                         StructureType,
-                         GridType)
-from pydap.lib import encode, quote, __version__
-from pydap.responses.lib import BaseResponse
-from pydap.responses.dds import typemap
+from ..model import (DatasetType, BaseType,
+                     StructureType,
+                     GridType)
+from ..lib import encode, quote, __version__
+from .lib import BaseResponse
+from .dds import typemap
 
 
 INDENT = ' ' * 4

--- a/src/pydap/responses/dds.py
+++ b/src/pydap/responses/dds.py
@@ -15,11 +15,11 @@ except ImportError:
 
 from six.moves import map, zip
 
-from pydap.model import (DatasetType, BaseType,
-                         SequenceType, StructureType,
-                         GridType)
-from pydap.responses.lib import BaseResponse
-from pydap.lib import __version__
+from ..model import (DatasetType, BaseType,
+                     SequenceType, StructureType,
+                     GridType)
+from .lib import BaseResponse
+from ..lib import __version__
 
 
 INDENT = ' ' * 4

--- a/src/pydap/responses/dods.py
+++ b/src/pydap/responses/dods.py
@@ -14,11 +14,11 @@ import copy
 import numpy as np
 from six import string_types
 
-from pydap.model import (BaseType,
+from ..model import (BaseType,
                          SequenceType, StructureType)
-from pydap.lib import walk, START_OF_SEQUENCE, END_OF_SEQUENCE, __version__
-from pydap.responses.lib import BaseResponse
-from pydap.responses.dds import dds
+from ..lib import walk, START_OF_SEQUENCE, END_OF_SEQUENCE, __version__
+from .lib import BaseResponse
+from .dds import dds
 
 try:
     from functools import singledispatch

--- a/src/pydap/responses/dods.py
+++ b/src/pydap/responses/dods.py
@@ -15,7 +15,7 @@ import numpy as np
 from six import string_types
 
 from ..model import (BaseType,
-                         SequenceType, StructureType)
+                     SequenceType, StructureType)
 from ..lib import walk, START_OF_SEQUENCE, END_OF_SEQUENCE, __version__
 from .lib import BaseResponse
 from .dds import dds

--- a/src/pydap/responses/error.py
+++ b/src/pydap/responses/error.py
@@ -10,7 +10,7 @@ from traceback import print_exception
 from webob import Response
 from six import StringIO, text_type
 
-from pydap.lib import encode, __version__
+from ..lib import encode, __version__
 
 
 class ErrorResponse(object):

--- a/src/pydap/responses/html/__init__.py
+++ b/src/pydap/responses/html/__init__.py
@@ -11,8 +11,8 @@ from webob.dec import wsgify
 from webob.exc import HTTPSeeOther
 from six.moves.urllib.parse import unquote
 
-from pydap.responses.lib import BaseResponse
-from pydap.lib import __version__
+from ..lib import BaseResponse
+from ...lib import __version__
 
 
 class HTMLResponse(BaseResponse):

--- a/src/pydap/responses/lib.py
+++ b/src/pydap/responses/lib.py
@@ -13,13 +13,22 @@ KML, WMS, JSON, etc., installed as third-party Python packages that declare the
 from pkg_resources import iter_entry_points
 
 from ..model import DatasetType
-from ..lib import __version__
+from ..lib import __version__, load_from_entry_point_relative
 
 
 def load_responses():
     """Load all available responses from the system, returning a dictionary."""
-    return dict(
-        (r.name, r.load()) for r in iter_entry_points('pydap.response'))
+    # Relative import of responses:
+    subpackage = 'pydap.responses'
+    entry_points = 'pydap.response'
+    base_dict = dict(load_from_entry_point_relative(r, subpackage)
+                     for r in iter_entry_points(entry_points)
+                     if r.module_name.startswith(subpackage))
+    opts_dict = dict((r.name, r.load())
+                     for r in iter_entry_points(entry_points)
+                     if not r.module_name.startswith(subpackage))
+    base_dict.update(opts_dict)
+    return base_dict
 
 
 class BaseResponse(object):

--- a/src/pydap/responses/lib.py
+++ b/src/pydap/responses/lib.py
@@ -12,8 +12,8 @@ KML, WMS, JSON, etc., installed as third-party Python packages that declare the
 
 from pkg_resources import iter_entry_points
 
-from pydap.model import DatasetType
-from pydap.lib import __version__
+from ..model import DatasetType
+from ..lib import __version__
 
 
 def load_responses():

--- a/src/pydap/responses/lib.py
+++ b/src/pydap/responses/lib.py
@@ -19,14 +19,14 @@ from ..lib import __version__, load_from_entry_point_relative
 def load_responses():
     """Load all available responses from the system, returning a dictionary."""
     # Relative import of responses:
-    subpackage = 'pydap.responses'
+    package = 'pydap'
     entry_points = 'pydap.response'
-    base_dict = dict(load_from_entry_point_relative(r, subpackage)
+    base_dict = dict(load_from_entry_point_relative(r, package)
                      for r in iter_entry_points(entry_points)
-                     if r.module_name.startswith(subpackage))
+                     if r.module_name.startswith(package))
     opts_dict = dict((r.name, r.load())
                      for r in iter_entry_points(entry_points)
-                     if not r.module_name.startswith(subpackage))
+                     if not r.module_name.startswith(package))
     base_dict.update(opts_dict)
     return base_dict
 

--- a/src/pydap/responses/version.py
+++ b/src/pydap/responses/version.py
@@ -7,7 +7,7 @@ from webob import Response
 from json import dumps
 from pkg_resources import iter_entry_points
 
-from pydap.lib import __version__, __dap__
+from ..lib import __version__, __dap__
 
 
 class VersionResponse(object):

--- a/src/pydap/tests/test_handlers_lib.py
+++ b/src/pydap/tests/test_handlers_lib.py
@@ -518,6 +518,9 @@ class MockEntryPoint(object):
 
     def __init__(self, handler):
         self.handler = handler
+        self.name = 'test'
+        self.module_name = 'pydap.handlers.test'
+        self.attrs = ('TestHandler', )
 
     def load(self):
         """Return the wrapped handler."""

--- a/src/pydap/tests/test_pydap.py
+++ b/src/pydap/tests/test_pydap.py
@@ -11,5 +11,3 @@ class TestNamespace(unittest.TestCase):
     def test_namespace(self):
         """Test the namespace."""
         self.assertEqual(pydap.__name__, "pydap")
-        self.assertEqual(
-            pydap.__doc__, "Declare the namespace ``pydap`` here.")

--- a/src/pydap/wsgi/app.py
+++ b/src/pydap/wsgi/app.py
@@ -30,10 +30,10 @@ import pkg_resources
 from six.moves.urllib.parse import unquote
 from six import string_types
 
-from pydap.lib import __version__
-from pydap.handlers.lib import get_handler, load_handlers
-from pydap.exceptions import ExtensionNotSupportedError
-from pydap.wsgi.ssf import ServerSideFunctions
+from ..lib import __version__
+from ..handlers.lib import get_handler, load_handlers
+from ..exceptions import ExtensionNotSupportedError
+from .ssf import ServerSideFunctions
 
 
 class DapServer(object):

--- a/src/pydap/wsgi/functions.py
+++ b/src/pydap/wsgi/functions.py
@@ -27,9 +27,9 @@ import numpy as np
 import coards
 import gsw
 
-from pydap.model import SequenceType, GridType, BaseType
-from pydap.lib import walk
-from pydap.exceptions import ConstraintExpressionError, ServerError
+from ..model import SequenceType, GridType, BaseType
+from ..lib import walk
+from ..exceptions import ConstraintExpressionError, ServerError
 
 
 def density(dataset, salinity, temperature, pressure):

--- a/src/pydap/wsgi/ssf.py
+++ b/src/pydap/wsgi/ssf.py
@@ -30,14 +30,14 @@ RELOP = re.compile(r'(<=|<|>=|>|=~|=|!=)')
 def load_functions():
     """Load all available functions from the system, returning a dictionary."""
     # Relative import of functions:
-    subpackage = 'pydap.wsgi'
+    package = 'pydap'
     entry_points = 'pydap.function'
-    base_dict = dict(load_from_entry_point_relative(r, subpackage)
+    base_dict = dict(load_from_entry_point_relative(r, package)
                      for r in iter_entry_points(entry_points)
-                     if r.module_name.startswith(subpackage))
+                     if r.module_name.startswith(package))
     opts_dict = dict((r.name, r.load())
                      for r in iter_entry_points(entry_points)
-                     if not r.module_name.startswith(subpackage))
+                     if not r.module_name.startswith(package))
     base_dict.update(opts_dict)
     return base_dict
 

--- a/src/pydap/wsgi/ssf.py
+++ b/src/pydap/wsgi/ssf.py
@@ -18,13 +18,28 @@ from six import string_types
 
 from ..model import DatasetType, SequenceType
 from ..parsers import parse_ce
-from ..lib import walk, fix_shorthand
+from ..lib import walk, fix_shorthand, load_from_entry_point_relative
 from ..handlers.lib import BaseHandler, apply_projection
 from ..exceptions import ServerError
 
 
 FUNCTION = re.compile(r'([^(]*)\((.*)\)')
 RELOP = re.compile(r'(<=|<|>=|>|=~|=|!=)')
+
+
+def load_functions():
+    """Load all available functions from the system, returning a dictionary."""
+    # Relative import of functions:
+    subpackage = 'pydap.wsgi'
+    entry_points = 'pydap.function'
+    base_dict = dict(load_from_entry_point_relative(r, subpackage)
+                     for r in iter_entry_points(entry_points)
+                     if r.module_name.startswith(subpackage))
+    opts_dict = dict((r.name, r.load())
+                     for r in iter_entry_points(entry_points)
+                     if not r.module_name.startswith(subpackage))
+    base_dict.update(opts_dict)
+    return base_dict
 
 
 class ServerSideFunctions(object):
@@ -40,9 +55,7 @@ class ServerSideFunctions(object):
     def __init__(self, app, **kwargs):
         self.app = app
 
-        self.functions = {}
-        for r in iter_entry_points("pydap.function"):
-            self.functions[r.name] = r.load()
+        self.functions = load_functions()
         self.functions.update(kwargs)
 
     def __call__(self, environ, start_response):

--- a/src/pydap/wsgi/ssf.py
+++ b/src/pydap/wsgi/ssf.py
@@ -16,11 +16,11 @@ import numpy as np
 from six.moves import reduce, map
 from six import string_types
 
-from pydap.model import DatasetType, SequenceType
-from pydap.parsers import parse_ce
-from pydap.lib import walk, fix_shorthand
-from pydap.handlers.lib import BaseHandler, apply_projection
-from pydap.exceptions import ServerError
+from ..model import DatasetType, SequenceType
+from ..parsers import parse_ce
+from ..lib import walk, fix_shorthand
+from ..handlers.lib import BaseHandler, apply_projection
+from ..exceptions import ServerError
 
 
 FUNCTION = re.compile(r'([^(]*)\((.*)\)')


### PR DESCRIPTION
This PR builds upon #55 to ensure that tests are successful.

This PR converts all imports to explicit relative imports. This makes it possible to include a fork of ``pydap`` as a submodule in another project. It is also much more robust as it prevents potential namespace collisions. Apart for the internal machinery, this PR should not change anything to the current ``pydap`` compatibility and capabilities.