### PR TITLE
Do not require gunicorn for a vanilla install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,16 @@
 language: python
+
+sudo: false
+
 python:
     - 2.7
     - 3.3
     - 3.4
     - 3.5
-addons:
-  apt:
-    packages:
-      - gfortran
-      - libblas-dev
-      - liblapack-dev
-      - cython
+    - 3.6
+
 install:
-    - travis_wait 30 pip install scipy
+    - pip install scipy
     - pip install -e .[testing,functions,tests]
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
 language: python
-
-sudo: false
-
 python:
     - 2.7
     - 3.3
     - 3.4
     - 3.5
-    - 3.6
-
+addons:
+  apt:
+    packages:
+      - gfortran
+      - libblas-dev
+      - liblapack-dev
+      - cython
 install:
-    - pip install scipy
+    - travis_wait 30 pip install scipy
     - pip install -e .[testing,functions,server,tests]
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: python
+
 python:
     - 2.7
     - 3.3
     - 3.4
     - 3.5
+    - 3.6
+
 addons:
   apt:
     packages:
@@ -11,6 +14,7 @@ addons:
       - libblas-dev
       - liblapack-dev
       - cython
+
 install:
     - travis_wait 30 pip install scipy
     - pip install -e .[testing,functions,server,tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 
 install:
     - pip install scipy
-    - pip install -e .[testing,functions,tests]
+    - pip install -e .[testing,functions,server,tests]
 
 script:
     - python setup.py nosetests -a '!auth'

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ cas_extras = [
     'requests'
     ]
 
-tests_require = functions_extras + cas_extras + server_extras +[
+tests_require = functions_extras + cas_extras + server_extras + [
     'WebTest',
     'beautifulsoup4',
     'scipy',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ install_requires = [
     'Webob',
     'Jinja2',
     'docopt',
-    'gunicorn',
     'six >= 1.4.0',
     'mechanicalsoup',
 ]
@@ -18,6 +17,10 @@ functions_extras = [
     'gsw',
     'coards',
     'scipy',
+]
+
+server_extras = [
+    'gunicorn',
 ]
 
 docs_extras = [
@@ -30,7 +33,7 @@ cas_extras = [
     'requests'
     ]
 
-tests_require = functions_extras + cas_extras + [
+tests_require = functions_extras + cas_extras + server_extras +[
     'WebTest',
     'beautifulsoup4',
     'scipy',
@@ -75,7 +78,8 @@ setup(name='Pydap',
             'testing': testing_extras,
             'docs': docs_extras,
             'tests': tests_require,
-            'cas': cas_extras
+            'cas': cas_extras,
+            'server': server_extras
       },
       test_suite="pydap.tests",
       entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ setup(name='Pydap',
             "Programming Language :: Python :: 2.7",
             "Programming Language :: Python :: 3.3",
             "Programming Language :: Python :: 3.4",
-            "Programming Language :: Python :: 3.5"
+            "Programming Language :: Python :: 3.5",
+            "Programming Language :: Python :: 3.6"
             # Get strings from
             # http://pypi.python.org/pypi?%3Aaction=list_classifiers
             ],


### PR DESCRIPTION
@rsignell-usgs reported issues on Widnows when trying to use `pydap`.
See https://gist.github.com/rsignell-usgs/7c9cf9f88a2f0c920c1a4ee7d7eaf601

This PR crates a `server_extras` entry to allow `pydap` to be installed, and usable without, `gunicorn` present.