### PR TITLE
add failing test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - 3.4
     - 3.5
     - 3.6
+
 addons:
   apt:
       packages:
@@ -13,6 +14,9 @@ addons:
       - netcdf-bin
       - libnetcdf-dev
 install:
+    # Workaround pip not properly pulling this version for netCDF4.
+    # See https://github.com/Unidata/netcdf4-python/pull/666#issuecomment-306219617
+    - pip install cython>=0.19
     - pip install -e .[testing,functions,server,tests]
 
 script:

--- a/src/pydap/tests/test_live_servers.py
+++ b/src/pydap/tests/test_live_servers.py
@@ -1,0 +1,9 @@
+from pydap.client import open_url
+from pydap.model import DatasetType
+
+url = 'http://geoport-dev.whoi.edu/thredds/dodsC/estofs/atlantic'
+
+
+def test_open():
+    dataset = open_url(url)
+    assert(isinstance(dataset, DatasetType))


### PR DESCRIPTION
This PR adds a test that passes with `pydap 3.2.1` but fails with `pydap 3.2.2`. Not sure what caused the regression and there is no need to merge this PR if the devs don't want to test against a live server that may not be always available. I only sent this to make it easier to debug in case someone have the time to bisect the last few PRs.