### PR TITLE
WIP: add user_charset arg

### DIFF
--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -56,7 +56,7 @@ from .parsers.das import parse_das, add_attributes
 
 
 def open_url(url, application=None, session=None, output_grid=True,
-             timeout=DEFAULT_TIMEOUT, verify=True, default_charset='ascii'):
+             timeout=DEFAULT_TIMEOUT, verify=True, user_charset='ascii'):
     """
     Open a remote URL, returning a dataset.
 
@@ -65,7 +65,7 @@ def open_url(url, application=None, session=None, output_grid=True,
     """
     dataset = DAPHandler(url, application, session, output_grid,
                          timeout=timeout, verify=verify,
-                         default_charset='ascii').dataset
+                         user_charset=user_charset).dataset
 
     # attach server-side functions
     dataset.functions = Functions(url, application, session)


### PR DESCRIPTION
Follows on from https://github.com/pydap/pydap/issues/196

I believe in https://github.com/pydap/pydap/pull/222 the charset arg (named `default_charset`) had a default value in the functions (`get_charset` and `safe_charset_text`) which weren't getting overridden in the high level `__init__` args.

Hence
```
from pydap.client import open_url
url = "https://thredds.ucar.edu/thredds/dodsC/grib/NCEP/GFS/Global_0p25deg/GFS_Global_0p25deg_20210914_0600.grib2"
dataset = open_url(url)
dataset = open_url(url, default_charset="utf-8")
```
both give
```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 15683: ordinal not in range(128)
```

and the current traceback
```
>>> dataset = open_url(url, default_charset="utf-8")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ray/miniconda3/envs/test_env/lib/python3.9/site-packages/pydap/client.py", line 66, in open_url
    dataset = DAPHandler(url, application, session, output_grid,
  File "/Users/ray/miniconda3/envs/test_env/lib/python3.9/site-packages/pydap/handlers/dap.py", line 63, in __init__
    das = safe_charset_text(r, default_charset)
  File "/Users/ray/miniconda3/envs/test_env/lib/python3.9/site-packages/pydap/handlers/dap.py", line 117, in safe_charset_text
    return r.text
  File "/Users/ray/miniconda3/envs/test_env/lib/python3.9/site-packages/webob/response.py", line 622, in _text__get
    return body.decode(decoding, self.unicode_errors)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 15683: ordinal not in range(128)
```
