### PR TITLE
Pin gsw to version 3.0.6 for support for python 2.7, 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if sys.version_info < (3, 5):
     install_requires.append('singledispatch')
 
 functions_extras = [
-    'gsw>=3.0.6',
+    'gsw==3.0.6',
     'coards'
 ]
 


### PR DESCRIPTION
This solves #100, at least temporarily, by pinning ``gsw`` version to 3.0.6.