### PR TITLE
Reintroduce IterData tests

### DIFF
--- a/src/pydap/handlers/lib.py
+++ b/src/pydap/handlers/lib.py
@@ -308,8 +308,9 @@ class IterData(object):
                 peek = x
                 if isinstance(x, IterData):
                     peek = next(iter(x))
-                return np.dtype([(col, array_dtype(val, template[col])) for col, val in 
-                                 zip(template.keys(), peek)])
+                return np.dtype([(col, array_dtype(val, template[col]))
+                                 for col, val
+                                 in zip(template.keys(), peek)])
             else:
                 return np.array(x).dtype
         return array_dtype(next(iter(self)), self.template)

--- a/src/pydap/handlers/lib.py
+++ b/src/pydap/handlers/lib.py
@@ -302,8 +302,17 @@ class IterData(object):
     @property
     def dtype(self):
         """Return Numpy dtype of the object."""
-        peek = next(iter(self))
-        return np.array(peek).dtype
+        def array_dtype(x, template):
+            if (hasattr(template, 'keys') and
+               len(template.keys()) > 1):
+                peek = x
+                if isinstance(x, IterData):
+                    peek = next(iter(x))
+                return np.dtype([(col, array_dtype(val, template[col])) for col, val in 
+                                 zip(template.keys(), peek)])
+            else:
+                return np.array(x).dtype
+        return array_dtype(next(iter(self)), self.template)
 
     def iterdata(self):
         """Included for code symmetry with Types"""

--- a/src/pydap/handlers/lib.py
+++ b/src/pydap/handlers/lib.py
@@ -304,7 +304,7 @@ class IterData(object):
         """Return Numpy dtype of the object."""
         def array_dtype(x, template):
             if (hasattr(template, 'keys') and
-               len(template.keys()) > 1):
+               len(list(template.keys())) > 1):
                 peek = x
                 if isinstance(x, IterData):
                     peek = next(iter(x))

--- a/src/pydap/tests/test_iter_data.py
+++ b/src/pydap/tests/test_iter_data.py
@@ -2,11 +2,11 @@
 
 import numpy as np
 from pydap.handlers.lib import IterData
+from pydap.model import DatasetType, SequenceType, BaseType, StructureType
 
 import unittest
 
 
-@unittest.skip("This test is not fully implemented")
 class TestSimpleIterData(unittest.TestCase):
 
     """Compare IterData object with corresponding Numpy array."""
@@ -22,16 +22,22 @@ class TestSimpleIterData(unittest.TestCase):
             (6, 7, 70.),
             (7, 8, 80.),
         ], dtype=[('byte', 'b'), ('int', 'i4'), ('float', 'f4')])
+        # add sequence and children for each column
+        name = 'nameless'
+        self.dataset = DatasetType(name)
+        seq = self.dataset['sequence'] = SequenceType('sequence')
+        for var in self.simple_array.dtype.names:
+            seq[var] = BaseType(var)
 
-        self.simple_object = IterData(("simple", ("byte", "int", "float")),
-                                      [(0, 1, 10.),
+        self.simple_object = IterData([(0, 1, 10.),
                                        (1, 2, 20.),
                                        (2, 3, 30.),
                                        (3, 4, 40.),
                                        (4, 5, 50.),
                                        (5, 6, 60.),
                                        (6, 7, 70.),
-                                       (7, 8, 80.)])
+                                       (7, 8, 80.)],
+                                       seq)
 
     def test_iter(self):
         self.assertEqual([tuple(row)
@@ -124,18 +130,33 @@ class TestSimpleIterData(unittest.TestCase):
                           (4, 5, 50.)])
 
 
-@unittest.skip("This test is not fully implemented")
 class TestNestedIterData(unittest.TestCase):
 
     def setUp(self):
