### PR TITLE
simplify HTML

### DIFF
--- a/src/pydap/responses/html/__init__.py
+++ b/src/pydap/responses/html/__init__.py
@@ -64,6 +64,7 @@ class HTMLResponse(BaseResponse):
             "location": req.path_url,
             "breadcrumbs": breadcrumbs,
             "dataset": self.dataset,
+            "dataurl": req.path_url.replace('.html', ''),
             "version": __version__,
         }
 

--- a/src/pydap/responses/html/templates/html.html
+++ b/src/pydap/responses/html/templates/html.html
@@ -4,33 +4,29 @@
 {% block title %}Dataset {{ location }}{% endblock %}
 
 {% block breadcrumbs %}
-<ul>
-    {% for crumb in breadcrumbs[:-1] %}
-    <li itemscope itemtype="http://data-vocabulary.org/Breadcrumb">
-    <a itemprop="url" href="{{ crumb.url }}/"><span itemprop="title">{{ crumb.title }}</span></a>
-    </li>
-    <li><i class="icon-angle-right"></i></li>                                              
+<p>
+    <span itemscope itemtype="http://data-vocabulary.org/Breadcrumb">
+        <a itemprop="url" href="{{ root }}"><span itemprop="title">Home</span></a>
+    </span>
+    {% for crumb in breadcrumbs %}
+    /<span itemscope itemtype="http://data-vocabulary.org/Breadcrumb">
+        <a itemprop="url" href="{{ crumb.url }}/"><span itemprop="title">{{ crumb.title }}</span></a>
+    </span>
     {% endfor %}
-    {% if breadcrumbs %}
-    <li itemscope itemtype="http://data-vocabulary.org/Breadcrumb" class="pure-menu-selected">
-    <a itemprop="url" href="{{ breadcrumbs[-1].url }}"><span itemprop="title">{{ breadcrumbs[-1].title[:-5] }}</span></a>
-    </li>
-    {% endif %}
-</ul>
+</p>
 {% endblock %}
 
 {% block content %}
-<div class="form">
-    <form class="pure-form pure-form-aligned" action="{{ location }}" method="POST">
-        <button type="submit" class="pure-button pure-button-submit">
-            <i class="icon-download-alt"></i>
-            Download data
-        </button>
+<div>
+    <form action="{{ location }}" method="POST">
+        <button type="submit">Download data</button>
+        <p>
+        <label for="dataset.url">
+            Data URL: <input name="dataset.url" id="dataset.url" type="text" value="{{ dataurl }}" size="50" readonly/>
+        </label>
+        </p>
         {{ dispatch(dataset) }}
-        <button type="submit" class="pure-button pure-button-submit">
-            <i class="icon-download-alt"></i>
-            Download data
-        </button>
+        <button type="submit">Download data</button>
     </form>
 </div>
 {% endblock %}

--- a/src/pydap/responses/html/templates/html.html
+++ b/src/pydap/responses/html/templates/html.html
@@ -26,7 +26,7 @@
         </label>
         </p>
         {{ dispatch(dataset) }}
-        <button type="submit">Download data</button>
+        <button type="submit">Download data</button><button type="reset">Reset</button>
     </form>
 </div>
 {% endblock %}

--- a/src/pydap/responses/html/templates/macros.html
+++ b/src/pydap/responses/html/templates/macros.html
@@ -1,9 +1,7 @@
 {% macro dispatch(var) %}
-<h2>{{ var.id|unquote }}</h2>
-
 {% if var.__class__.__name__ == "GridType" %}
 <label for="{{ var.id }}" class="pure-checkbox">
-    <input name="{{ var.id }}" id="{{ var.id }}" type="checkbox" value="on">
+    <input name="{{ var.id }}" id="{{ var.id }}" type="checkbox" value="on"/>
     Download this variable
 </label>
 
@@ -11,19 +9,20 @@
 
 <fieldset>
     {% for name in var.maps %}
