### PR TITLE
Do not require mock for Python 3.3 or later

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,11 +51,12 @@ testing_extras = tests_require + [
     'pytest>=2.8',
     'pytest-cov',
     'pytest-attrib',
-    'mock',
     'requests-mock',
     'requests'
 ]
 
+if sys.version_info < (3, 3):
+    testing_extras.append('mock')
 
 setup(name='Pydap',
       version=__version__,


### PR DESCRIPTION
`unittest.mock` is available since Python 3.3