### PR TITLE
Fix CEDA openid authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
 
 script:
     - flake8
-    - py.test -a 'not auth' --cov=src/pydap/
+    - py.test --cov=src/pydap/

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -350,8 +350,9 @@ Authentication is done through an ``openid`` and a ``password``:
 
     >>> from pydap.client import open_url  
     >>> from pydap.cas.esgf import setup_session 
-    >>> session = setup_session(openid, password)
-    >>> dataset = open_url('http://server.example.com/path/to/dataset', session=session)
+    >>> dataset_url = 'http://server.example.com/path/to/dataset'
+    >>> session = setup_session(openid, password, check_url=dataset_url)
+    >>> dataset = open_url(dataset_url, session=session)
 
 If your ``openid`` contains contains the
 string ``ceda.ac.uk`` authentication requires an additional ``username`` argument:
@@ -360,8 +361,8 @@ string ``ceda.ac.uk`` authentication requires an additional ``username`` argumen
 
     >>> from pydap.client import open_url  
     >>> from pydap.cas.esgf import setup_session 
-    >>> session = setup_session(openid, password, username=username)
-    >>> dataset = open_url('http://server.example.com/path/to/dataset', session=session)
+    >>> session = setup_session(openid, password, check_url=dataset_url, username=username)
+    >>> dataset = open_url(dataset_url, session=session)
 
 Advanced features
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = [
     'Jinja2',
     'docopt',
     'six >= 1.4.0',
-    'mechanicalsoup>=0.7',
+    'beautifulsoup4',
 ]
 
 if sys.version_info < (3, 5):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = [
     'Jinja2',
     'docopt',
     'six >= 1.4.0',
-    'mechanicalsoup',
+    'mechanicalsoup>=0.7',
 ]
 
 if sys.version_info < (3, 5):

