### PR TITLE
Add a timeout option to open_urls and open_dods

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -441,12 +441,13 @@ You can specify a cache directory in the ``pydap.lib.CACHE`` global variable. If
 Timeout
 ~~~~~~~
 
-To specify a timeout for the client, just set the global variable ``pydap.lib.TIMEOUT`` to the desired number of seconds; after this time trying to connect the client will give up. The default is ``None`` (never timeout).
+To specify a timeout for the client, just set the desired number of seconds using the ``timeout`` option to ``open_url(...)`` or ``open_dods(...)``.
+For example, the following commands would timeout after 30 seconds without receiving a response from the server:
 
 .. code-block:: python
 
-    >>> import pydap.lib
-    >>> pydap.lib.TIMEOUT = 60
+    >>> dataset = open_url('http://test.opendap.org/dap/data/nc/coads_climatology.nc, timeout=30)
+    >>> dataset = open_dods('http://test.opendap.org/dap/data/nc/coads_climatology.nc.dods, timeout=30)
 
 Configuring a proxy
 ~~~~~~~~~~~~~~~~~~~

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -27,7 +27,7 @@ from ..net import GET, raise_for_status
 from ..lib import (
     encode, combine_slices, fix_slice, hyperslab,
     START_OF_SEQUENCE, walk, StreamReader, BytesReader,
-  DEFAULT_TIMEOUT)
+    DEFAULT_TIMEOUT)
 from .lib import ConstraintExpression, BaseHandler, IterData
 from ..parsers.dds import build_dataset
 from ..parsers.das import parse_das, add_attributes

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -26,7 +26,7 @@ from pydap.model import (BaseType,
 from ..net import GET, raise_for_status
 from ..lib import (
     encode, combine_slices, fix_slice, hyperslab,
-    START_OF_SEQUENCE, walk)
+    START_OF_SEQUENCE, walk, DEFAULT_TIMEOUT)
 from .lib import ConstraintExpression, BaseHandler, IterData
 from ..parsers.dds import build_dataset
 from ..parsers.das import parse_das, add_attributes
@@ -42,19 +42,20 @@ class DAPHandler(BaseHandler):
 
     """Build a dataset from a DAP base URL."""
 
-    def __init__(self, url, application=None, session=None, output_grid=True):
+    def __init__(self, url, application=None, session=None, output_grid=True,
+                 timeout=DEFAULT_TIMEOUT):
         # download DDS/DAS
         scheme, netloc, path, query, fragment = urlsplit(url)
 
         ddsurl = urlunsplit((scheme, netloc, path + '.dds', query, fragment))
-        r = GET(ddsurl, application, session)
+        r = GET(ddsurl, application, session, timeout=timeout)
         raise_for_status(r)
         if not r.charset:
             r.charset = 'ascii'
         dds = r.text
 
         dasurl = urlunsplit((scheme, netloc, path + '.das', query, fragment))
-        r = GET(dasurl, application, session)
+        r = GET(dasurl, application, session, timeout=timeout)
         raise_for_status(r)
         if not r.charset:
             r.charset = 'ascii'
@@ -109,7 +110,7 @@ class BaseProxy(object):
     """
 
     def __init__(self, baseurl, id, dtype, shape, slice_=None,
-                 application=None, session=None):
+                 application=None, session=None, timeout=DEFAULT_TIMEOUT):
         self.baseurl = baseurl
         self.id = id
         self.dtype = dtype
@@ -117,6 +118,7 @@ class BaseProxy(object):
         self.slice = slice_ or tuple(slice(None) for s in self.shape)
         self.application = application
         self.session = session
+        self.timeout = timeout
 
     def __repr__(self):
         return 'BaseProxy(%s)' % ', '.join(
@@ -134,7 +136,7 @@ class BaseProxy(object):
 
         # download and unpack data
         logger.info("Fetching URL: %s" % url)
-        r = GET(url, self.application, self.session)
+        r = GET(url, self.application, self.session, timeout=self.timeout)
         raise_for_status(r)
         dds, data = r.body.split(b'\nData:\n', 1)
         dds = dds.decode(r.content_encoding or 'ascii')
@@ -183,13 +185,14 @@ class SequenceProxy(object):
     shape = ()
 
     def __init__(self, baseurl, template, selection=None, slice_=None,
-                 application=None, session=None):
+                 application=None, session=None, timeout=DEFAULT_TIMEOUT):
         self.baseurl = baseurl
         self.template = template
         self.selection = selection or []
         self.slice = slice_ or (slice(None),)
         self.application = application
         self.session = session
+        self.timeout = timeout
 
         # this variable is true when only a subset of the children are selected
         self.sub_children = False
@@ -256,7 +259,7 @@ class SequenceProxy(object):
 
     def __iter__(self):
         # download and unpack data
-        r = GET(self.url, self.application, self.session)
+        r = GET(self.url, self.application, self.session, timeout=self.timeout)
         raise_for_status(r)
 
         i = r.app_iter

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -16,6 +16,7 @@ __version__ = get_distribution("Pydap").version
 START_OF_SEQUENCE = b'\x5a\x00\x00\x00'
 END_OF_SEQUENCE = b'\xa5\x00\x00\x00'
 STRING = '|S128'
+DEFAULT_TIMEOUT = 120  # 120 seconds = 2 minutes
 
 
 def quote(name):

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -52,7 +52,6 @@ def follow_redirect(url, application=None, session=None,
 
 
 def create_request(url, session=None, timeout=DEFAULT_TIMEOUT):
-    req = Request.blank(url)
     if session is not None:
         # If session is set and cookies were loaded using pydap.cas.get_cookies
         # using the check_url option, then we can legitimately expect that
@@ -69,7 +68,8 @@ def create_request(url, session=None, timeout=DEFAULT_TIMEOUT):
         # If a session object was not passed, we simply pass a new
         # requests.Session() object. The requests library allows the
         # handling of redirects that are not naturally handled by Webob.
-        return create_request_from_session(url, requests.Session(), timeout=timeout)
+        return create_request_from_session(url, requests.Session(),
+                                           timeout=timeout)
 
 
 def create_request_from_session(url, session, timeout=DEFAULT_TIMEOUT):

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -1,7 +1,7 @@
 from webob.request import Request
 from webob.exc import HTTPError
 from contextlib import closing
-from requests.exceptions import MissingSchema
+from requests.exceptions import MissingSchema, Timeout
 
 from six.moves.urllib.parse import urlsplit, urlunsplit
 
@@ -80,7 +80,7 @@ def create_request(url, session=None, timeout=DEFAULT_TIMEOUT):
             # Missing schema can occur in tests when the url
             # is not pointing to any resource. Simply pass.
             pass
-        except requests.exceptions.Timeout:
+        except Timeout:
             raise HTTPError('Timeout')
     req.environ['webob.client.timeout'] = timeout
     return req

--- a/src/pydap/tests/test_server_devel.py
+++ b/src/pydap/tests/test_server_devel.py
@@ -73,14 +73,16 @@ def test_timeout(sequence_type_data):
     # to guarantee that it timeouts
     def wrap_mocker(func):
         def mock_add_latency(*args, **kwargs):
-            time.sleep(1)
+            time.sleep(1e-1)
             return func(*args, **kwargs)
+        return mock_add_latency
 
-    application.__call__ = wrap_mocker(application.__call__)
+    application = wrap_mocker(application)
     with LocalTestServer(application) as server:
         url = ("http://0.0.0.0:%s/" % server.port)
 
         # test open_url
+        assert open_url(url) == TestDataset
         with pytest.raises(HTTPError) as e:
             open_url(url, timeout=1e-5)
         assert 'Timeout' in str(e)

--- a/src/pydap/tests/test_server_devel.py
+++ b/src/pydap/tests/test_server_devel.py
@@ -84,16 +84,16 @@ def test_open_timeout(sequence_type_data):
         seq = dataset['sequence']
         assert isinstance(seq.data, SequenceProxy)
         # Change the timeout of the sequence proxy:
-        seq.data.timeout = 1e-8
+        seq.data.timeout = 1e-12
         with pytest.raises(HTTPError) as e:
-            next(iter(seq))
+            next(seq.iterdata())
         assert 'Timeout' in str(e)
 
         # test baseproxy:
         dat = dataset['byte']
         assert isinstance(dat.data, BaseProxy)
         # Change the timeout of the baseprox proxy:
-        dat.data.timeout = 1e-8
+        dat.data.timeout = 1e-12
         with pytest.raises(HTTPError) as e:
             dat[:]
         assert 'Timeout' in str(e)

--- a/src/pydap/tests/test_server_devel.py
+++ b/src/pydap/tests/test_server_devel.py
@@ -8,7 +8,6 @@ it could work with more data formats.
 """
 
 import numpy as np
-import requests
 import pytest
 
 from webob.exc import HTTPError
@@ -60,6 +59,7 @@ def test_open(sequence_type_data):
                                     sequence_type_data.data[:],
                                     dtype=sequence_type_data.data.dtype))
 
+
 @server
 def test_open_timeout(sequence_type_data):
     """Test that timeout works properly"""
@@ -73,12 +73,12 @@ def test_open_timeout(sequence_type_data):
         with pytest.raises(HTTPError) as e:
             open_url(url, timeout=1e-8)
         assert 'Timeout' in str(e)
-        
+
         # test open_dods
         with pytest.raises(HTTPError):
             open_dods(url + '.dods?sequence', timeout=1e-8)
         assert 'Timeout' in str(e)
-        
+
         # test sequenceproxy
         dataset = open_url(url)
         seq = dataset['sequence']


### PR DESCRIPTION
This PR follows #92 and supersedes #37. It introduces a simple timeout feature that enables a user to use ``open_urls`` and ``open_dods`` with an optional ``timeout`` argument. When opened this way, urls will raise an error is the server fails to respond is fewer seconds than specific by the ``timeout`` argument.