-    <div class="pure-control-group">
+    <div>
         <label for="{{ var.id }}[{{ loop.index0 }}]">{{ name }}</label>
+        (start:step:stop):
         <input
             id="{{ var.id }}[{{ loop.index0 }}]"
             type="text"
-            placeholder="0:1:{{ var[name].shape[0]-1 }}">
+            placeholder="0:1:{{ var[name].shape[0]-1 }}"/>
     </div>
     {% endfor %}
 </fieldset>
 
 {% elif var.__class__.__name__ == "BaseType" %}
-<label for="{{ var.id }}" class="pure-checkbox">
-    <input name="{{ var.id }}" id="{{ var.id }}" type="checkbox" value="on">
+<label for="{{ var.id }}">
+    <input name="{{ var.id }}" id="{{ var.id }}" type="checkbox" value="on"/>
     Download this variable
 </label>
 
@@ -31,16 +30,17 @@
 
 {% if var.shape %}
 <fieldset>
-    <div class="pure-control-group">
+    <div>
         {% for shp in var.shape %}
         <label for="{{ var.id }}[{{ loop.index0 }}]">{{ var.name }}[{{ loop.index0 }}]</label>
         {% if shp > 0 %}
+        (start:step:stop):
         <input
             id="{{ var.id }}[{{ loop.index0 }}]"
             type="text"
             placeholder="0:1:{{ shp - 1 }}">
         {% else %}
-        <input id="{{ var.id }}[{{ loop.index0 }}]" type="text" value="0" readonly>
+        <input id="{{ var.id }}[{{ loop.index0 }}]" type="text" value="0" readonly/>
         {% endif %}
         {% endfor %}
     </div>
@@ -51,7 +51,7 @@
 {{ attributes(var.attributes) }}
 
 <fieldset>
-    Filter where
+    Filter where:
     <select name="var1_{{ var.id }}" id="var1_{{ var.id }}">
         <option value="--" selected>--</option>
         {% for child in var.children() %}
@@ -67,8 +67,8 @@
         <option value="%3E%3D">≥</option>
         <option value="%3D%7E">≈</option>
     </select>
-    <input type="text" name="var2_{{ var.id }}" id="var2_{{ var.id }}" value="">
-<fieldset>
+    <input type="text" name="var2_{{ var.id }}" id="var2_{{ var.id }}" value=""/>
+</fieldset>
 
 {% for child in var.children() %}
 {{ dispatch(child) }}
@@ -92,14 +92,14 @@
     <dt>{{ k }}</dt>
     {% if v is mapping %}
     <dd>
-    <div class="nested">
+    <div>
     {{ attributes(v) }}
     </div>
     </dd>
     {% elif v is sequence and not v is string %}
-    <dd class="value">{{ v|join(", ") }}</dd>
+    <dd>{{ v|join(", ") }}</dd>
     {% else %}
-    <dd class="value">{{ v }}</dd>
+    <dd>{{ v }}</dd>
     {% endif %}
     {% endfor %}
 </dl>

--- a/src/pydap/tests/test_responses_html.py
+++ b/src/pydap/tests/test_responses_html.py
@@ -44,7 +44,7 @@ class TestHTMLResponseSequence(unittest.TestCase):
                 ('XDODS-Server', 'pydap/' + __version__),
                 ('Content-description', 'dods_form'),
                 ('Content-type', 'text/html; charset=utf-8'),
-                ('Content-Length', '5215')]))
+                ('Content-Length', '5747')]))
 
     def test_body(self):
         """Test the HTML response.

--- a/src/pydap/tests/test_responses_html.py
+++ b/src/pydap/tests/test_responses_html.py
@@ -44,7 +44,7 @@ class TestHTMLResponseSequence(unittest.TestCase):
                 ('XDODS-Server', 'pydap/' + __version__),
                 ('Content-description', 'dods_form'),
                 ('Content-type', 'text/html; charset=utf-8'),
-                ('Content-Length', '5747')]))
+                ('Content-Length', '5829')]))
 
     def test_body(self):
         """Test the HTML response.

