### PR TITLE
Import ABC from collections.abc instead of collections for Python 3 compatibility

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.x', '3.7', '3.8', '3.9', '3.10' ]
-    name: Python ${{ matrix.python-version }} sample
+    name: Python ${{ matrix.python-version }} 
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.x', 'pypy-3.7', 'pypy-3.8' ]
+        python-version: [ '3.x', '3.7', '3.8', '3.9', '3.10', '3.11' ]
     name: Python ${{ matrix.python-version }} sample
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.x', '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.x', '3.6', '3.7', '3.8', '3.9' ]
     name: Python ${{ matrix.python-version }} 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.x', '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.x', '3.7', '3.8', '3.9', '3.10' ]
     name: Python ${{ matrix.python-version }} sample
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,6 +10,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.x', 'pypy-3.7', 'pypy-3.8' ]
+    name: Python ${{ matrix.python-version }} sample
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.x', '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.x', '3.6', '3.7', '3.8', '3.9', '3.10' ]
     name: Python ${{ matrix.python-version }} 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Python 3
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           pip3 install -U pip setuptools

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -172,9 +172,12 @@ import copy
 from six.moves import reduce, map
 from six import string_types
 import numpy as np
-from collections import OrderedDict, Mapping
+from collections import OrderedDict
 import warnings
-
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 from .lib import quote, decode_np_strings
 
 

--- a/src/pydap/responses/das.py
+++ b/src/pydap/responses/das.py
@@ -11,8 +11,10 @@ try:
     from functools import singledispatch
 except ImportError:
     from singledispatch import singledispatch
-from collections import Iterable
-
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from six import string_types, integer_types
 from six.moves import map
 

--- a/src/pydap/tests/test_model.py
+++ b/src/pydap/tests/test_model.py
@@ -176,7 +176,10 @@ def test_StructureType_init():
 def test_StructureType_instance():
     """Test that it is a Mapping and DapType."""
     var = StructureType("var")
-    from collections import Mapping
+    try:
+       from collections.abc import Mapping
+    except ImportError:
+       from collections import Mapping
     assert isinstance(var, Mapping)
     assert isinstance(var, DapType)
 


### PR DESCRIPTION
Fixes #203 

Import ABC from collections.abc instead of collections for Python 3 compatibility.

This is the same as #210. Resubmitting it as a new PR to get GitHub actions CI to run on it.