### PR TITLE
Default charset to 'utf8'

### DIFF
--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -49,11 +49,15 @@ class DAPHandler(BaseHandler):
         ddsurl = urlunsplit((scheme, netloc, path + '.dds', query, fragment))
         r = GET(ddsurl, application, session)
         raise_for_status(r)
+        if not r.charset:
+            r.charset = 'utf8'
         dds = r.text
 
         dasurl = urlunsplit((scheme, netloc, path + '.das', query, fragment))
         r = GET(dasurl, application, session)
         raise_for_status(r)
+        if not r.charset:
+            r.charset = 'utf8'
         das = r.text
 
         # build the dataset from the DDS and add attributes from the DAS

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -50,14 +50,14 @@ class DAPHandler(BaseHandler):
         r = GET(ddsurl, application, session)
         raise_for_status(r)
         if not r.charset:
-            r.charset = 'utf8'
+            r.charset = 'ascii'
         dds = r.text
 
         dasurl = urlunsplit((scheme, netloc, path + '.das', query, fragment))
         r = GET(dasurl, application, session)
         raise_for_status(r)
         if not r.charset:
-            r.charset = 'utf8'
+            r.charset = 'ascii'
         das = r.text
 
         # build the dataset from the DDS and add attributes from the DAS


### PR DESCRIPTION
URLs like the one below,

```python
from pydap.client import open_url

url = 'http://geoport-dev.whoi.edu/thredds/dodsC/estofs/atlantic'
ds = open_url(url)
```

do not have a charset and will fail. It seems that it is safe to set a default to `utf-8`.