### PR TITLE
Parse dods response to handle ERDDAP servers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ tests_require = functions_extras + cas_extras + server_extras + [
 
 testing_extras = tests_require + [
     'nose',
+    'mock',
     'coverage',
     'requests'
 ]

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -28,7 +28,7 @@ from ..lib import (
     encode, combine_slices, fix_slice, hyperslab,
     START_OF_SEQUENCE, walk)
 from .lib import ConstraintExpression, BaseHandler, IterData
-from ..parsers.dds import build_dataset
+from ..parsers.dds import build_dataset, convert_data_to_array
 from ..parsers.das import parse_das, add_attributes
 from ..parsers import parse_ce
 logger = logging.getLogger('pydap')
@@ -139,43 +139,9 @@ class BaseProxy(object):
         dds, data = r.body.split(b'\nData:\n', 1)
         dds = dds.decode(r.content_encoding or 'ascii')
 
-        if self.shape:
-            # skip size packing
-            if self.dtype.char in 'SU':
-                data = data[4:]
-            else:
-                data = data[8:]
-
-        # calculate array size
-        shape = tuple(
-            int(np.ceil((s.stop-s.start)/float(s.step))) for s in index)
-        size = int(np.prod(shape))
-
-        if self.dtype == np.byte:
-            return np.fromstring(data[:size], 'B').reshape(shape)
-        elif self.dtype.char in 'SU':
-            out = []
-            for word in range(size):
-                n = np.asscalar(np.fromstring(data[:4], '>I'))  # read length
-                data = data[4:]
-                out.append(data[:n])
-                data = data[n + (-n % 4):]
-            return np.array([text_type(x.decode('ascii'))
-                             for x in out], 'S').reshape(shape)
-        else:
-            try:
-                return np.fromstring(data, self.dtype).reshape(shape)
-            except ValueError as e:
-                if str(e) == 'total size of new array must be unchanged':
-                    # server-side failure.
-                    # it is expected that the user should be mindful of this:
-                    raise RuntimeError(
-                                ('variable {0} could not be properly '
-                                 'retrieved. To avoid this '
-                                 'error consider using open_url(..., '
-                                 'output_grid=False).').format(quote(self.id)))
-                else:
-                    raise
+        # Parse received dataset:
+        dataset = build_dataset(dds, data=data)
+        return dataset[self.id].data
 
     def __len__(self):
         return self.shape[0]

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -28,7 +28,7 @@ from ..lib import (
     encode, combine_slices, fix_slice, hyperslab,
     START_OF_SEQUENCE, walk)
 from .lib import ConstraintExpression, BaseHandler, IterData
-from ..parsers.dds import build_dataset, convert_data_to_array
+from ..parsers.dds import build_dataset
 from ..parsers.das import parse_das, add_attributes
 from ..parsers import parse_ce
 logger = logging.getLogger('pydap')

--- a/src/pydap/handlers/lib.py
+++ b/src/pydap/handlers/lib.py
@@ -196,12 +196,18 @@ def apply_selection(selection, dataset):
     return dataset
 
 
+def degenerate_grid_to_structure(candidate):
+    if isinstance(candidate, GridType):
+        candidate = StructureType(
+            candidate.name, candidate.attributes)
+    return candidate
+
+
 def apply_projection(projection, dataset):
     """Apply a given projection to a dataset.
 
     This function builds and returns a new dataset by adding those variables
     that were requested on the projection.
-
     """
     out = DatasetType(name=dataset.name, attributes=dataset.attributes)
 
@@ -218,9 +224,7 @@ def apply_projection(projection, dataset):
                         # if there are more children to add we need to clear
                         # the candidate so it has only explicitly added
                         # children; also, Grids are degenerated into Structures
-                        if isinstance(candidate, GridType):
-                            candidate = StructureType(
-                                candidate.name, candidate.attributes)
+                        candidate = degenerate_grid_to_structure(candidate)
                         candidate._keys = []
                     target[name] = candidate
                 target, template = target[name], template[name]

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -322,8 +322,17 @@ class StructureType(DapType):
         item.id = '%s.%s' % (self.id, item.name)
 
     def __getitem__(self, key):
-        key = quote(key)
-        return self._dict[key]
+        try:
+            return self._dict[quote(key)]
+        except KeyError:
+            splitted = key.split('.')
+            if len(splitted) > 1:
+                try:
+                    return self.__getitem__(splitted[0])['.'.join(splitted[1:])]
+                except KeyError:
+                    return self.__getitem__('.'.join(splitted[1:]))
+            else:
+                raise
 
     def __delitem__(self, key):
         self._dict.__delitem__(key)

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -328,7 +328,8 @@ class StructureType(DapType):
             splitted = key.split('.')
             if len(splitted) > 1:
                 try:
-                    return self.__getitem__(splitted[0])['.'.join(splitted[1:])]
+                    return (self
+                            .__getitem__(splitted[0])['.'.join(splitted[1:])])
                 except KeyError:
                     return self.__getitem__('.'.join(splitted[1:]))
             else:

--- a/src/pydap/parsers/dds.py
+++ b/src/pydap/parsers/dds.py
@@ -3,13 +3,13 @@
 import re
 
 import numpy as np
+from six import text_type
 
 from . import SimpleParser
 from ..model import (DatasetType, BaseType,
                      SequenceType, StructureType,
                      GridType)
 from ..lib import quote, STRING
-
 
 typemap = {
     'byte':    np.dtype("B"),
@@ -32,9 +32,10 @@ class DDSParser(SimpleParser):
 
     """A parser for the DDS."""
 
-    def __init__(self, dds):
+    def __init__(self, dds, data=None):
         super(DDSParser, self).__init__(dds, re.IGNORECASE)
         self.dds = dds
+        self.data = data
 
     def consume(self, regexp):
         """Consume and return a token."""
@@ -81,6 +82,8 @@ class DDSParser(SimpleParser):
         self.consume(';')
 
         data = DummyData(dtype, shape)
+        if self.data is not None:
+            data, self.data = convert_data_to_array(self.data, shape, dtype, name)
         var = BaseType(name, data, dimensions=dimensions)
 
         return var
@@ -156,12 +159,53 @@ class DDSParser(SimpleParser):
         return grid
 
 
-def build_dataset(dds):
+def build_dataset(dds, data=None):
     """Return a dataset object from a DDS representation."""
-    return DDSParser(dds).parse()
+    return DDSParser(dds, data=data).parse()
 
 
 class DummyData(object):
     def __init__(self, dtype, shape):
         self.dtype = dtype
         self.shape = shape
+
+
+def convert_data_to_array(data, shape, dtype, id):
+    if len(shape) > 0:
+        if dtype.char in 'SU':
+            data = data[4:]
+        else:
+            data = data[8:]
+
+    # calculate array size
+    size = 1
+    if len(shape) > 0:
+        size = int(np.prod(shape))
+
+    nitems = dtype.itemsize * size
+
+    if dtype == np.byte:
+        return np.fromstring(data[:nitems], 'B').reshape(shape), data[nitems:]
+    elif dtype.char in 'SU':
+        out = []
+        for word in range(size):
+            n = np.asscalar(np.fromstring(data[:4], '>I'))  # read itemsize
+            data = data[4:]
+            out.append(data[:n])
+            data = data[n + (-n % 4):]
+        return np.array([text_type(x.decode('ascii'))
+                         for x in out], 'S').reshape(shape), data
+    else:
+        try:
+            return np.fromstring(data[:nitems], dtype).reshape(shape), data[nitems:]
+        except ValueError as e:
+            if str(e) == 'total size of new array must be unchanged':
+                # server-side failure.
+                # it is expected that the user should be mindful of this:
+                raise RuntimeError(
+                            ('variable {0} could not be properly '
+                             'retrieved. To avoid this '
+                             'error consider using open_url(..., '
+                             'output_grid=False).').format(quote(id)))
+            else:
+                raise

--- a/src/pydap/parsers/dds.py
+++ b/src/pydap/parsers/dds.py
@@ -83,7 +83,8 @@ class DDSParser(SimpleParser):
 
         data = DummyData(dtype, shape)
         if self.data is not None:
-            data, self.data = convert_data_to_array(self.data, shape, dtype, name)
+            data, self.data = convert_data_to_array(self.data, shape,
+                                                    dtype, name)
         var = BaseType(name, data, dimensions=dimensions)
 
         return var
@@ -197,7 +198,8 @@ def convert_data_to_array(data, shape, dtype, id):
                          for x in out], 'S').reshape(shape), data
     else:
         try:
