### PR TITLE
fixed pytest warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,9 @@
 [pytest]
 addopts = --doctest-modules --doctest-glob='*.rst'
 doctest_optionflags= NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE ALLOW_BYTES
+markers =
+    server
+    client
+    prod_url
+    good_url
+    auth


### PR DESCRIPTION
Fixes #245 

Fix warnings by registering our custom pytest test markers.