### PR TITLE
Import ABC from collections.abc instead of collections for Python 3 compatibility

### DIFF
--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -170,9 +170,10 @@ therefore highly recommended.
 import operator
 import copy
 from six.moves import reduce, map
+from six.moves.collections_abc import Mapping
 from six import string_types
 import numpy as np
-from collections import OrderedDict, Mapping
+from collections import OrderedDict
 import warnings
 
 from .lib import quote, decode_np_strings

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -170,11 +170,15 @@ therefore highly recommended.
 import operator
 import copy
 from six.moves import reduce, map
-from six.moves.collections_abc import Mapping
 from six import string_types
 import numpy as np
 from collections import OrderedDict
 import warnings
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 from .lib import quote, decode_np_strings
 

--- a/src/pydap/responses/das.py
+++ b/src/pydap/responses/das.py
@@ -11,10 +11,10 @@ try:
     from functools import singledispatch
 except ImportError:
     from singledispatch import singledispatch
-from collections import Iterable
 
 from six import string_types, integer_types
 from six.moves import map
+from six.moves.collections_abc import Iterable
 
 import numpy as np
 

--- a/src/pydap/responses/das.py
+++ b/src/pydap/responses/das.py
@@ -12,9 +12,13 @@ try:
 except ImportError:
     from singledispatch import singledispatch
 
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
+
 from six import string_types, integer_types
 from six.moves import map
-from six.moves.collections_abc import Iterable
 
 import numpy as np
 

--- a/src/pydap/tests/test_model.py
+++ b/src/pydap/tests/test_model.py
@@ -176,7 +176,7 @@ def test_StructureType_init():
 def test_StructureType_instance():
     """Test that it is a Mapping and DapType."""
     var = StructureType("var")
-    from collections import Mapping
+    from six.moves.collections_abc import Mapping
     assert isinstance(var, Mapping)
     assert isinstance(var, DapType)
 

--- a/src/pydap/tests/test_model.py
+++ b/src/pydap/tests/test_model.py
@@ -176,7 +176,10 @@ def test_StructureType_init():
 def test_StructureType_instance():
     """Test that it is a Mapping and DapType."""
     var = StructureType("var")
-    from six.moves.collections_abc import Mapping
+    try:
+        from collections.abc import Mapping
+    except ImportError:
+        from collections import Mapping
     assert isinstance(var, Mapping)
     assert isinstance(var, DapType)
 


### PR DESCRIPTION
Fixes #203 