-            return np.fromstring(data[:nitems], dtype).reshape(shape), data[nitems:]
+            return (np.fromstring(data[:nitems], dtype).reshape(shape),
+                    data[nitems:])
         except ValueError as e:
             if str(e) == 'total size of new array must be unchanged':
                 # server-side failure.

--- a/src/pydap/tests/test_handlers_dap.py
+++ b/src/pydap/tests/test_handlers_dap.py
@@ -51,8 +51,9 @@ class TestDapHandler(unittest.TestCase):
         self.assertEqual(
             dataset.SimpleGrid.SimpleGrid.data.slice,
             (slice(None), slice(None)))
-        self.assertEqual(repr(dataset.SimpleGrid[:]),
-                         "<GridType with array 'SimpleGrid' and maps 'x', 'y'>")
+        self.assertEqual(
+                repr(dataset.SimpleGrid[:]),
+                "<GridType with array 'SimpleGrid' and maps 'x', 'y'>")
 
     def test_grid_erddap(self):
         """Test that dataset has the correct data proxies for grids
@@ -60,8 +61,9 @@ class TestDapHandler(unittest.TestCase):
         with patch('pydap.handlers.lib.degenerate_grid_to_structure',
                    side_effect=(lambda x: x)) as mock_degenerate:
             dataset = DAPHandler("http://localhost:8001/", self.app1).dataset
-            self.assertEqual(repr(dataset.SimpleGrid[:]),
-                             "<GridType with array 'SimpleGrid' and maps 'x', 'y'>")
+            self.assertEqual(
+                    repr(dataset.SimpleGrid[:]),
+                    "<GridType with array 'SimpleGrid' and maps 'x', 'y'>")
             mock_degenerate.assert_called()
 
     def test_grid_output_grid_false(self):

--- a/src/pydap/tests/test_handlers_dap.py
+++ b/src/pydap/tests/test_handlers_dap.py
@@ -8,7 +8,10 @@ from pydap.tests.datasets import (
     SimpleSequence, SimpleGrid, SimpleArray, VerySimpleSequence)
 
 import unittest
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 
 class TestDapHandler(unittest.TestCase):
@@ -64,7 +67,7 @@ class TestDapHandler(unittest.TestCase):
             self.assertEqual(
                     repr(dataset.SimpleGrid[:]),
                     "<GridType with array 'SimpleGrid' and maps 'x', 'y'>")
-            mock_degenerate.assert_called()
+            assert mock_degenerate.called
 
     def test_grid_output_grid_false(self):
         """Test that dataset has the correct data proxies for grids with
@@ -111,7 +114,7 @@ class TestDapHandler(unittest.TestCase):
                                  output_grid=False).dataset
             np.testing.assert_array_equal(dataset.SimpleGrid[:],
                                           [[0, 1, 2], [3, 4, 5]])
-            mock_degenerate.assert_called()
+            assert mock_degenerate.called
 
     def test_grid_with_projection(self):
         """Test that a sliced proxy can be created for grids."""


### PR DESCRIPTION
This PR fixes #6. This code should now work:
```
from pydap.client import open_url

dataset = open_url('http://oos.soest.hawaii.edu/erddap/griddap/NCEP_Global_Best')
tmpsfc = dataset['tmpsfc']
tmpsfc[0, :, :]
```

This code also makes it possible to solve #76. The way I see it, it will only require a few tweaks to allow these types of links.