### PR TITLE
Remove scipy from testing requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ cas_extras = [
 tests_require = functions_extras + cas_extras + server_extras + [
     'WebTest',
     'beautifulsoup4',
-    'scipy',
     'flake8'
 ]
 


### PR DESCRIPTION
`scipy` is only needed transitively by `gsw` (upstream made this dependency [optional](https://github.com/TEOS-10/python-gsw/commit/2fb1ab7518e2797e690c895a8d501e60f368b64d) since the last release).