### PR TITLE
add netcdf handler entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,9 @@ setup(name='pydap',
       },
       test_suite="pydap.tests",
       entry_points="""
+            [pydap.handler]
+            nc = pydap.handlers.netcdf:NetCDFHandler
+
             [pydap.response]
             das = pydap.responses.das:DASResponse
             dds = pydap.responses.dds:DDSResponse


### PR DESCRIPTION
This is the simple fix recommended by @jblarsen  in https://github.com/pydap/pydap/issues/129#issue-238923262.

fixes #129
fixes #165
 
Basically, it seems like the netcdf handler entry point was not being installed by `setup.py`. So when `load_handlers()` gets called (https://github.com/pydap/pydap/blob/master/src/pydap/handlers/lib.py#L43), no netcdf handler was being found. Consequently, when I tried to run a server
```
pydap --data /path/with/netcdf/files
```
The netcdf files were not being handled correctly.

Contrary to what the [docs say](http://pydap.org/en/latest/handlers.html#installing-data-handlers), the following does not seem to properly set up the entry point:
```
$ pip install Pydap[handlers.netcdf]
```
I just get
```
Requirement already satisfied: Pydap[handlers.netcdf] in ./src (3.2.2)
```

Evidently this situation is not covered by the test suite. I wonder if an integration test involving running the command-line app would be useful.