### PR TITLE
Version bump for release 3.4.1

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,22 +5,29 @@ pydap contributors (sorted alphabetically)
 
 * Aleksandar Jelenak
 * Amanda Yoshiizumi  
+* [Anthony Baxter](anthonybaxter)
 * Beto Dealmeida, Roberto De Almeida
 * Christian Skarby  
 * Daniel Gray
 * Danny  
 * Edward Hartnett  
+* [Fedor Baart](https://github.com/SiggyF)
+* [Filipe Fernandes](https://github.com/ocefpaf)
 * Frédéric Laliberté  
 * Ghislain Antony Vaillant  
 * Hugo  
 * James Gallagher  
 * James Hiebert  
+* [Jonas Gliß](https://github.com/jgliss)
 * Juan Luis Cano Rodríguez  
 * Lewis John McGibbney
+* [Massimo Di Stefano](epifanio)
 * Michael Bunsen  
 * Mike McCann
+* [Nathan Carlson](nathanlcarlson)
 * Nathan Potter  
 * Niklas Griessbaum
+* [Owen Littlejohns](https://github.com/owenlittlejohns)
 * Ray Bell  
 * Rich Signell  
 * Ryan Abernathey  
@@ -30,8 +37,3 @@ pydap contributors (sorted alphabetically)
 * Tobias Kölling  
 * Tom Kralidis  
 * Will Holmgren  
-* [SiggyF](https://github.com/SiggyF)
-* [ocefpaf](https://github.com/ocefpaf)
-* anthonybaxter  
-* epifanio  
-* nathanlcarlson  

--- a/src/pydap/__init__.py
+++ b/src/pydap/__init__.py
@@ -3,4 +3,4 @@ Declare the namespace ``pydap`` here.
 '''
 __import__('pkg_resources').declare_namespace(__name__)
 
-__version__ = '3.4.0'
+__version__ = '3.4.1'


### PR DESCRIPTION
This PR updates the version as tracked in `src/pydap/__init__.py`, which is used when publishing to PyPI. It also updates `CONTRIBUTORS.md` to include myself and @jgliss, as well as organises the list back to being alphabetical.