### PR TITLE
Remove scipy from travis-ci to close #84

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,7 @@ python:
     - 3.5
     - 3.6
 
-addons:
-  apt:
-    packages:
-      - gfortran
-      - libblas-dev
-      - liblapack-dev
-      - cython
-
 install:
-    - travis_wait 30 pip install scipy
     - pip install -e .[testing,functions,server,tests]
 
 script:

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,7 @@ if sys.version_info < (3, 5):
 
 functions_extras = [
     'gsw',
-    'coards',
-    'scipy',
+    'coards'
 ]
 
 server_extras = [

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if sys.version_info < (3, 5):
     install_requires.append('singledispatch')
 
 functions_extras = [
-    'gsw',
+    'gsw>=3.0.6',
     'coards'
 ]
 


### PR DESCRIPTION
This PR completely removes ``scipy`` from testing following the publication of version 3.0.6 of ``gsw`` on [PyPI](https://github.com/TEOS-10/python-gsw/issues/41). This speeds up our builds significantly, hurray! Also, it closes #84.