### PR TITLE
Prevent a Deprecation Warning in 3.6

### DIFF
--- a/src/pydap/handlers/lib.py
+++ b/src/pydap/handlers/lib.py
@@ -189,7 +189,7 @@ def apply_selection(selection, dataset):
         conditions = [
             condition for condition in selection
             if re.match(
-                '%s\.[^\.]+(<=|<|>=|>|=|!=)' % re.escape(seq.id), condition)]
+                r'%s\.[^\.]+(<=|<|>=|>|=|!=)' % re.escape(seq.id), condition)]
         for condition in conditions:
             id1, op, id2 = parse_selection(condition, dataset)
             seq.data = seq[op(id1, id2)].data

--- a/src/pydap/parsers/__init__.py
+++ b/src/pydap/parsers/__init__.py
@@ -42,7 +42,7 @@ def parse_projection(input):
         if '(' not in token:
             token = token.split('.')
             token = [
-                re.match('(.*?)(\[.*\])?$', part).groups()
+                re.match(r'(.*?)(\[.*\])?$', part).groups()
                 for part in token]
             token = [
                 (name, parse_hyperslab(slice_ or ''))

--- a/src/pydap/parsers/das.py
+++ b/src/pydap/parsers/das.py
@@ -49,8 +49,8 @@ class DASParser(SimpleParser):
         """Collect the attributes for a DAP variable."""
         self.consume('{')
         while not self.peek('}'):
-            if self.peek('[^\s]+\s+{'):
-                name = self.consume('[^\s]+')
+            if self.peek(r'[^\s]+\s+{'):
+                name = self.consume(r'[^\s]+')
                 target[name] = {}
                 self.container(target[name])
             else:
@@ -66,8 +66,8 @@ class DASParser(SimpleParser):
         attribute(s).
 
         """
-        type = self.consume('[^\s]+')
-        name = self.consume('[^\s]+')
+        type = self.consume(r'[^\s]+')
+        name = self.consume(r'[^\s]+')
 
         values = []
         while not self.peek(';'):

--- a/src/pydap/parsers/dds.py
+++ b/src/pydap/parsers/dds.py
@@ -24,7 +24,7 @@ typemap = {
     'url':     np.dtype(STRING),
     }
 constructors = ('grid', 'sequence', 'structure')
-name_regexp = '[\w%!~"\'\*-]+'
+name_regexp = r'[\w%!~"\'\*-]+'
 
 
 class DDSParser(SimpleParser):
@@ -60,7 +60,7 @@ class DDSParser(SimpleParser):
 
     def declaration(self):
         """Parse and return a declaration."""
-        token = self.peek('\w+').lower()
+        token = self.peek(r'\w+').lower()
 
         map = {
             'grid':      self.grid,
@@ -72,10 +72,10 @@ class DDSParser(SimpleParser):
 
     def base(self):
         """Parse a base variable, returning a ``BaseType``."""
-        type = self.consume('\w+')
+        type = self.consume(r'\w+')
 
         dtype = typemap[type.lower()]
-        name = quote(self.consume('[^;\[]+'))
+        name = quote(self.consume(r'[^;\[]+'))
         shape, dimensions = self.dimensions()
         self.consume(';')
 
@@ -89,14 +89,14 @@ class DDSParser(SimpleParser):
         shape = []
         names = []
         while not self.peek(';'):
-            self.consume('\[')
+            self.consume(r'\[')
             token = self.consume(name_regexp)
             if self.peek('='):
                 names.append(token)
                 self.consume('=')
-                token = self.consume('\d+')
+                token = self.consume(r'\d+')
             shape.append(int(token))
-            self.consume('\]')
+            self.consume(r'\]')
         return tuple(shape), tuple(names)
 
     def sequence(self):

--- a/src/pydap/tests/test_handlers_lib.py
+++ b/src/pydap/tests/test_handlers_lib.py
@@ -504,7 +504,7 @@ class MockHandler(BaseHandler):
 
     """A fake handler for testing."""
 
-    extensions = "^.*\.foo$"
+    extensions = r"^.*\.foo$"
 
     def __init__(self, dataset=None):
         BaseHandler.__init__(self, dataset)

--- a/src/pydap/tests/test_parsers.py
+++ b/src/pydap/tests/test_parsers.py
@@ -159,23 +159,23 @@ class TestSimpleParser(unittest.TestCase):
     def test_peek_existing(self):
         """Test the peek method when the token exists."""
         parser = SimpleParser("Hello, World!")
-        self.assertEqual(parser.peek("\w+"), "Hello")
+        self.assertEqual(parser.peek(r"\w+"), "Hello")
 
     def test_peek_missing(self):
         """Test the peek method when the token does not exist."""
         parser = SimpleParser("Hello, World!")
-        self.assertEqual(parser.peek("\d+"), "")
+        self.assertEqual(parser.peek(r"\d+"), "")
 
     def test_consume_existing(self):
         """Test the consume method when the token exists."""
         parser = SimpleParser("Hello, World!")
-        self.assertEqual(parser.consume("\w+"), "Hello")
+        self.assertEqual(parser.consume(r"\w+"), "Hello")
         self.assertEqual(parser.consume(", "), ", ")
-        self.assertEqual(parser.consume("\w+"), "World")
+        self.assertEqual(parser.consume(r"\w+"), "World")
         self.assertEqual(parser.consume("!"), "!")
 
     def test_consume_missing(self):
         """Test the consume method when the token does not exist."""
         parser = SimpleParser("Hello, World!")
         with self.assertRaises(Exception):
-            parser.consume("\d+")
+            parser.consume(r"\d+")

--- a/src/pydap/tests/test_responses_error.py
+++ b/src/pydap/tests/test_responses_error.py
@@ -34,7 +34,7 @@ class TestErrorResponse(unittest.TestCase):
                          'pydap/' + __version__)
 
     def test_body(self):
-        self.assertRegexpMatches(self.res.text, """Error {
+        self.assertRegexpMatches(self.res.text, r"""Error {
     code = -1;
     message = "Traceback \(most recent call last\):
   File .*

--- a/src/pydap/wsgi/functions.py
+++ b/src/pydap/wsgi/functions.py
@@ -127,7 +127,7 @@ bounds.__version__ = "1.0"
 
 def parse_step(step):
     """Parse a GrADS time step returning a timedelta."""
-    value, units = re.search('(\d+)(.*)', step).groups()
+    value, units = re.search(r'(\d+)(.*)', step).groups()
     value = int(value)
     if units.lower() == 'mn':
         return timedelta(minutes=value)

--- a/src/pydap/wsgi/ssf.py
+++ b/src/pydap/wsgi/ssf.py
@@ -181,7 +181,7 @@ def eval_function(dataset, function, functions):
             return eval_function(dataset, token, functions)
         else:
             try:
-                names = re.sub('\[.*?\]', '', str(token)).split('.')
+                names = re.sub(r'\[.*?\]', '', str(token)).split('.')
                 return reduce(operator.getitem, [dataset] + names)
             except:
                 try:


### PR DESCRIPTION
This PR prevents a deprecation warning in python 3.6 about escape characters. It removes the warning by explicitly converting all strings with escaped characters to string literals ``r'...'``.