--- a/src/pydap/wsgi/templates/base.html
+++ b/src/pydap/wsgi/templates/base.html
@@ -4,40 +4,68 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{% block title %}{% endblock %}</title>
-
-        <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.2.0/pure-min.css">
-        <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.2.0/base-min.css">
-        <link href="//netdna.bootstrapcdn.com/font-awesome/3.2.0/css/font-awesome.css" rel="stylesheet">
-        <link rel="stylesheet" href="/static/style.css">
+        <style type="text/css">
+           body {
+                background-color: #ffffff;
+                font-family: arial, verdana, sans-serif;
+                text-align: left;
+                float: left;
+            }
+            .flat {
+                border: 0px;
+            }
+            header {
+                display: inline-block;
+            }
+            table {
+                border-width: 1px;
+                border-spacing: 0px;
+                border-style: solid;
+                border-color: black;
+                border-collapse: collapse;
+                background-color: white;
+                width: 100%;
+            }
+            table th {
+                border-width: 1px;
+                padding: 5px;
+                border-style: solid;
+                border-color: gray;
+                background-color: white;
+            }
+            table td {
+                border-width: 1px;
+                padding: 5px;
+                border-style: solid;
+                border-color: gray;
+                background-color: white;
+            }
+            .header-img {
+                float: left;
+            }
+        </style>
     </head>
     <body>
-        <div class="content pure-g-r">
-            <div class="header pure-u-1">
-                <div class="pure-menu pure-menu-open pure-menu-fixed pure-menu-horizontal">
-                    <a class="pure-menu-heading" href="{{ root }}">Home</a>
+        <header>
+            <h1>OPeNDAP <img class="header-img" src="https://www.opendap.org/sites/default/files/OPeNDAP-meatball.png" alt="OPeNDAP" title="OPeNDAP" width="90" height="90"/></h1>
+        </header>
+        <div>
+            <div class="header">
+                <div>
                     {% block breadcrumbs %}{% endblock %}
                 </div>
             </div>
-            <div class="content pure-u-1">
+            <div>
                 {% block content %}{% endblock %}
             </div>
-            <div class="footer pure-u-1">
-                {% block footer %}                                                              
+            <footer>
                 <p itemscope itemtype="http://schema.org/WebApplication">                       
-                <a itemprop="url" href="http://pydap.org/"><span itemprop="name">Pydap</span> <span itemprop="softwareVersion">{{ version }}</span></a>, released under the <a href="http://opensource.org/licenses/MIT">MIT license</a> (c) 2003&ndash;2013 <a href="https://www.gittip.com/robertodealmeida/">Roberto De Almeida</a>.
+                    <a itemprop="url" href="http://pydap.org/"><span itemprop="name">Pydap</span> <span itemprop="softwareVersion">{{ version }}</span></a>, released under the <a href="http://opensource.org/licenses/MIT">MIT license</a> (c) 2003&ndash;2013 <a href="https://www.gittip.com/robertodealmeida/">Roberto De Almeida</a>.
                 </p>                                                                            
-                {% endblock %}
-            </div>
+                <hr>
+                <a href="http://validator.w3.org/check?verbose=1&amp;uri=referer" title="Valid HTML 5!"><img class="flat" src="http://www.w3.org/html/logo/downloads/HTML5_Badge_32.png" alt="Valid HTML 5!" height="32" width="32"/></a>
+                <a href="http://jigsaw.w3.org/css-validator/check/referer" title="Valid CSS!"><img class="flat" src="http://jigsaw.w3.org/css-validator/images/vcss-blue" alt="Valid CSS!" height="31" width="88"/></a>
+            </footer>
         </div>
