### PR TITLE
Fix gzip compression (#126)

### DIFF
--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -23,8 +23,11 @@ def GET(url, application=None, session=None, timeout=DEFAULT_TIMEOUT):
         _, _, path, query, fragment = urlsplit(url)
         url = urlunsplit(('', '', path, query, fragment))
 
-    return follow_redirect(url, application=application, session=session,
-                           timeout=timeout)
+    response = follow_redirect(url, application=application, session=session,
+                               timeout=timeout)
+    # Decode request response (i.e. gzip)
+    response.decode_content()
+    return response
 
 
 def raise_for_status(response):


### PR DESCRIPTION
I had o problem loading data from the Global Forecast System (GFS). It raised a UnicodeDecodeError exception, which after a while I figured out it happens because the data is gzipped. I came up with a solution modifying the `GET` function in the `net` module, adding `response.decode_content()`.