### PR TITLE
fix decode issue when UTF-8 Characters are used in data-resources met…

### DIFF
--- a/src/pydap/responses/das.py
+++ b/src/pydap/responses/das.py
@@ -45,7 +45,7 @@ class DASResponse(BaseResponse):
         for line in das(self.dataset):
             try:
                 yield line.encode('ascii')
-            except:
+            except UnicodeDecodeError:
                 yield line.encode('UTF-8')
 
 

--- a/src/pydap/responses/das.py
+++ b/src/pydap/responses/das.py
@@ -43,7 +43,10 @@ class DASResponse(BaseResponse):
 
     def __iter__(self):
         for line in das(self.dataset):
-            yield line.encode('ascii')
+            try:
+                yield line.encode('ascii')
+            except:
+                yield line.encode('UTF-8')
 
 
 @singledispatch


### PR DESCRIPTION
 fixing `pydap.das` response when attempting to serve netcdf data that includes UTF-8 characters in its metadata.
[Example NetCDF](https://github.com/epifanio/pydap/blob/master/docker_test/SN99938.nc), **Note:** pydap requires [this fix in `webob`](https://github.com/epifanio/webob/commit/22c8c80059ab8b828e227956348ca21dc99c508b) to properly serve the example file provided. Probably the error is the way how pydap uses `webob`, but aftyer few attempts, I wasn't able to fix this on `pydap` side.