-        self.nested_object = IterData(("nested", ("a", "b", "c",
-                                                  ("d", ("e", "f", "g")))),
-                                      [(1, 1, 1, [(10, 11, 12), (21, 22, 23)]),
-                                       (2, 4, 4, [(15, 16, 17)]),
-                                       (3, 6, 9, []),
-                                       (4, 8, 16,
-                                        [(31, 32, 33), (41, 42, 43),
-                                         (51, 52, 53), (61, 62, 63)])])
+        self.nested_array = [(1, 1, 1, [(10, 11, 12),
+                                        (21, 22, 23)]),
+                             (2, 4, 4, [(15, 16, 17)]),
+                             (3, 6, 9, []),
+                             (4, 8, 16, [(31, 32, 33),
+                                         (41, 42, 43),
+                                         (51, 52, 53),
+                                         (61, 62, 63)])]
+            
+        self.dtype = np.dtype([('a', '<i8'), ('b', '<i8'),
+                               ('c', '<i8'),
+                               ('d', np.dtype([('e', '<i8'),
+                                               ('f', '<i8'),
+                                               ('g', '<i8')]))])
+        name = 'nameless'
+        self.dataset = DatasetType(name)
+        seq = self.dataset['nested'] = SequenceType('nested')
+        for var in ['a', 'b', 'c']:
+            seq[var] = BaseType(var)
+        seq['d'] = SequenceType('d')
+        for var in ['e', 'f', 'g']:
+            seq['d'][var] = BaseType(var)
+
+        self.nested_object = IterData(self.nested_array, seq)
 
     def test_iter(self):
         self.assertEqual([tuple(row) for row in self.nested_object],
@@ -158,36 +179,19 @@ class TestNestedIterData(unittest.TestCase):
                            (51, 52, 53), (61, 62, 63)]])
 
     def test_iter_nested_deep_child(self):
-        print(self.nested_object["d"]["e"].cols)
         self.assertEqual(list(self.nested_object["d"]["e"]),
-                         [[(10, 11, 12), (21, 22, 23)],
-                          [(15, 16, 17)],
+                         [[10, 21],
+                          [15],
                           [],
-                          [(31, 32, 33), (41, 42, 43),
-                           (51, 52, 53), (61, 62, 63)]])
-        self.assertEqual([tuple(row) for row in self.simple_object],
-                         [(0, 1, 10.),
-                          (1, 2, 20.),
-                          (2, 3, 30.),
-                          (3, 4, 40.),
-                          (4, 5, 50.),
-                          (5, 6, 60.),
-                          (6, 7, 70.),
-                          (7, 8, 80.)])
-        self.assertEqual(
-            list(self.simple_object["byte"]), [0, 1, 2, 3, 4, 5, 6, 7])
+                          [31, 41,
+                           51, 61]])
 
     def test_dtype(self):
         self.assertEqual(
-            self.simple_array.dtype,
-            np.dtype([('byte', 'i1'), ('int', '<i4'), ('float', '<f4')]))
-        self.assertEqual(self.simple_array["int"].dtype, "<i4")
+            self.nested_object.dtype,
+            self.dtype)
 
-        self.assertEqual(
-            self.simple_object.dtype,
-            np.dtype([('byte', '<i8'), ('int', '<i8'), ('float', '<f8')]))
-        self.assertEqual(self.simple_object["int"].dtype, "<i8")
-
+    @unittest.skip("This test is not fully implemented")
     def test_selection(self):
         selection = self.simple_array[self.simple_array["byte"] > 3]
         self.assertEqual([tuple(row) for row in selection],
@@ -203,6 +207,7 @@ class TestNestedIterData(unittest.TestCase):
                           (6, 7, 70.),
                           (7, 8, 80.)])
 
+    @unittest.skip("This test is not fully implemented")
     def test_projection(self):
         projection = self.simple_array[1::2]
         self.assertEqual([tuple(row) for row in projection],
@@ -226,6 +231,7 @@ class TestNestedIterData(unittest.TestCase):
         self.assertEqual(
             list(self.simple_object[1::2]["byte"]), [1, 3, 5, 7])
 
+    @unittest.skip("This test is not fully implemented")
     def test_combined(self):
         filtered = self.simple_array[self.simple_array["byte"] > 1]
         filtered = filtered[filtered["byte"] < 6]

--- a/src/pydap/tests/test_iter_data.py
+++ b/src/pydap/tests/test_iter_data.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 from pydap.handlers.lib import IterData
-from pydap.model import DatasetType, SequenceType, BaseType, StructureType
+from pydap.model import DatasetType, SequenceType, BaseType
 
 import unittest
 
@@ -37,7 +37,7 @@ class TestSimpleIterData(unittest.TestCase):
                                        (5, 6, 60.),
                                        (6, 7, 70.),
                                        (7, 8, 80.)],