--- a/src/pydap/cas/get_cookies.py
+++ b/src/pydap/cas/get_cookies.py
@@ -1,4 +1,5 @@
-import mechanicalsoup
+from bs4 import BeautifulSoup
+from six.moves.urllib.parse import urlsplit, urlunsplit
 import warnings
 import requests
 from requests.packages.urllib3.exceptions import (InsecureRequestWarning,
@@ -20,7 +21,7 @@ def setup_session(uri,
                   password_field='password'):
     '''
     A general function to set-up requests session with cookies
-    using mechanicalsoup and by calling the right url.
+    using beautifulsoup and by calling the right url.
     '''
 
     if session is None:
@@ -37,7 +38,6 @@ def setup_session(uri,
     if not verify:
         verify_flag = session.verify
         session.verify = False
-    br = mechanicalsoup.StatefulBrowser(session=session)
 
     if isinstance(uri, str):
         url = uri
@@ -70,19 +70,19 @@ def setup_session(uri,
                 warnings.filterwarnings("ignore",
                                         category=category)
 
-        response = mechanicalsoup_login(br, url, username, password,
-                                        username_field=username_field,
-                                        password_field=password_field)
+        response = soup_login(session, url, username, password,
+                              username_field=username_field,
+                              password_field=password_field)
 
         # If there are further security levels.
         # At the moment only used for CEDA OPENID:
         if (isinstance(full_url, list) and
            len(full_url) > 1):
             for url in full_url[1:]:
-                response = mechanicalsoup_login(br, response.url,
-                                                username, password,
-                                                username_field=username_field,
-                                                password_field=password_field)
+                response = soup_login(session, response.url,
+                                      username, password,
+                                      username_field=None,
+                                      password_field=None)
         response.close()
 
         if check_url:
@@ -106,69 +106,67 @@ def raise_if_form_exists(url, session):
 
     user_warning = ('Navigate to {0}, '.format(url) +
                     'login and follow instructions. '
-                    'It is likely that you have to perform some one-time'
+                    'It is likely that you have to perform some one-time '
                     'registration steps before acessing this data.')
 
-    # This is important for the python 2.6 build:
-    try:
-        from six.moves.html_parser import HTMLParseError
-    except ImportError:
-        # HTMLParseError is removed in Python 3.5. Since it can never be
-        # thrown in 3.5, we can just define our own class as a placeholder.
-        # *from bs4/builder/_htmlparser.py
-        class HTMLParseError(Exception):
-            pass
-
-    br = mechanicalsoup.StatefulBrowser(session=session)
-    try:
-        login_page = br.get(url)
-    except HTMLParseError:
-        # This is important for the python 2.6 build:
-        raise UserWarning(user_warning)
-
-    if ((hasattr(login_page, 'soup') and
-       len(login_page.soup.select('form')) > 0)):
+    resp = session.get(url)
+    soup = BeautifulSoup(resp.content, 'html5lib')
+    if len(soup.select('form')) > 0:
         raise UserWarning(user_warning)
 
 
-def mechanicalsoup_login(br, url, username, password,
-                         username_field='username',
-                         password_field='password'):
-    login_page = br.get(url)
+def soup_login(session, url, username, password,
+               username_field='username',
+               password_field='password'):
+    resp = session.get(url)
 
-    if not hasattr(login_page, 'soup'):
-        return login_page
+    soup = BeautifulSoup(resp.content, 'html5lib')
+    login_form = soup.select('form')[0]
+    
+    def get_to_url(current_url, to_url):
+        split_current = urlsplit(current_url)
+        split_to = urlsplit(to_url)
+        comb = [val2 if val1 == '' else val1
+                for val1, val2 in zip(split_to, split_current)]
+        return urlunsplit(comb)
+    to_url = get_to_url(resp.url, login_form.get('action'))
 
-    try:
-        login_form = login_page.soup.select('form')[0]
-    except IndexError:
-        # There are no login form.
-        # Assume that we are logged-in
-        return login_page
+    session.headers['Referer'] = resp.url
+    method = login_form.get('method')
 
-    try:
-        login_form.select('#' + username_field)[0]['value'] = username
-    except IndexError:
-        # There might not need a username (e.g. ESGF)
-        pass
+    payload = {}
+    if username_field is not None:
+        if len(login_form.findAll('input', {'name': username_field})) > 0:
+           payload.update({username_field: username})
 
-    try:
-        login_form.select('#' + password_field)[0]['value'] = password
-    except IndexError:
-        # If there is no password_field, it might be because
-        # something should be handled in the browser
-        # for the first attempt. This is common when using
-        # pydap with the ESGF for the first time.
-        raise Exception('Navigate to {0}. '
-                        'If you are unable to '
-                        'login, you must either '
-                        'wait or use authentication '
-                        'from another service.'
-                        .format(url))
+    if password_field is not None:
+        if len(login_form.findAll('input', {'name': password_field})) > 0:
+           payload.update({password_field: password})
+        else:
+            # If there is no password_field, it might be because
+            # something should be handled in the browser
+            # for the first attempt. This is common when using
+            # pydap with the ESGF for the first time.
+            raise Exception('Navigate to {0}. '
+                            'If you are unable to '
+                            'login, you must either '
+                            'wait or use authentication '
+                            'from another service.'
+                            .format(url))
+    
+    # Replicate all other fields:
+    for input in login_form.findAll('input'):
+        if (input.get('name') not in payload and
+           input.get('name') is not None):
+            payload.update({input.get('name'): input.get('value')})
 
-    # This is specific for CEDA OPENID:
-    try:
-        login_form.find("remember").items[0].selected = True
-    except AttributeError:
-        pass
-    return br.submit(login_form, login_page.url)
+    # Remove other submit fields:
+    submit_type = 'submit'
+    submit_names = [input.get('name') for input 
+                    in login_form.findAll('input', {'type': submit_type})]
+    for input in login_form.findAll('input', {'type': submit_type}):
+        if ('submit' in submit_names and
+           input.get('name').lower() != 'submit'):
+            payload.pop(input.get('name'), None)
+
+    return session.post(to_url, data=payload)

--- a/src/pydap/cas/get_cookies.py
+++ b/src/pydap/cas/get_cookies.py
@@ -152,7 +152,7 @@ def soup_login(session, url, username, password,
                             'wait or use authentication '
                             'from another service.'
                             .format(url))
-    
+
     # Replicate all other fields:
     for input in login_form.findAll('input'):
         if (input.get('name') not in payload and
@@ -161,7 +161,7 @@ def soup_login(session, url, username, password,
 
     # Remove other submit fields:
     submit_type = 'submit'
-    submit_names = [input.get('name') for input 
+    submit_names = [input.get('name') for input
                     in login_form.findAll('input', {'type': submit_type})]
     for input in login_form.findAll('input', {'type': submit_type}):
         if ('submit' in submit_names and

--- a/src/pydap/cas/get_cookies.py
+++ b/src/pydap/cas/get_cookies.py
@@ -122,7 +122,7 @@ def soup_login(session, url, username, password,
 
     soup = BeautifulSoup(resp.content, 'html5lib')
     login_form = soup.select('form')[0]
-    
+
     def get_to_url(current_url, to_url):
         split_current = urlsplit(current_url)
         split_to = urlsplit(to_url)
@@ -132,16 +132,15 @@ def soup_login(session, url, username, password,
     to_url = get_to_url(resp.url, login_form.get('action'))
 
     session.headers['Referer'] = resp.url
-    method = login_form.get('method')
 
     payload = {}
     if username_field is not None:
         if len(login_form.findAll('input', {'name': username_field})) > 0:
-           payload.update({username_field: username})
+            payload.update({username_field: username})
 
     if password_field is not None:
         if len(login_form.findAll('input', {'name': password_field})) > 0:
-           payload.update({password_field: password})
+            payload.update({password_field: password})
         else:
             # If there is no password_field, it might be because
             # something should be handled in the browser

--- a/src/pydap/cas/get_cookies.py
+++ b/src/pydap/cas/get_cookies.py
@@ -37,7 +37,7 @@ def setup_session(uri,
     if not verify:
         verify_flag = session.verify
         session.verify = False
-    br = mechanicalsoup.Browser(session=session)
+    br = mechanicalsoup.StatefulBrowser(session=session)
 
     if isinstance(uri, str):
         url = uri
@@ -53,7 +53,7 @@ def setup_session(uri,
         return session
 
     # Allow for several subsequent security layers:
-    full_url = copy.copy(uri)
+    full_url = copy.copy(url)
     if isinstance(full_url, list):
         url = full_url[0]
 
@@ -119,7 +119,7 @@ def raise_if_form_exists(url, session):
         class HTMLParseError(Exception):
             pass
 
-    br = mechanicalsoup.Browser(session=session)
+    br = mechanicalsoup.StatefulBrowser(session=session)
     try:
         login_page = br.get(url)
     except HTMLParseError:

--- a/src/pydap/tests/test_cas_esgf.py
+++ b/src/pydap/tests/test_cas_esgf.py
@@ -91,3 +91,25 @@ class TestESGF(unittest.TestCase):
                          [677.014, 628.29675, 551.06, 455.5758, 343.7354],
                          [1268.3304, 1287.9553, 1161.0402, 978.3153, 809.143]]
         assert(np.isclose(data, expected_data).all())
+
+
+    def test_variable_esgf_query_ceda(self):
+        assert(os.environ.get('OPENID_ESGF_CEDA'))
+        assert(os.environ.get('USERNAME_ESGF_CEDA'))
+        assert(os.environ.get('PASSWORD_ESGF_CEDA'))
+        session = esgf.setup_session(os.environ.get('OPENID_ESGF_CEDA'),
+                                     os.environ.get('PASSWORD_ESGF_CEDA'),
+                                     check_url=self.url,
+                                     username=os.environ.get('USERNAME_ESGF_CEDA'))
+        # Ensure authentication:
+        res = pydap.net.follow_redirect(self.test_url, session=session)
+        assert(res.status_code == 200)
+
+        dataset = open_url(self.url, session=session, output_grid=False)
+        data = dataset['orog'][50:55, 50:55]
+        expected_data = [[197.70425, 16.319595, 0.0, 0.0, 0.0],
+                         [0.0, 0.0, 0.0, 0.0, 0.0],
+                         [0.0, 0.0, 0.0, 0.0, 0.0],
+                         [677.014, 628.29675, 551.06, 455.5758, 343.7354],
+                         [1268.3304, 1287.9553, 1161.0402, 978.3153, 809.143]]
+        assert(np.isclose(data, expected_data).all())

--- a/src/pydap/tests/test_cas_esgf.py
+++ b/src/pydap/tests/test_cas_esgf.py
@@ -92,15 +92,15 @@ class TestESGF(unittest.TestCase):
                          [1268.3304, 1287.9553, 1161.0402, 978.3153, 809.143]]
         assert(np.isclose(data, expected_data).all())
 
-
     def test_variable_esgf_query_ceda(self):
         assert(os.environ.get('OPENID_ESGF_CEDA'))
         assert(os.environ.get('USERNAME_ESGF_CEDA'))
         assert(os.environ.get('PASSWORD_ESGF_CEDA'))
-        session = esgf.setup_session(os.environ.get('OPENID_ESGF_CEDA'),
-                                     os.environ.get('PASSWORD_ESGF_CEDA'),
-                                     check_url=self.url,
-                                     username=os.environ.get('USERNAME_ESGF_CEDA'))
+        session = esgf.setup_session(
+                        os.environ.get('OPENID_ESGF_CEDA'),
+                        os.environ.get('PASSWORD_ESGF_CEDA'),
+                        check_url=self.url,
+                        username=os.environ.get('USERNAME_ESGF_CEDA'))
         # Ensure authentication:
         res = pydap.net.follow_redirect(self.test_url, session=session)
         assert(res.status_code == 200)

--- a/src/pydap/tests/test_cas_esgf.py
+++ b/src/pydap/tests/test_cas_esgf.py
@@ -36,6 +36,7 @@ def test_registration_esgf_auth():
                            os.environ.get('PASSWORD_ESGF_NO_REG'),
                            check_url=url)
 
+
 @pytest.mark.auth
 @pytest.mark.prod_url
 @pytest.mark.skipif(not (os.environ.get('OPENID_ESGF') and

--- a/src/pydap/tests/test_cas_esgf.py
+++ b/src/pydap/tests/test_cas_esgf.py
@@ -4,112 +4,132 @@ from pydap.cas import esgf
 import requests
 import numpy as np
 import os
-from nose.plugins.attrib import attr
-import unittest
+import pytest
 
 
-@attr('auth')
-@attr('prod_url')
-class TestESGF(unittest.TestCase):
-    url = ('http://aims3.llnl.gov/thredds/dodsC/'
-           'cmip5_css02_data/cmip5/output1/CCCma/CanCM4/'
-           'decadal1995/fx/atmos/fx/r0i0p0/orog/1/'
-           'orog_fx_CanCM4_decadal1995_r0i0p0.nc')
-    test_url = url + '.dods?orog[0:1:4][0:1:4]'
+url = ('http://aims3.llnl.gov/thredds/dodsC/'
+       'cmip5_css02_data/cmip5/output1/CCCma/CanCM4/'
+       'decadal1995/fx/atmos/fx/r0i0p0/orog/1/'
+       'orog_fx_CanCM4_decadal1995_r0i0p0.nc')
+test_url = url + '.dods?orog[0:1:4][0:1:4]'
 
-    def test_registration_esgf_auth(self):
-        """
-        Attempt to access a ESGF OPENDAP link for which
-        the user has not yet selected a registration group.
-        This procedure has to be completed only once per project
-        over the lifetime of an ESGF OPENID
 
-        Requires OPENID_ESGF_NO_REG and PASSWORD_ESGF_NO_REG
-        environment variables. These must be associated with credentials
-        where no group was selected.
-        """
-        assert(os.environ.get('OPENID_ESGF_NO_REG'))
-        assert(os.environ.get('PASSWORD_ESGF_NO_REG'))
-        with self.assertRaises(UserWarning):
-            esgf.setup_session(os.environ.get('OPENID_ESGF_NO_REG'),
-                               os.environ.get('PASSWORD_ESGF_NO_REG'),
-                               check_url=self.url)
+@pytest.mark.auth
+@pytest.mark.prod_url
+@pytest.mark.skipif(not (os.environ.get('OPENID_ESGF_NO_REG') and
+                         os.environ.get('PASSWORD_ESGF_NO_REG')),
+                    reason=('Without auth credentials, '
+                            'this test cannot work'))
+def test_registration_esgf_auth():
+    """
+    Attempt to access a ESGF OPENDAP link for which
+    the user has not yet selected a registration group.
+    This procedure has to be completed only once per project
+    over the lifetime of an ESGF OPENID
 
-    def test_basic_esgf_auth(self):
-        """
-        Set up PyDAP to use the ESGF request() function.
+    Requires OPENID_ESGF_NO_REG and PASSWORD_ESGF_NO_REG
+    environment variables. These must be associated with credentials
+    where no group was selected.
+    """
+    with pytest.raises(UserWarning):
+        esgf.setup_session(os.environ.get('OPENID_ESGF_NO_REG'),
+                           os.environ.get('PASSWORD_ESGF_NO_REG'),
+                           check_url=url)
 
-        The intent here is to ensure that pydap.net is able to
-        open and url if and only if requests is able to
-        open the same url.
-        """
-        assert(os.environ.get('OPENID_ESGF'))
-        assert(os.environ.get('PASSWORD_ESGF'))
-        session = esgf.setup_session(os.environ.get('OPENID_ESGF'),
-                                     os.environ.get('PASSWORD_ESGF'),
-                                     check_url=self.url)
+@pytest.mark.auth
+@pytest.mark.prod_url
+@pytest.mark.skipif(not (os.environ.get('OPENID_ESGF') and
+                         os.environ.get('PASSWORD_ESGF')),
+                    reason=('Without auth credentials, '
+                            'this test cannot work'))
+def test_basic_esgf_auth():
+    """
+    Set up PyDAP to use the ESGF request() function.
 
-        res = requests.get(self.test_url, cookies=session.cookies,
-                           verify=False)
-        assert(res.status_code == 200)
-        res.close()
+    The intent here is to ensure that pydap.net is able to
+    open and url if and only if requests is able to
+    open the same url.
+    """
+    session = esgf.setup_session(os.environ.get('OPENID_ESGF'),
+                                 os.environ.get('PASSWORD_ESGF'),
+                                 check_url=url)
 
-        res = pydap.net.follow_redirect(self.test_url, session=session)
-        assert(res.status_code == 200)
+    res = requests.get(test_url, cookies=session.cookies,
+                       verify=False)
+    assert(res.status_code == 200)
+    res.close()
 
-    def test_dimension_esgf_query(self):
-        assert(os.environ.get('OPENID_ESGF'))
-        assert(os.environ.get('PASSWORD_ESGF'))
-        session = esgf.setup_session(os.environ.get('OPENID_ESGF'),
-                                     os.environ.get('PASSWORD_ESGF'),
-                                     check_url=self.url)
+    res = pydap.net.follow_redirect(test_url, session=session)
+    assert(res.status_code == 200)
 
-        # Ensure authentication:
-        res = pydap.net.follow_redirect(self.test_url, session=session)
-        assert(res.status_code == 200)
 
-        dataset = open_url(self.url, session=session)
-        data = dataset['lon'][:5]
-        expected_data = np.array([0.0, 2.8125, 5.625, 8.4375, 11.25])
-        assert(np.isclose(data, expected_data).all())
+@pytest.mark.auth
+@pytest.mark.prod_url
+@pytest.mark.skipif(not (os.environ.get('OPENID_ESGF') and
+                         os.environ.get('PASSWORD_ESGF')),
+                    reason=('Without auth credentials, '
+                            'this test cannot work'))
+def test_dimension_esgf_query():
+    session = esgf.setup_session(os.environ.get('OPENID_ESGF'),
+                                 os.environ.get('PASSWORD_ESGF'),
+                                 check_url=url)
 
-    def test_variable_esgf_query(self):
-        assert(os.environ.get('OPENID_ESGF'))
-        assert(os.environ.get('PASSWORD_ESGF'))
-        session = esgf.setup_session(os.environ.get('OPENID_ESGF'),
-                                     os.environ.get('PASSWORD_ESGF'),
-                                     check_url=self.url)
-        # Ensure authentication:
-        res = pydap.net.follow_redirect(self.test_url, session=session)
-        assert(res.status_code == 200)
+    # Ensure authentication:
+    res = pydap.net.follow_redirect(test_url, session=session)
+    assert(res.status_code == 200)
 
-        dataset = open_url(self.url, session=session, output_grid=False)
-        data = dataset['orog'][50:55, 50:55]
-        expected_data = [[197.70425, 16.319595, 0.0, 0.0, 0.0],
-                         [0.0, 0.0, 0.0, 0.0, 0.0],
-                         [0.0, 0.0, 0.0, 0.0, 0.0],
-                         [677.014, 628.29675, 551.06, 455.5758, 343.7354],
-                         [1268.3304, 1287.9553, 1161.0402, 978.3153, 809.143]]
-        assert(np.isclose(data, expected_data).all())
+    dataset = open_url(url, session=session)
+    data = dataset['lon'][:5]
+    expected_data = np.array([0.0, 2.8125, 5.625, 8.4375, 11.25])
+    assert(np.isclose(data, expected_data).all())
 
-    def test_variable_esgf_query_ceda(self):
-        assert(os.environ.get('OPENID_ESGF_CEDA'))
-        assert(os.environ.get('USERNAME_ESGF_CEDA'))
-        assert(os.environ.get('PASSWORD_ESGF_CEDA'))
-        session = esgf.setup_session(
-                        os.environ.get('OPENID_ESGF_CEDA'),
-                        os.environ.get('PASSWORD_ESGF_CEDA'),
-                        check_url=self.url,
-                        username=os.environ.get('USERNAME_ESGF_CEDA'))
-        # Ensure authentication:
-        res = pydap.net.follow_redirect(self.test_url, session=session)
-        assert(res.status_code == 200)
 
-        dataset = open_url(self.url, session=session, output_grid=False)
-        data = dataset['orog'][50:55, 50:55]
-        expected_data = [[197.70425, 16.319595, 0.0, 0.0, 0.0],
-                         [0.0, 0.0, 0.0, 0.0, 0.0],
-                         [0.0, 0.0, 0.0, 0.0, 0.0],
-                         [677.014, 628.29675, 551.06, 455.5758, 343.7354],
-                         [1268.3304, 1287.9553, 1161.0402, 978.3153, 809.143]]
-        assert(np.isclose(data, expected_data).all())
+@pytest.mark.auth
+@pytest.mark.prod_url
+@pytest.mark.skipif(not (os.environ.get('OPENID_ESGF') and
+                         os.environ.get('PASSWORD_ESGF')),
+                    reason=('Without auth credentials, '
+                            'this test cannot work'))
+def test_variable_esgf_query():
+    session = esgf.setup_session(os.environ.get('OPENID_ESGF'),
+                                 os.environ.get('PASSWORD_ESGF'),
+                                 check_url=url)
+    # Ensure authentication:
+    res = pydap.net.follow_redirect(test_url, session=session)
+    assert(res.status_code == 200)
+
+    dataset = open_url(url, session=session, output_grid=False)
+    data = dataset['orog'][50:55, 50:55]
+    expected_data = [[197.70425, 16.319595, 0.0, 0.0, 0.0],
+                     [0.0, 0.0, 0.0, 0.0, 0.0],
+                     [0.0, 0.0, 0.0, 0.0, 0.0],
+                     [677.014, 628.29675, 551.06, 455.5758, 343.7354],
+                     [1268.3304, 1287.9553, 1161.0402, 978.3153, 809.143]]
+    assert(np.isclose(data, expected_data).all())
+
+
+@pytest.mark.auth
+@pytest.mark.prod_url
+@pytest.mark.skipif(not (os.environ.get('OPENID_ESGF_CEDA') and
+                         os.environ.get('USERNAME_ESGF_CEDA') and
+                         os.environ.get('PASSWORD_ESGF_CEDA')),
+                    reason=('Without auth credentials, '
+                            'this test cannot work'))
+def test_variable_esgf_query_ceda():
+    session = esgf.setup_session(
+                    os.environ.get('OPENID_ESGF_CEDA'),
+                    os.environ.get('PASSWORD_ESGF_CEDA'),
+                    check_url=url,
+                    username=os.environ.get('USERNAME_ESGF_CEDA'))
+    # Ensure authentication:
+    res = pydap.net.follow_redirect(test_url, session=session)
+    assert(res.status_code == 200)
+
+    dataset = open_url(url, session=session, output_grid=False)
+    data = dataset['orog'][50:55, 50:55]
+    expected_data = [[197.70425, 16.319595, 0.0, 0.0, 0.0],
+                     [0.0, 0.0, 0.0, 0.0, 0.0],
+                     [0.0, 0.0, 0.0, 0.0, 0.0],
+                     [677.014, 628.29675, 551.06, 455.5758, 343.7354],
+                     [1268.3304, 1287.9553, 1161.0402, 978.3153, 809.143]]
+    assert(np.isclose(data, expected_data).all())

--- a/src/pydap/tests/test_cas_urs.py
+++ b/src/pydap/tests/test_cas_urs.py
@@ -4,8 +4,6 @@ import pydap.net
 import requests
 import os
 import pytest
-from nose.plugins.attrib import attr
-import unittest
 
 
 url = ('https://goldsmr3.gesdisc.eosdis.nasa.gov/opendap/'

--- a/src/pydap/tests/test_cas_urs.py
+++ b/src/pydap/tests/test_cas_urs.py
@@ -3,66 +3,74 @@ from pydap.cas import urs
 import pydap.net
 import requests
 import os
+import pytest
 from nose.plugins.attrib import attr
 import unittest
 
 
-@attr('auth')
-@attr('prod_url')
-class TestUrs(unittest.TestCase):
-    url = ('https://goldsmr3.gesdisc.eosdis.nasa.gov/opendap/'
-           'MERRA_MONTHLY/MAIMCPASM.5.2.0/1979/'
-           'MERRA100.prod.assim.instM_3d_asm_Cp.197901.hdf')
-    test_url = url + '.dods?SLP[0:1:0][0:1:10][0:1:10]'
-    test_url_2 = url + '.dods?PS[0:1:0][0:1:10][0:1:10]'
+url = ('https://goldsmr3.gesdisc.eosdis.nasa.gov/opendap/'
+       'MERRA_MONTHLY/MAIMCPASM.5.2.0/1979/'
+       'MERRA100.prod.assim.instM_3d_asm_Cp.197901.hdf')
+test_url = url + '.dods?SLP[0:1:0][0:1:10][0:1:10]'
+test_url_2 = url + '.dods?PS[0:1:0][0:1:10][0:1:10]'
 
-    def test_basic_urs_auth(self):
-        """
-        Set up PyDAP to use the URS request() function.
 
-        The intent here is to ensure that pydap.net is able to
-        open and url if and only if requests is able to
-        open the same url.
-        """
-        assert(os.environ.get('USERNAME_URS'))
-        assert(os.environ.get('PASSWORD_URS'))
-        session = urs.setup_session(os.environ.get('USERNAME_URS'),
-                                    os.environ.get('PASSWORD_URS'),
-                                    check_url=self.url)
+@pytest.mark.auth
+@pytest.mark.prod_url
+@pytest.mark.skipif(not (os.environ.get('USERNAME_URS') and
+                         os.environ.get('PASSWORD_URS')),
+                    reason=('Without auth credentials, '
+                            'this test cannot work'))
+def test_basic_urs_auth():
+    """
+    Set up PyDAP to use the URS request() function.
 
-        # Check that the requests library can access the link:
-        res = requests.get(self.test_url, cookies=session.cookies)
-        assert(res.status_code == 200)
-        res.close()
+    The intent here is to ensure that pydap.net is able to
+    open and url if and only if requests is able to
+    open the same url.
+    """
+    session = urs.setup_session(os.environ.get('USERNAME_URS'),
+                                os.environ.get('PASSWORD_URS'),
+                                check_url=url)
 
-        # Check that the pydap library can access the link:
-        res = pydap.net.follow_redirect(self.test_url, session=session)
-        assert(res.status_code == 200)
+    # Check that the requests library can access the link:
+    res = requests.get(test_url, cookies=session.cookies)
+    assert(res.status_code == 200)
+    res.close()
 
-        # Check that the pydap library can access another link:
-        res = pydap.net.follow_redirect(self.test_url_2, session=session)
-        assert(res.status_code == 200)
-        session.close()
+    # Check that the pydap library can access the link:
+    res = pydap.net.follow_redirect(test_url, session=session)
+    assert(res.status_code == 200)
 
-    def test_basic_urs_query(self):
-        assert(os.environ.get('USERNAME_URS'))
-        assert(os.environ.get('PASSWORD_URS'))
-        session = urs.setup_session(os.environ.get('USERNAME_URS'),
-                                    os.environ.get('PASSWORD_URS'),
-                                    check_url=self.url)
-        # Ensure authentication:
-        res = pydap.net.follow_redirect(self.test_url, session=session)
-        assert(res.status_code == 200)
-        dataset = open_url(self.url, session=session)
-        expected_data = [[[99066.15625, 99066.15625, 99066.15625,
-                           99066.15625, 99066.15625],
-                          [98868.15625, 98870.15625, 98872.15625,
-                           98874.15625, 98874.15625],
-                          [98798.15625, 98810.15625, 98820.15625,
-                           98832.15625, 98844.15625],
-                          [98856.15625, 98828.15625, 98756.15625,
-                           98710.15625, 98776.15625],
-                          [99070.15625, 99098.15625, 99048.15625,
-                           98984.15625, 99032.15625]]]
-        assert((dataset['SLP'][0, :5, :5] == expected_data).all())
-        session.close()
+    # Check that the pydap library can access another link:
+    res = pydap.net.follow_redirect(test_url_2, session=session)
+    assert(res.status_code == 200)
+    session.close()
+
+
+@pytest.mark.auth
+@pytest.mark.prod_url
+@pytest.mark.skipif(not (os.environ.get('USERNAME_URS') and
+                         os.environ.get('PASSWORD_URS')),
+                    reason=('Without auth credentials, '
+                            'this test cannot work'))
+def test_basic_urs_query():
+    session = urs.setup_session(os.environ.get('USERNAME_URS'),
+                                os.environ.get('PASSWORD_URS'),
+                                check_url=url)
+    # Ensure authentication:
+    res = pydap.net.follow_redirect(test_url, session=session)
+    assert(res.status_code == 200)
+    dataset = open_url(url, session=session)
+    expected_data = [[[99066.15625, 99066.15625, 99066.15625,
+                       99066.15625, 99066.15625],
+                      [98868.15625, 98870.15625, 98872.15625,
+                       98874.15625, 98874.15625],
+                      [98798.15625, 98810.15625, 98820.15625,
+                       98832.15625, 98844.15625],
+                      [98856.15625, 98828.15625, 98756.15625,
+                       98710.15625, 98776.15625],
+                      [99070.15625, 99098.15625, 99048.15625,
+                       98984.15625, 99032.15625]]]
+    assert((dataset['SLP'][0, :5, :5] == expected_data).all())
+    session.close()


### PR DESCRIPTION
This PR fixes the authentication scheme to ensure that CEDA openids are working. It also includes a test to prevent regressions.

This fix replaces the ``mechanicalsoup`` dependency with ``beautifulsoup4``. I think this is for the best since ``beautifulsoup4`` is a generally better maintained package.