### PR TITLE
Hot fix to ensure that CEDA openid fix is working

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = [
     'Jinja2',
     'docopt',
     'six >= 1.4.0',
-    'beautifulsoup4',
+    'beautifulsoup4'
 ]
 
 if sys.version_info < (3, 5):
@@ -32,7 +32,7 @@ docs_extras = [
 
 cas_extras = [
     'requests',
-    'html5lib'
+    'lmxl'
     ]
 
 hdl_netcdf_extras = [

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ docs_extras = [
 ]
 
 cas_extras = [
-    'requests'
+    'requests',
+    'html5lib'
     ]
 
 hdl_netcdf_extras = [

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ tests_require = (functions_extras + cas_extras + server_extras +
                  hdl_netcdf_extras +
                  ['WebTest',
                   'beautifulsoup4',
-                  'scipy',
                   'flake8'])
 
 testing_extras = tests_require + [

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ docs_extras = [
 
 cas_extras = [
     'requests',
-    'lmxl'
+    'lxml'
     ]
 
 hdl_netcdf_extras = [

--- a/src/pydap/cas/get_cookies.py
+++ b/src/pydap/cas/get_cookies.py
@@ -110,7 +110,7 @@ def raise_if_form_exists(url, session):
                     'registration steps before acessing this data.')
 
     resp = session.get(url)
-    soup = BeautifulSoup(resp.content, 'html5lib')
+    soup = BeautifulSoup(resp.content, 'lxml')
     if len(soup.select('form')) > 0:
         raise UserWarning(user_warning)
 
@@ -120,7 +120,7 @@ def soup_login(session, url, username, password,
                password_field='password'):
     resp = session.get(url)
 
-    soup = BeautifulSoup(resp.content, 'html5lib')
+    soup = BeautifulSoup(resp.content, 'lxml')
     login_form = soup.select('form')[0]
 
     def get_to_url(current_url, to_url):


### PR DESCRIPTION
This PR fixes #102. It switches ``html5lib`` to ``lxml`` parser and adds ``lxml`` as a dependency in ``setup.py``. This PR also removes ``scipy`` from dependencies. It must have been re-added by mistake (#90).