### PR TITLE
Remove unused `pyOpenSSL` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,7 @@ tests_extras = [
     'requests-mock',
     'WebTest',
     'flake8',
-    'werkzeug',
-    'pyopenssl']
+    'werkzeug']
 
 
 testing_extras = (functions_extras + cas_extras + server_extras +


### PR DESCRIPTION
`pyOpenSSL` does not seem to be used anywhere in the codebase. This PR removes it from the testing dependencies.