### PR TITLE
Clean up test workflows.

### DIFF
--- a/.github/workflows/run_tests_macos.yml
+++ b/.github/workflows/run_tests_macos.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [ '3.x', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.7' ]
     name: macos-latest Python ${{ matrix.python-version }} 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run_tests_macos.yml
+++ b/.github/workflows/run_tests_macos.yml
@@ -1,4 +1,4 @@
-name: Run Python Tests
+name: Run Python Tests on MacOS
 on:
   push:
     branches:
@@ -9,30 +9,27 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix:
         python-version: [ '3.x', '3.9', '3.10', '3.11' ]
-    name: ubuntu-latest Python ${{ matrix.python-version }} 
+    name: macos-latest Python ${{ matrix.python-version }} 
     steps:
       - uses: actions/checkout@v3
       - name: Install Python 3
-        # if: success() || failure() removed jhrg 5/19/23
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        if: success() || failure()
+      - name: install hdf5
         run: |
-          python -m pip install --upgrade pip
+          brew install hdf5
+      - name: Install dependencies
+        run: |
           pip3 install -U pip setuptools
-          pip3 install -U "werkzeug>=2.2.2" cryptography
+          pip3 install -U "werkzeug<2.1"
           pip3 install -U numpy webtest gsw coards
           pip3 install -U netCDF4 pytest numpy Webob Jinja2 docopt six beautifulsoup4 requests testresources
       - name: Run tests with pytest
-        if: success() || failure()
         run: |
           pip install -e .[tests,netcdf,client]
-      - name: Run tests with pytest
-        run: |
-          pytest
+          pytest 

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -1,4 +1,4 @@
-name: Run Python Tests on MacOS
+name: Run Python Tests
 on:
   push:
     branches:
@@ -9,31 +9,27 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7' ]
-    name: macos-latest Python ${{ matrix.python-version }} 
+        python-version: [ '3.x', '3.9', '3.10', '3.11' ]
+    name: ubuntu-latest Python ${{ matrix.python-version }} 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Python 3
-        if: success() || failure()
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: install hdf5
-        if: success() || failure()
-        run: |
-          brew install hdf5
       - name: Install dependencies
-        if: success() || failure()
         run: |
+          python -m pip install --upgrade pip
           pip3 install -U pip setuptools
-          pip3 install -U "werkzeug<2.1"
+          pip3 install -U "werkzeug>=2.2.2" cryptography
           pip3 install -U numpy webtest gsw coards
           pip3 install -U netCDF4 pytest numpy Webob Jinja2 docopt six beautifulsoup4 requests testresources
       - name: Run tests with pytest
-        if: success() || failure()
         run: |
           pip install -e .[tests,netcdf,client]
-          pytest 
+      - name: Run tests with pytest
+        run: |
+          pytest


### PR DESCRIPTION
This PR makes a few really small changes to the GitHub workflows that run tests:

* Renames the files containing the workflows:
  * `python.yml` becomes `run_tests_ubuntu.yml`.
  * `python_macos.yml` becomes `run_tests_macos.yml`.
* The following condition has been removed from several workflow steps: `if: success() || failure()`. This would force a step to run even if a preceding step failed. These workflows install packages that must be successfully installed for the tests to run, so the later steps should not run on failure (I _think_).
* ~~Updating the MacOS Python versions that the tests run on to align with the Ubuntu workflow.~~ I reverted this change as the tests fail on 3.8+. I'll try and determine why in a later PR.

I did also consider trying to consolidate the workflows into a single file, but saw the MacOS workflow has an additional step. To keep things trucking along, I stuck with a simpler PR.