-                                       seq)
+                                      seq)
 
     def test_iter(self):
         self.assertEqual([tuple(row)
@@ -134,8 +134,8 @@ class TestNestedIterData(unittest.TestCase):
 
     def setUp(self):
         self.shallow_data = [(1, 1, 1), (2, 4, 4),
-                            (3, 6, 9), (4, 8, 16)]
-        self.deep_data = [[(10, 11, 12), (21, 22, 23),],
+                             (3, 6, 9), (4, 8, 16)]
+        self.deep_data = [[(10, 11, 12), (21, 22, 23)],
                           [(15, 16, 17)],
                           [],
                           [(31, 32, 33), (41, 42, 43),
@@ -189,7 +189,6 @@ class TestNestedIterData(unittest.TestCase):
                          [tuple(row) for row in self.nested_data
                           if row[0] > 2])
 
-    #@unittest.skip("This test is not fully implemented")
     def test_projection(self):
         projection = self.nested_data[1::2]
         self.assertEqual([tuple(row) for row in projection],
@@ -210,10 +209,10 @@ class TestNestedIterData(unittest.TestCase):
                     if row[0] < 4]
         filtered = filtered[::2]
         self.assertEqual([tuple(row) for row in filtered],
-                         [(3, 6, 9, [])]) 
+                         [(3, 6, 9, [])])
 
         filtered = self.nested_object[self.nested_object["a"] > 2]
         filtered = filtered[filtered["a"] < 4]
         filtered = filtered[::2]
         self.assertEqual([tuple(row) for row in filtered],
-                         [(3, 6, 9, [])]) 
+                         [(3, 6, 9, [])])

--- a/src/pydap/tests/test_iter_data.py
+++ b/src/pydap/tests/test_iter_data.py
@@ -165,20 +165,19 @@ def test_nested_iter(nested_data, nested_object):
 
 
 def test_nested_iter_child(nested_data, nested_object):
-    assert (
-        list(nested_object["a"]) ==
-        [row[0] for row in nested_data])
+    expected = [row[0] for row in nested_data]
+    assert list(nested_object["a"]) == expected
 
 
 def test_nested_iter_nested_sequence(nested_data, nested_object):
-    assert (list(nested_object["d"]) ==
-            [row[3] for row in nested_data])
+    expected = [row[3] for row in nested_data]
+    assert list(nested_object["d"]) == expected
 
 
 def test_nested_iter_nested_deep_child(nested_data, nested_object):
-    assert (list(nested_object['d']['e']) ==
-            [[col[0] for col in row[3]]
-             for row in nested_data])
+    expected = [[col[0] for col in row[3]]
+                for row in nested_data]
+    assert list(nested_object['d']['e']) == expected
 
 
 def test_nested_dtype(nested_dtype, nested_object):
@@ -187,23 +186,23 @@ def test_nested_dtype(nested_dtype, nested_object):
 
 def test_nested_selection(nested_data, nested_object):
     selection = nested_object[nested_object["a"] > 2]
-    assert ([tuple(row) for row in selection] ==
-            [tuple(row) for row in nested_data
-             if row[0] > 2])
+    expected = [tuple(row) for row in nested_data
+                if row[0] > 2]
+    assert [tuple(row) for row in selection] == expected
 
 
 def test_nested_projection(nested_data, nested_object):
     projection = nested_data[1::2]
-    assert ([tuple(row) for row in projection] ==
-            [tuple(row) for row_id, row
-             in enumerate(nested_data)
-             if row_id in range(1, len(nested_data), 2)])
+    expected = [tuple(row) for row_id, row
+                in enumerate(nested_data)
+                if row_id in range(1, len(nested_data), 2)]
+    assert [tuple(row) for row in projection] == expected
 
     projection = nested_object[1::2]
-    assert ([tuple(row) for row in projection] ==
-            [tuple(row) for row_id, row
-             in enumerate(nested_data)
-             if row_id in range(1, len(nested_data), 2)])
+    expected = [tuple(row) for row_id, row
+                in enumerate(nested_data)
+                if row_id in range(1, len(nested_data), 2)]
+    assert [tuple(row) for row in projection] == expected
 
 
 def test_nested_combined(nested_data, nested_object):

--- a/src/pydap/tests/test_iter_data.py
+++ b/src/pydap/tests/test_iter_data.py
@@ -3,16 +3,12 @@
 import numpy as np
 from pydap.handlers.lib import IterData
 from pydap.model import DatasetType, SequenceType, BaseType
+import pytest
 
-import unittest
 
-
-class TestSimpleIterData(unittest.TestCase):
-
-    """Compare IterData object with corresponding Numpy array."""
-
-    def setUp(self):
-        self.simple_array = np.array([
+@pytest.fixture
+def simple_array():
+    arr = np.array([
             (0, 1, 10.),
             (1, 2, 20.),
             (2, 3, 30.),
@@ -22,197 +18,205 @@ class TestSimpleIterData(unittest.TestCase):
             (6, 7, 70.),
             (7, 8, 80.),
         ], dtype=[('byte', 'b'), ('int', 'i4'), ('float', 'f4')])
-        # add sequence and children for each column
+    return arr
+
+
+@pytest.fixture
+def simple_object(simple_array):
+    # add sequence and children for each column
+    name = 'nameless'
+    dataset = DatasetType(name)
+    seq = dataset['sequence'] = SequenceType('sequence')
+    for var in simple_array.dtype.names:
+        seq[var] = BaseType(var)
+
+    obj = IterData([(0, 1, 10.),
+                    (1, 2, 20.),
+                    (2, 3, 30.),
+                    (3, 4, 40.),
+                    (4, 5, 50.),
+                    (5, 6, 60.),
+                    (6, 7, 70.),
+                    (7, 8, 80.)],
+                   seq)
+    return obj
+
+
+def test_iter(simple_array, simple_object):
+    assert ([tuple(row)
+             for row in simple_array] ==
+            [(0, 1, 10.), (1, 2, 20.),
+             (2, 3, 30.), (3, 4, 40.),
+             (4, 5, 50.), (5, 6, 60.),
+             (6, 7, 70.), (7, 8, 80.)])
+    assert (list(simple_array["byte"]) ==
+            [0, 1, 2, 3, 4, 5, 6, 7])
+
+    assert ([tuple(row) for row in simple_object] ==
+            [(0, 1, 10.), (1, 2, 20.),
+             (2, 3, 30.), (3, 4, 40.),
+             (4, 5, 50.), (5, 6, 60.),
+             (6, 7, 70.), (7, 8, 80.)])
+    assert (list(simple_object["byte"]) ==
+            [0, 1, 2, 3, 4, 5, 6, 7])
+
+
+def test_dtype(simple_array, simple_object):
+    assert (
+        simple_array.dtype ==
+        np.dtype([('byte', 'i1'), ('int', '<i4'), ('float', '<f4')]))
+    assert (simple_array["int"].dtype == "<i4")
+
+    assert (
+        simple_object.dtype ==
+        np.dtype([('byte', '<i8'), ('int', '<i8'), ('float', '<f8')]))
+    assert (simple_object["int"].dtype == "<i8")
+
+
+def test_selection(simple_array, simple_object):
+    selection = simple_array[simple_array["byte"] > 3]
+    assert ([tuple(row) for row in selection] ==
+            [(4, 5, 50.), (5, 6, 60.),
+             (6, 7, 70.), (7, 8, 80.)])
+
+    selection = simple_object[simple_object["byte"] > 3]
+    assert ([tuple(row) for row in selection] ==
+            [(4, 5, 50.), (5, 6, 60.),
+             (6, 7, 70.), (7, 8, 80.)])
+
+
+def test_projection(simple_array, simple_object):
+    projection = simple_array[1::2]
+    assert ([tuple(row) for row in projection] ==
+            [(1, 2, 20.), (3, 4, 40.),
+             (5, 6, 60.), (7, 8, 80.)])
+    assert (
+        list(simple_array["byte"][1::2]) == [1, 3, 5, 7])
+    assert (
+        list(simple_array[1::2]["byte"]) == [1, 3, 5, 7])
+
+    projection = simple_object[1::2]
+    assert ([tuple(row) for row in projection] ==
+            [(1, 2, 20.), (3, 4, 40.),
+             (5, 6, 60.), (7, 8, 80.)])
+    assert (
+        list(simple_object["byte"][1::2]) == [1, 3, 5, 7])
+    assert (
+        list(simple_object[1::2]["byte"]) == [1, 3, 5, 7])
+
+
+def test_combined(simple_array, simple_object):
+    filtered = simple_array[simple_array["byte"] > 1]
+    filtered = filtered[filtered["byte"] < 6]
+    filtered = filtered[::2]
+    assert ([tuple(row) for row in filtered] ==
+            [(2, 3, 30.), (4, 5, 50.)])
+
+    filtered = simple_object[simple_object["byte"] > 1]
+    filtered = filtered[filtered["byte"] < 6]
+    filtered = filtered[::2]
+    assert ([tuple(row) for row in filtered] ==
+            [(2, 3, 30.), (4, 5, 50.)])
+
+
+@pytest.fixture
+def nested_data():
+        shallow_data = [(1, 1, 1), (2, 4, 4),
+                        (3, 6, 9), (4, 8, 16)]
+        deep_data = [[(10, 11, 12), (21, 22, 23)],
+                     [(15, 16, 17)],
+                     [],
+                     [(31, 32, 33), (41, 42, 43),
+                      (51, 52, 53), (61, 62, 63)]]
+        nested = [x + (deep_data[x_id],)
+                  for x_id, x
+                  in enumerate(shallow_data)]
+        return nested
+
+
+@pytest.fixture
+def nested_dtype():
+        dtype = np.dtype([('a', '<i8'), ('b', '<i8'),
+                          ('c', '<i8'),
+                          ('d', np.dtype([('e', '<i8'),
+                                          ('f', '<i8'),
+                                          ('g', '<i8')]))])
+        return dtype
+
+
+@pytest.fixture
+def nested_object(nested_data):
         name = 'nameless'
-        self.dataset = DatasetType(name)
-        seq = self.dataset['sequence'] = SequenceType('sequence')
-        for var in self.simple_array.dtype.names:
-            seq[var] = BaseType(var)
-
-        self.simple_object = IterData([(0, 1, 10.),
-                                       (1, 2, 20.),
-                                       (2, 3, 30.),
-                                       (3, 4, 40.),
-                                       (4, 5, 50.),
-                                       (5, 6, 60.),
-                                       (6, 7, 70.),
-                                       (7, 8, 80.)],
-                                      seq)
-
-    def test_iter(self):
-        self.assertEqual([tuple(row)
-                          for row in self.simple_array],
-                         [(0, 1, 10.),
-                          (1, 2, 20.),
-                          (2, 3, 30.),
-                          (3, 4, 40.),
-                          (4, 5, 50.),
-                          (5, 6, 60.),
-                          (6, 7, 70.),
-                          (7, 8, 80.)])
-        self.assertEqual(
-            list(self.simple_array["byte"]), [0, 1, 2, 3, 4, 5, 6, 7])
-
-        self.assertEqual([tuple(row) for row in self.simple_object],
-                         [(0, 1, 10.),
-                          (1, 2, 20.),
-                          (2, 3, 30.),
-                          (3, 4, 40.),
-                          (4, 5, 50.),
-                          (5, 6, 60.),
-                          (6, 7, 70.),
-                          (7, 8, 80.)])
-        self.assertEqual(
-            list(self.simple_object["byte"]), [0, 1, 2, 3, 4, 5, 6, 7])
-
-    def test_dtype(self):
-        self.assertEqual(
-            self.simple_array.dtype,
-            np.dtype([('byte', 'i1'), ('int', '<i4'), ('float', '<f4')]))
-        self.assertEqual(self.simple_array["int"].dtype, "<i4")
-
-        self.assertEqual(
-            self.simple_object.dtype,
-            np.dtype([('byte', '<i8'), ('int', '<i8'), ('float', '<f8')]))
-        self.assertEqual(self.simple_object["int"].dtype, "<i8")
-
-    def test_selection(self):
-        selection = self.simple_array[self.simple_array["byte"] > 3]
-        self.assertEqual([tuple(row) for row in selection],
-                         [(4, 5, 50.),
-                          (5, 6, 60.),
-                          (6, 7, 70.),
-                          (7, 8, 80.)])
-
-        selection = self.simple_object[self.simple_object["byte"] > 3]
-        self.assertEqual([tuple(row) for row in selection],
-                         [(4, 5, 50.),
-                          (5, 6, 60.),
-                          (6, 7, 70.),
-                          (7, 8, 80.)])
-
-    def test_projection(self):
-        projection = self.simple_array[1::2]
-        self.assertEqual([tuple(row) for row in projection],
-                         [(1, 2, 20.),
-                          (3, 4, 40.),
-                          (5, 6, 60.),
-                          (7, 8, 80.)])
-        self.assertEqual(
-            list(self.simple_array["byte"][1::2]), [1, 3, 5, 7])
-        self.assertEqual(
-            list(self.simple_array[1::2]["byte"]), [1, 3, 5, 7])
-
-        projection = self.simple_object[1::2]
-        self.assertEqual([tuple(row) for row in projection],
-                         [(1, 2, 20.),
-                          (3, 4, 40.),
-                          (5, 6, 60.),
-                          (7, 8, 80.)])
-        self.assertEqual(
-            list(self.simple_object["byte"][1::2]), [1, 3, 5, 7])
-        self.assertEqual(
-            list(self.simple_object[1::2]["byte"]), [1, 3, 5, 7])
-
-    def test_combined(self):
-        filtered = self.simple_array[self.simple_array["byte"] > 1]
-        filtered = filtered[filtered["byte"] < 6]
-        filtered = filtered[::2]
-        self.assertEqual([tuple(row) for row in filtered],
-                         [(2, 3, 30.),
-                          (4, 5, 50.)])
-
-        filtered = self.simple_object[self.simple_object["byte"] > 1]
-        filtered = filtered[filtered["byte"] < 6]
-        filtered = filtered[::2]
-        self.assertEqual([tuple(row) for row in filtered],
-                         [(2, 3, 30.),
-                          (4, 5, 50.)])
-
-
-class TestNestedIterData(unittest.TestCase):
-
-    def setUp(self):
-        self.shallow_data = [(1, 1, 1), (2, 4, 4),
-                             (3, 6, 9), (4, 8, 16)]
-        self.deep_data = [[(10, 11, 12), (21, 22, 23)],
-                          [(15, 16, 17)],
-                          [],
-                          [(31, 32, 33), (41, 42, 43),
-                           (51, 52, 53), (61, 62, 63)]]
-        self.nested_data = [x + (self.deep_data[x_id],)
-                            for x_id, x
-                            in enumerate(self.shallow_data)]
-
-        self.dtype = np.dtype([('a', '<i8'), ('b', '<i8'),
-                               ('c', '<i8'),
-                               ('d', np.dtype([('e', '<i8'),
-                                               ('f', '<i8'),
-                                               ('g', '<i8')]))])
-        name = 'nameless'
-        self.dataset = DatasetType(name)
-        seq = self.dataset['nested'] = SequenceType('nested')
+        dataset = DatasetType(name)
+        seq = dataset['nested'] = SequenceType('nested')
         for var in ['a', 'b', 'c']:
             seq[var] = BaseType(var)
         seq['d'] = SequenceType('d')
         for var in ['e', 'f', 'g']:
             seq['d'][var] = BaseType(var)
 
-        self.nested_object = IterData(self.nested_data, seq)
+        nested = IterData(nested_data, seq)
+        return nested
 
-    def test_iter(self):
-        self.assertEqual([tuple(row) for row in self.nested_object],
-                         self.nested_data)
 
-    def test_iter_child(self):
-        self.assertEqual(
-            list(self.nested_object["a"]),
-            [row[0] for row in self.nested_data])
+def test_nested_iter(nested_data, nested_object):
+    assert ([tuple(row) for row in nested_object] ==
+            nested_data)
 
-    def test_iter_nested_sequence(self):
-        self.assertEqual(list(self.nested_object["d"]),
-                         [row[3] for row in self.nested_data])
 
-    def test_iter_nested_deep_child(self):
-        self.assertEqual(list(self.nested_object['d']['e']),
-                         [[col[0] for col in row[3]]
-                          for row in self.nested_data])
+def test_nested_iter_child(nested_data, nested_object):
+    assert (
+        list(nested_object["a"]) ==
+        [row[0] for row in nested_data])
 
-    def test_dtype(self):
-        self.assertEqual(
-            self.nested_object.dtype,
-            self.dtype)
 
-    def test_selection(self):
-        selection = self.nested_object[self.nested_object["a"] > 2]
-        self.assertEqual([tuple(row) for row in selection],
-                         [tuple(row) for row in self.nested_data
-                          if row[0] > 2])
+def test_nested_iter_nested_sequence(nested_data, nested_object):
+    assert (list(nested_object["d"]) ==
+            [row[3] for row in nested_data])
 
-    def test_projection(self):
-        projection = self.nested_data[1::2]
-        self.assertEqual([tuple(row) for row in projection],
-                         [tuple(row) for row_id, row
-                          in enumerate(self.nested_data)
-                          if row_id in range(1, len(self.nested_data), 2)])
 
-        projection = self.nested_object[1::2]
-        self.assertEqual([tuple(row) for row in projection],
-                         [tuple(row) for row_id, row
-                          in enumerate(self.nested_data)
-                          if row_id in range(1, len(self.nested_data), 2)])
+def test_nested_iter_nested_deep_child(nested_data, nested_object):
+    assert (list(nested_object['d']['e']) ==
+            [[col[0] for col in row[3]]
+             for row in nested_data])
 
-    def test_combined(self):
-        filtered = [tuple(row) for row in self.nested_data
-                    if row[0] > 2]
-        filtered = [tuple(row) for row in filtered
-                    if row[0] < 4]
-        filtered = filtered[::2]
-        self.assertEqual([tuple(row) for row in filtered],
-                         [(3, 6, 9, [])])
 
-        filtered = self.nested_object[self.nested_object["a"] > 2]
-        filtered = filtered[filtered["a"] < 4]
-        filtered = filtered[::2]
-        self.assertEqual([tuple(row) for row in filtered],
-                         [(3, 6, 9, [])])
+def test_nested_dtype(nested_dtype, nested_object):
+    assert nested_object.dtype == nested_dtype
+
+
+def test_nested_selection(nested_data, nested_object):
+    selection = nested_object[nested_object["a"] > 2]
+    assert ([tuple(row) for row in selection] ==
+            [tuple(row) for row in nested_data
+             if row[0] > 2])
+
+
+def test_nested_projection(nested_data, nested_object):
+    projection = nested_data[1::2]
+    assert ([tuple(row) for row in projection] ==
+            [tuple(row) for row_id, row
+             in enumerate(nested_data)
+             if row_id in range(1, len(nested_data), 2)])
+
+    projection = nested_object[1::2]
+    assert ([tuple(row) for row in projection] ==
+            [tuple(row) for row_id, row
+             in enumerate(nested_data)
+             if row_id in range(1, len(nested_data), 2)])
+
+
+def test_nested_combined(nested_data, nested_object):
+    filtered = [tuple(row) for row in nested_data
+                if row[0] > 2]
+    filtered = [tuple(row) for row in filtered
+                if row[0] < 4]
+    filtered = filtered[::2]
+    assert ([tuple(row) for row in filtered] ==
+            [(3, 6, 9, [])])
+
+    filtered = nested_object[nested_object["a"] > 2]
+    filtered = filtered[filtered["a"] < 4]
+    filtered = filtered[::2]
+    assert ([tuple(row) for row in filtered] ==
+            [(3, 6, 9, [])])


### PR DESCRIPTION
This PR reintroduces the previously skipped ``IterData`` tests. It introduces small modifications to the ``IterData`` structure (namely how it outputs datatypes).

Also, I have converted the reintroduced tests to ``pytest`` format.