### PR TITLE
DAP4/DAS Patch

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.x', '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.x', '3.9', '3.10', '3.11' ]
     name: ubuntu-latest Python ${{ matrix.python-version }} 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.x', '3.6', '3.7', '3.8', '3.9' ]
+        python-version: [ '3.x', '3.7', '3.8', '3.9', '3.10', '3.11' ]
     name: ubuntu-latest Python ${{ matrix.python-version }} 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,16 +17,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 3
+        if: success() || failure()
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
+        if: success() || failure()
         run: |
           pip3 install -U pip setuptools
           pip3 install -U "werkzeug<2.1"
           pip3 install -U numpy webtest gsw coards
           pip3 install -U netCDF4 pytest numpy Webob Jinja2 docopt six beautifulsoup4 requests testresources
       - name: Run tests with pytest
+        if: success() || failure()
         run: |
           pip install -e .[tests,netcdf,client]
           pytest 

--- a/.github/workflows/python_macos.yml
+++ b/.github/workflows/python_macos.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [ '3.7' ]
+        python-version: [ '3.8' ]
     name: macos-latest Python ${{ matrix.python-version }} 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python_macos.yml
+++ b/.github/workflows/python_macos.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [ '3.8' ]
+        python-version: [ '3.10' ]
     name: macos-latest Python ${{ matrix.python-version }} 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python_macos.yml
+++ b/.github/workflows/python_macos.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [ '3.11' ]
+        python-version: [ '3.7' ]
     name: macos-latest Python ${{ matrix.python-version }} 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python_macos.yml
+++ b/.github/workflows/python_macos.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [ '3.10' ]
+        python-version: [ '3.11' ]
     name: macos-latest Python ${{ matrix.python-version }} 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python_macos.yml
+++ b/.github/workflows/python_macos.yml
@@ -17,19 +17,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 3
+        if: success() || failure()
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
       - name: install hdf5
+        if: success() || failure()
         run: |
           brew install hdf5
       - name: Install dependencies
+        if: success() || failure()
         run: |
           pip3 install -U pip setuptools
           pip3 install -U "werkzeug<2.1"
           pip3 install -U numpy webtest gsw coards
           pip3 install -U netCDF4 pytest numpy Webob Jinja2 docopt six beautifulsoup4 requests testresources
       - name: Run tests with pytest
+        if: success() || failure()
         run: |
           pip install -e .[tests,netcdf,client]
           pytest 

--- a/.github/workflows/python_macos.yml
+++ b/.github/workflows/python_macos.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [ '3.9' ]
+        python-version: [ '3.7' ]
     name: macos-latest Python ${{ matrix.python-version }} 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python_macos.yml
+++ b/.github/workflows/python_macos.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [ '3.7' ]
+        python-version: [ '3.9' ]
     name: macos-latest Python ${{ matrix.python-version }} 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ nosetests.xml
 __pycache__
 /src/pydap/tests/dap_4_access/user.config
 /src/pydap/tests/dap_4_access/dap4_access_test.log
+
+# OS-X Finder
+*.DS_Store
+
+# IDEA Projects
+.idea

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -94,7 +94,7 @@ class DAPHandler(pydap.handlers.lib.BaseHandler):
             self.dataset_from_dap4()
         else:
             self.dataset_from_dap2()
-        self.attach_das()
+            self.attach_das()
 
     def dataset_from_dap4(self):
         dmr_url = six.moves.urllib.parse.urlunsplit((self.scheme, self.netloc, self.path + '.dmr', self.query, self.fragment))

--- a/src/pydap/tests/test_responses_error.py
+++ b/src/pydap/tests/test_responses_error.py
@@ -43,4 +43,3 @@ class TestErrorResponse(unittest.TestCase):
 )?ZeroDivisionError:( integer)? division( or modulo)? by zero
 ";
 }""")
-

--- a/src/pydap/tests/test_responses_error.py
+++ b/src/pydap/tests/test_responses_error.py
@@ -38,7 +38,8 @@ class TestErrorResponse(unittest.TestCase):
     code = -1;
     message = "Traceback \(most recent call last\):
   File .*
-    1/0
+    1\/0
+    \~\^\~
 ZeroDivisionError:( integer)? division( or modulo)? by zero
 ";
 }""")

--- a/src/pydap/tests/test_responses_error.py
+++ b/src/pydap/tests/test_responses_error.py
@@ -39,7 +39,7 @@ class TestErrorResponse(unittest.TestCase):
     message = "Traceback \(most recent call last\):
   File .*
     1\/0
-    \~\^\~
-ZeroDivisionError:( integer)? division( or modulo)? by zero
+(    \~\^\~
+)?ZeroDivisionError:( integer)? division( or modulo)? by zero
 ";
 }""")

--- a/src/pydap/tests/test_responses_error.py
+++ b/src/pydap/tests/test_responses_error.py
@@ -43,3 +43,4 @@ class TestErrorResponse(unittest.TestCase):
 )?ZeroDivisionError:( integer)? division( or modulo)? by zero
 ";
 }""")
+


### PR DESCRIPTION
Fixing a typo that was causing the client to attempt to build a DAS in a DAP4 context.

This PR also drops testing for Python 3.6, 3.7, and 3.8. The OS-X tests remain at 3.7 , to be sorted another day.

Some baseline regex had to be updated for newer Python behavior.