### PR TITLE
Require singledispatch for Python 3.4 or earlier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,15 @@ __version__ = '3.2.0'
 
 install_requires = [
     'numpy',
-    'singledispatch',
     'Webob',
     'Jinja2',
     'docopt',
     'six >= 1.4.0',
     'mechanicalsoup',
 ]
+
+if sys.version_info < (3, 5):
+    install_requires.append('singledispatch')
 
 functions_extras = [
     'gsw',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-
+import sys
 
 __version__ = '3.2.0'
 


### PR DESCRIPTION
It is provided by `functools` for Python 3.5 onwards. Successfully validated on Debian Stretch (Python 3.5.3).