### PR TITLE
Trap IndexErrors in StructureType._getitem_string, when attempting to apply a split string.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ tests_require = (functions_extras + cas_extras + server_extras +
                  hdl_netcdf_extras +
                  ['WebTest',
                   'beautifulsoup4',
-                  'flake8'])
+                  'flake8 < 3.5.0'])
 
 testing_extras = tests_require + [
     'pytest>=2.8',

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -408,7 +408,7 @@ class StructureType(DapType, Mapping):
             if len(splitted) > 1:
                 try:
                     return self[splitted[0]]['.'.join(splitted[1:])]
-                except KeyError:
+                except (KeyError,IndexError):
                     return self['.'.join(splitted[1:])]
             else:
                 raise

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -408,7 +408,7 @@ class StructureType(DapType, Mapping):
             if len(splitted) > 1:
                 try:
                     return self[splitted[0]]['.'.join(splitted[1:])]
-                except (KeyError,IndexError):
+                except (KeyError, IndexError):
                     return self['.'.join(splitted[1:])]
             else:
                 raise


### PR DESCRIPTION
Seems to fix issue #150, hopefully for the right reasons.  I'm not an expert on the code base, so a review by a more knowledgeable person would be appreciated.