### PR TITLE
Fix bad link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This will install Pydap together with all the required dependencies. You can now
                8.10000002e-01]]], dtype=float32), array([ 366.]), array([-69., -67., -65., -63.]), array([ 41.,  43.,  45.,  47.])]
 ```
 
-For more information, please check the documentation on [using Pydap as a client](http://pydap.readthedocs.io/en/latest/server.html). Pydap also comes with a simple server, implemented as a [WSGI]( http://wsgi.org/) application. To use it, you first need to install the server and optionally a data handler:
+For more information, please check the documentation on [using Pydap as a client](http://pydap.readthedocs.io/en/latest/client.html). Pydap also comes with a simple server, implemented as a [WSGI]( http://wsgi.org/) application. To use it, you first need to install the server and optionally a data handler:
 
 ```bash
 


### PR DESCRIPTION
The README linked to http://pydap.readthedocs.io/en/latest/server.html when it should have linked to http://pydap.readthedocs.io/en/latest/client.html.