### PR TITLE
Hackfest addendum

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -28,6 +28,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+      - name: Ensure setuptools, wheel and twine are new enough for Markdown
+        run: python3 -m pip install --upgrade setuptools wheel twine
       - name: Install Python build package
         run: python -m pip install --upgrade build
       - name: Generate source and built distribution

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Install Python build package
         run: python -m pip install --upgrade build
       - name: Generate source and built distribution

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import io
 import os
+from pathlib import Path
 import re
 from setuptools import setup, find_packages
 import sys
@@ -81,10 +82,15 @@ def get_package_version():
     raise RuntimeError('Unable to find version string.')
 
 
+def get_long_description():
+    """ Return contents of README.md as the long_description. """
+    return (Path(__file__).parent / "README.md" ).read_text()
+
+
 setup(name='pydap',
       version=get_package_version(),
       description="An implementation of the Data Access Protocol.",
-      long_description="",
+      long_description=get_long_description(),
       classifiers=[
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(name='pydap',
       version=get_package_version(),
       description="An implementation of the Data Access Protocol.",
       long_description=get_long_description(),
+      long_description_content_type='text/markdown',
       classifiers=[
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
This PR fixes a couple of things that were overlooked (and not really testable) in the previous PR for the workflow to publish to PyPI:

* The `python_version` in the `setup-python` action needed to be a string.
* PyPI didn't like the format of the `long_description`. This required ensuring new enough versions of some dependencies and then also specifically telling `setup.py` that the `long_description` was Markdown content type.

This workflow has now successfully run, so [pydap==3.4.0](https://pypi.org/project/pydap/) is now available. :tada: