### PR TITLE
Drop usage of Webob in favor of requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ install_requires = [
     'docopt',
     'six >= 1.4.0',
     'mechanicalsoup',
+    'requests',
+    'requests_wsgi_adapter'
 ]
 
 if sys.version_info < (3, 5):
@@ -31,10 +33,6 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
-cas_extras = [
-    'requests'
-    ]
-
 tests_require = functions_extras + cas_extras + server_extras + [
     'WebTest',
     'beautifulsoup4',
@@ -45,8 +43,7 @@ tests_require = functions_extras + cas_extras + server_extras + [
 testing_extras = tests_require + [
     'pytest-cov',
     'pytest-attrib',
-    'mock',
-    'requests'
+    'mock'
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,6 @@ setup(name='Pydap',
             'testing': testing_extras,
             'docs': docs_extras,
             'tests': tests_require,
-            'cas': cas_extras,
             'server': server_extras
       },
       test_suite="pydap.tests",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
-tests_require = functions_extras + cas_extras + server_extras + [
+tests_require = functions_extras + server_extras + [
     'WebTest',
     'beautifulsoup4',
     'scipy',

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -106,8 +106,8 @@ def open_file(dods, das=None):
 def open_dods(url, metadata=False, application=None, session=None):
     """Open a `.dods` response directly, returning a dataset."""
     r = GET(url, application, session)
-    dds, data = r.body.split(b'\nData:\n', 1)
-    dds = dds.decode(r.content_encoding or 'ascii')
+    dds, data = r.content.split(b'\nData:\n', 1)
+    dds = dds.decode(r.encoding or 'ascii')
     dataset = build_dataset(dds)
     stream = StreamReader(BytesIO(data))
     dataset.data = unpack_data(stream, dataset)

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -51,14 +51,14 @@ class DAPHandler(BaseHandler):
         raise_for_status(r)
         if not r.charset:
             r.charset = 'ascii'
-        dds = r.text
+        dds = r.body
 
         dasurl = urlunsplit((scheme, netloc, path + '.das', query, fragment))
         r = GET(dasurl, application, session)
         raise_for_status(r)
         if not r.charset:
             r.charset = 'ascii'
-        das = r.text
+        das = r.body
 
         # build the dataset from the DDS and add attributes from the DAS
         self.dataset = build_dataset(dds)

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -40,40 +40,11 @@ def follow_redirect(url, application=None, session=None):
     headers as the passed session.
     """
 
-    req = create_request(url, session=session)
-    return req.get_response(application)
-
-
-def create_request(url, session=None):
-    if session is not None:
-        # If session is set and cookies were loaded using pydap.cas.get_cookies
-        # using the check_url option, then we can legitimately expect that
-        # the connection will go through seamlessly. However, there might be
-        # redirects that might want to modify the cookies. Webob is not
-        # really up to the task here. The approach used here is to
-        # piggy back on the requests library and use it to fetch the
-        # head of the requested url. Requests will follow redirects and
-        # adjust the cookies as needed. We can then use the final url and
-        # the final cookies to set up a webob Request object that will
-        # be guaranteed to have all the needed credentials:
-        try:
-            # Use session to follow redirects:
-            with closing(session.head(url)) as head:
-                req = Request.blank(head.url)
-
-                # Get cookies from head:
-                cookies_dict = head.cookies.get_dict()
-
-                # Set request cookies to the head cookies:
-                req.headers['Cookie'] = ','.join(name + '=' +
-                                                 cookies_dict[name]
-                                                 for name in cookies_dict)
-                # Set the headers to the session headers:
-                for item in head.request.headers:
-                    req.headers[item] = head.request.headers[item]
-                return req
-        except MissingSchema:
-            # Missing schema can occur in tests when the url
-            # is not pointing to any resource. Simply pass.
-            pass
-    return Request.blank(url)
+    if session is None:
+        session = requests.Session()
+    scheme, netloc, path, query, fragment = urlsplit(url)
+    domain = urlunsplit((scheme, netloc, '', '', ''))
+    session.mount(domain, wsgiadapter.WSGIAdapter(application))
+    resp = session.get(url)
+    session.unmount(domain, requests.HTTPAdapter())
+    return resp

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -1,4 +1,3 @@
-from webob.exc import HTTPError
 from contextlib import closing
 import requests
 from requests.exceptions import MissingSchema
@@ -25,12 +24,7 @@ def GET(url, application=None, session=None):
 
 
 def raise_for_status(response):
-    if response.status_code >= 400:
-        raise HTTPError(
-            detail=response.status,
-            headers=response.headers,
-            comment=response.content
-        )
+    response.raise_for_status()
 
 
 class WSGISession():

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -1,7 +1,8 @@
-from webob.request import Request
 from webob.exc import HTTPError
 from contextlib import closing
+import requests
 from requests.exceptions import MissingSchema
+import wsgiadapter
 
 from six.moves.urllib.parse import urlsplit, urlunsplit
 
@@ -17,9 +18,10 @@ def GET(url, application=None, session=None):
     """
     if application:
         _, _, path, query, fragment = urlsplit(url)
-        url = urlunsplit(('', '', path, query, fragment))
+        url = urlunsplit(('WSGIapplication', '', path, query, fragment))
 
-    return follow_redirect(url, application=application, session=session)
+    with WSGISession(url, application, session) as wsgi:
+        return wsgi.get(url)
 
 
 def raise_for_status(response):
@@ -27,24 +29,30 @@ def raise_for_status(response):
         raise HTTPError(
             detail=response.status,
             headers=response.headers,
-            comment=response.body
+            comment=response.content
         )
 
 
-def follow_redirect(url, application=None, session=None):
-    """
-    This function essentially performs the following command:
-    >>> Request.blank(url).get_response(application)
+class WSGISession():
+    def __init__(self, url, application=None, session=None):
+        self.session = session
+        self._close_session = False
+        if session is None:
+            self.session = requests.Session()
+            self._close_session = True
 
-    It however makes sure that the request possesses the same cookies and
-    headers as the passed session.
-    """
+        scheme, netloc, path, query, fragment = urlsplit(url)
+        self._domain = urlunsplit((scheme, netloc, '', '', ''))
+        self.session.mount(self._domain, wsgiadapter.WSGIAdapter(application))
 
-    if session is None:
-        session = requests.Session()
-    scheme, netloc, path, query, fragment = urlsplit(url)
-    domain = urlunsplit((scheme, netloc, '', '', ''))
-    session.mount(domain, wsgiadapter.WSGIAdapter(application))
-    resp = session.get(url)
-    session.unmount(domain, requests.HTTPAdapter())
-    return resp
+    def __enter__(self):
+        return self.session
+
+    def close(self):
+        if self._close_session:
+            self.session.close()
+        else:
+            session.mount(self._domain, requests.adapters.HTTPAdapter())
+
+    def __exit__(self ,type, value, traceback):
+        self.close()


### PR DESCRIPTION
I know the opposite was done in commit 91f01609ec3536279cf985695cfab6eca2124374 but ``requests`` is so much better than ``webob`` to handle redirects and authentication. In this PR, I propose converting ``requests`` to a WSGI using an adapter. I seems to be working. This is not urgent and the goal here is to have a discussion.

What's your gut feeling @jameshiebert ?