-        <script src="http://yui.yahooapis.com/3.10.1/build/yui/yui-min.js"></script>
-        <script>
-            YUI().use('node-base', 'node-event-delegate', function (Y) {
-                // This just makes sure that the href="#" attached to the anchor elements
-                // don't scroll you back up the page.
-                Y.one('.content').delegate('click', function (e) {
-                    e.preventDefault();
-                }, 'a[href="#"]');
-            });
-        </script>
     </body>
 </html>

--- a/src/pydap/wsgi/templates/index.html
+++ b/src/pydap/wsgi/templates/index.html
@@ -1,62 +1,65 @@
 {% extends "base.html" %}
 
-{% block title %}Index of {{ location }}{% endblock %}
+{% block title %}OPeNDAP Pydap: Index of {{ location }}{% endblock %}
 
 {% block breadcrumbs %}
-<ul>
-    {% for crumb in breadcrumbs[:-1] %}
-    <li itemscope itemtype="http://data-vocabulary.org/Breadcrumb">
-    <a itemprop="url" href="{{ crumb.url }}/"><span itemprop="title">{{ crumb.title }}</span></a>
-    </li>
-    <li><i class="icon-angle-right"></i></li>                                             
-    {% endfor %}
-    {% if breadcrumbs %}
-    <li itemscope itemtype="http://data-vocabulary.org/Breadcrumb" class="pure-menu-selected">
-    <a itemprop="url" href="{{ breadcrumbs[-1].url }}/"><span itemprop="title">{{ breadcrumbs[-1].title }}</span></a>
-    </li>
-    {% endif %}
-</ul>
+    <p>
+        <span itemscope itemtype="http://data-vocabulary.org/Breadcrumb">
+            <a itemprop="url" href="{{ root }}"><span itemprop="title">Home</span></a>
+        </span>
+        {% for crumb in breadcrumbs %}
+        /<span itemscope itemtype="http://data-vocabulary.org/Breadcrumb">
+            <a itemprop="url" href="{{ crumb.url }}/"><span itemprop="title">{{ crumb.title }}</span></a>
+        </span>
+        {% endfor %}
+    </p>
 {% endblock %}
 
 {% block content %}
-<table class="pure-table pydap-listing">
+<table>
     <thead>
         <tr>
             <th>Name</th>
             <th>Size</th>
             <th>Last modified</th>
+            <th>DAP Response Links</th>
         </tr>
     </thead>
 
     <tbody>
+        {% if breadcrumbs %}
+        <tr>
+            <td><a href="..">..</a></td>
+            <td>&ndash;</td>
+            <td>&ndash;</td>
+            <td>&ndash;</td>
+        </tr>
+        {% endif %}
         {% for directory in directories %}
         <tr>
-            <td><i class="icon-folder-close icon-fixed-width"></i> <a href="{{ directory.name }}/">{{ directory.name }}/</a></td>
+            <td><a href="{{ directory.name }}/">{{ directory.name }}/</a></td>
             <td>&ndash;</td>
             <td>{{ directory.last_modified|datetimeformat }}</td>
+            <td>&ndash;</td>
         </tr>
         {% endfor %}
         {% for file in files %}
         <tr>
             {% if file.supported %}
-            <td><i class="icon-globe icon-fixed-width"></i>
-            <a title="Inspect and filter data" href="{{ file.name }}.html">{{ file.name }}</a>
-            <span class="dap">
-            <a title="View the DDS response" href="{{ file.name }}.dds">dds</a> |
-            <a title="View the DAS response" href="{{ file.name }}.das">das</a>
-            </span>
-            </td>
+            <td><a title="Inspect and filter data" href="{{ file.name }}.html">{{ file.name }}</a></td>
             {% elif file.name.endswith(".html") %}
-            <td><i class="icon-file icon-fixed-width"></i>
-            <a href="{{ file.name }}">{{ file.name }}</a>
+            <td><a href="{{ file.name }}">{{ file.name }}</a>
             </td>
             {% else %}
