### PR TITLE
`sudo` is no longer needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 
-sudo: required
-
 dist: xenial
 
 python:


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Follow on from https://github.com/pydap/pydap/pull/192