-            <td><i class="icon-file icon-fixed-width"></i>
-            {{ file.name }}
-            </td>
+            <td>{{ file.name }}</td>
             {% endif %}
             <td><a title="Download file" href="{{ file.name }}">{{ file.size|filesizeformat}}</a></td>
             <td>{{ file.last_modified|datetimeformat }}</td>
+            {% if file.supported %}
+            <td><a title="View the DDS response" href="{{ file.name }}.dds">dds</a> | <a title="View the DAS response" href="{{ file.name }}.das">das</a></td>
+            {% else %}
+            <td>&ndash;</td>
+            {% endif %}
         </tr>
         {% endfor %}
     </tbody>

--- a/src/pydap/wsgi/templates/static/style.css
+++ b/src/pydap/wsgi/templates/static/style.css
@@ -1,116 +1,39 @@
 body {
-    font-size: 86%;
-    margin: 0 auto;
-    line-height: 1.7em;
+    background-color: #ffffff;
+    font-family: arial, verdana, sans-serif;
+    text-align: left;
+    float: left;
 }
-
-a, .pure-menu a {
-    color: #15c;
+.flat {
+    border: 0px;
 }
-
-.header {
-    margin: 0 0;
-}
-
-    .header .pure-menu {
-        padding: 0.5em;
-    }
-
-        .header .pure-menu li a:hover,
-        .header .pure-menu li a:focus {
-            background: none;
-            border: none;
-        }
-
-.content {
-    margin-top: 3.5em;
-}
-
-.footer {
-    background: #111;
-    color: #666;
-    text-align: center;
-    padding: 0.5em;
-    font-size: 80%;
-}
-
-    .footer a {
-        color: #888;
-    }
-
-.icon-fixed-width {
-    width: 1.28571429em;
+header {
     display: inline-block;
-    text-align: center;
 }
-
-.pydap-listing {
-    margin: 0;
-    width: 100%;
+table {
+    border-width: 2px;
+    border-spacing: 0px;
+    border-style: solid;
+    border-color: black;
+    border-collapse: collapse;
+    background-color: white;
 }
-
-.dap, .dap a {
-    color: #aaa;
-    font-size: 90%;
-    visibility: hidden;
+    table th {
+    border-width: 4px;
+    padding: 5px;
+    border-style: solid;
+    border-color: gray;
+    background-color: white;
 }
-
-tbody tr {
-    border-left: 4px solid #fff;
+    table td {
+    border-width: 4px;
+    padding: 5px;
+    border-style: solid;
+    border-color: gray;
+    background-color: white;
 }
-tbody tr:hover {
-    border-left: 4px solid #15c;
-}
-tbody tr:hover td {
-    background-color: #fafafa;
-}
-tbody tr:hover td .dap,
-tbody tr:hover td .dap a {
-    visibility: visible;
-}
-
-div.attributes {
-    font-size: 90%;
-}
-
-dl {
-    padding-top: 1.65em;
-}
-
-dt {
-    width: 9em;
-    text-align: right;
-    color: #999;
-    overflow: hidden;
-}
-dd {
-    position: relative;
-    margin: -1.65em 0 0 10em;
-}
-
-dd.value {
-    white-space: pre;
-}
-
-div.form {
-    padding: 1.0em;
-}
-
-div.nested {
-    margin-left: -8em;
-    clear: left;
-}
-
-fieldset {
-    clear: left;
-}
-
-.pure-button-submit {
-    color: white;
-    border-radius: 4px;
-    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
-}
-
-.pure-button-submit {
-    background: rgb(28, 184, 65); /* this is a green */
+.header-img {
+    float: left;
+    margin: 0px 15px 15px 0px;
+    border: 0;
 }


### PR DESCRIPTION
This PR simplifies the HTML as follows:

- HTML is fully valid
- CSS is fully valid
- outbound dependencies (fontawesome, YUI) dropped to allow for baseline install without external web dependency requirements (TODO: manage requirements as packaging within codebase instead)
- breadcrumbs updated
- data url download field added to response page
- added OPeNDAP logo to page headers
- show parent directory as required