### PR TITLE
Iss303

### DIFF
--- a/.github/workflows/run_tests_macos.yml
+++ b/.github/workflows/run_tests_macos.yml
@@ -28,7 +28,7 @@ jobs:
           pip3 install -U pip setuptools
           pip3 install -U "werkzeug<2.1"
           pip3 install -U numpy webtest gsw coards
-          pip3 install -U netCDF4 pytest numpy Webob Jinja2 docopt six beautifulsoup4 requests testresources
+          pip3 install -U netCDF4 pytest numpy Webob Jinja2 docopt-ng beautifulsoup4 requests testresources
       - name: Run tests with pytest
         run: |
           pip install -e .[tests,netcdf,client]

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -26,7 +26,7 @@ jobs:
           pip3 install -U pip setuptools
           pip3 install -U "werkzeug>=2.2.2" cryptography
           pip3 install -U numpy webtest gsw coards
-          pip3 install -U netCDF4 pytest numpy Webob Jinja2 docopt six beautifulsoup4 requests testresources
+          pip3 install -U netCDF4 pytest numpy Webob Jinja2 docopt-ng beautifulsoup4 requests testresources
       - name: Run tests with pytest
         run: |
           pip install -e .[tests,netcdf,client]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ install_requires = [
     'Webob',
     'Jinja2',
     'docopt-ng',
-    'six >= 1.4.0',
     'beautifulsoup4',
     'requests'
 ]

--- a/src/pydap/cas/esgf.py
+++ b/src/pydap/cas/esgf.py
@@ -1,4 +1,4 @@
-from six.moves.urllib.parse import quote_plus
+from urllib.parse import quote_plus
 from . import get_cookies
 
 

--- a/src/pydap/cas/get_cookies.py
+++ b/src/pydap/cas/get_cookies.py
@@ -1,5 +1,6 @@
 from bs4 import BeautifulSoup
-from six.moves.urllib.parse import urlsplit, urlunsplit
+from requests.utils import urlparse, urlunparse
+
 import warnings
 import requests
 from requests.packages.urllib3.exceptions import (InsecureRequestWarning,
@@ -124,11 +125,11 @@ def soup_login(session, url, username, password,
     login_form = soup.select('form')[0]
 
     def get_to_url(current_url, to_url):
-        split_current = urlsplit(current_url)
-        split_to = urlsplit(to_url)
+        split_current = urlparse(current_url)
+        split_to = urlparse(to_url)
         comb = [val2 if val1 == '' else val1
                 for val1, val2 in zip(split_to, split_current)]
-        return urlunsplit(comb)
+        return urlunparse(comb)
     to_url = get_to_url(resp.url, login_form.get('action'))
 
     session.headers['Referer'] = resp.url

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -45,7 +45,7 @@ lazy mechanism for function call, supporting any function. Eg, to call the
 """
 
 from io import open, BytesIO
-from six.moves.urllib.parse import urlsplit, urlunsplit
+from requests.utils import urlparse, urlunparse
 
 import pydap.model
 import pydap.lib
@@ -179,8 +179,8 @@ def open_dods_url(url, metadata=False, application=None, session=None,
     dataset.data = pydap.handlers.dap.unpack_dap2_data(stream, dataset)
 
     if metadata:
-        scheme, netloc, path, query, fragment = urlsplit(url)
-        dasurl = urlunsplit((scheme, netloc, path[:-4] + 'das', query, fragment))
+        scheme, netloc, path, params, query, fragment = urlparse(url)
+        dasurl = urlunparse((scheme, netloc, path[:-4] + 'das', params, query, fragment))
         r = pydap.net.GET(dasurl, application, session, timeout=timeout, verify=verify)
         pydap.net.raise_for_status(r)
         das = pydap.parsers.das.parse_das(r.text)
@@ -239,8 +239,8 @@ class ServerFunctionResult(object):
         self.session = session
         self.timeout = timeout
 
-        scheme, netloc, path, query, fragment = urlsplit(baseurl)
-        self.url = urlunsplit((scheme, netloc, path + '.dods', id_, None))
+        scheme, netloc, path, params, query, fragment = urlparse(baseurl)
+        self.url = urlunparse((scheme, netloc, path + '.dods', params, id_, None))
 
     def __getitem__(self, key):
         if self.dataset is None:

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -20,7 +20,7 @@ from numpy.lib.arrayterator import Arrayterator
 import logging
 import numpy
 from requests.utils import urlparse, urlunparse, quote
-from six import BytesIO
+from io import BytesIO
 
 import pydap.model
 

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -20,7 +20,7 @@ from numpy.lib.arrayterator import Arrayterator
 import logging
 import numpy
 from requests.utils import urlparse, urlunparse, quote
-from six import text_type, string_types, BytesIO
+from six import text_type, BytesIO
 
 import pydap.model
 
@@ -376,7 +376,7 @@ class SequenceProxy(object):
         out = copy.copy(self)
 
         # return the data for a children
-        if isinstance(key, string_types):
+        if isinstance(key, str):
             out.template = out.template[key]
 
         # return a new object with requested columns

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -20,7 +20,7 @@ from numpy.lib.arrayterator import Arrayterator
 import logging
 import numpy
 from requests.utils import urlparse, urlunparse, quote
-from six import text_type, BytesIO
+from six import BytesIO
 
 import pydap.model
 
@@ -529,7 +529,7 @@ def convert_stream_to_list(stream, parser_dtype, shape, id):
                 k = numpy.frombuffer(stream.read(4), DAP2_ARRAY_LENGTH_NUMPY_TYPE)[0]
                 data.append(stream.read(k))
                 stream.read(-k % 4)
-            out.append(numpy.array([text_type(x.decode('ascii')) for x in data], 'S').reshape(shape))
+            out.append(numpy.array([str(x.decode('ascii')) for x in data], 'S').reshape(shape))
         else:
             stream.read(4)  # read additional length
             try:
@@ -555,7 +555,7 @@ def convert_stream_to_list(stream, parser_dtype, shape, id):
         # response_dtype.char should never be
         # 'U'
         k = numpy.frombuffer(stream.read(4), DAP2_ARRAY_LENGTH_NUMPY_TYPE)[0]
-        out.append(text_type(stream.read(k).decode('ascii')))
+        out.append(str(stream.read(k).decode('ascii')))
         stream.read(-k % 4)
     # usual data
     else:

--- a/src/pydap/handlers/lib.py
+++ b/src/pydap/handlers/lib.py
@@ -20,7 +20,7 @@ from webob import Request
 import pkg_resources
 from numpy.lib.arrayterator import Arrayterator
 from six.moves import filter, map
-from six import string_types, next
+from six import next
 
 from ..responses.lib import load_responses
 from ..responses.error import ErrorResponse
@@ -350,7 +350,7 @@ class IterData(object):
 
         # return a child, and adjust the data so that only the corresponding
         # column is returned
-        if isinstance(key, string_types):
+        if isinstance(key, str):
             try:
                 col = list(self.template._all_keys()).index(key)
             except ValueError:

--- a/src/pydap/handlers/lib.py
+++ b/src/pydap/handlers/lib.py
@@ -19,7 +19,6 @@ import numpy as np
 from webob import Request
 import pkg_resources
 from numpy.lib.arrayterator import Arrayterator
-from six.moves import filter
 
 from ..responses.lib import load_responses
 from ..responses.error import ErrorResponse

--- a/src/pydap/handlers/lib.py
+++ b/src/pydap/handlers/lib.py
@@ -19,7 +19,7 @@ import numpy as np
 from webob import Request
 import pkg_resources
 from numpy.lib.arrayterator import Arrayterator
-from six.moves import filter, map
+from six.moves import filter
 from six import next
 
 from ..responses.lib import load_responses

--- a/src/pydap/handlers/lib.py
+++ b/src/pydap/handlers/lib.py
@@ -20,7 +20,6 @@ from webob import Request
 import pkg_resources
 from numpy.lib.arrayterator import Arrayterator
 from six.moves import filter
-from six import next
 
 from ..responses.lib import load_responses
 from ..responses.error import ErrorResponse

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -6,7 +6,7 @@ from pkg_resources import get_distribution
 from requests.utils import quote as quote_
 from functools import reduce
 from itertools import zip_longest
-from six import binary_type, MAXSIZE, string_types
+from six import binary_type, MAXSIZE
 
 from .exceptions import ConstraintExpressionError
 
@@ -145,7 +145,7 @@ def encode(obj):
     """Return an object encoded to its DAP representation."""
     # fix for Python 3.5, where strings are being encoded as numbers
     if (
-            isinstance(obj, string_types) or
+            isinstance(obj, str) or
             isinstance(obj, np.ndarray) and obj.dtype.char in 'SU'
     ):
         return '"{0}"'.format(obj)

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -6,7 +6,7 @@ from pkg_resources import get_distribution
 from requests.utils import quote as quote_
 from functools import reduce
 from itertools import zip_longest
-from six import binary_type, MAXSIZE
+from sys import maxsize as MAXSIZE
 
 from .exceptions import ConstraintExpressionError
 
@@ -300,7 +300,7 @@ def get_var(dataset, id_):
 
 def decode_np_strings(numpy_var):
     """Given a fixed-width numpy string, decode it to a unicode type"""
-    if isinstance(numpy_var, binary_type) and hasattr(numpy_var, 'tobytes'):
+    if isinstance(numpy_var, bytes) and hasattr(numpy_var, 'tobytes'):
         return numpy_var.tobytes().decode('utf-8')
     else:
         return numpy_var

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -3,8 +3,9 @@ import operator
 
 import numpy as np
 from pkg_resources import get_distribution
-from six.moves.urllib.parse import quote as quote_
-from six.moves import reduce, zip_longest
+from requests.utils import quote as quote_
+from functools import reduce
+from itertools import zip_longest
 from six import binary_type, MAXSIZE, string_types
 
 from .exceptions import ConstraintExpressionError

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -171,7 +171,6 @@ import operator
 import copy
 from six.moves import map
 from functools import reduce
-from six import string_types
 import numpy as np
 from collections import OrderedDict
 import warnings
@@ -425,9 +424,9 @@ class StructureType(DapType, Mapping):
         return out
 
     def __getitem__(self, key):
-        if isinstance(key, string_types):
+        if isinstance(key, str):
             return self._getitem_string(key)
-        elif isinstance(key, tuple) and all(isinstance(name, string_types) for name in key):
+        elif isinstance(key, tuple) and all(isinstance(name, str) for name in key):
             out = copy.copy(self)
             out._visible_keys = list(key)
             return out
@@ -681,7 +680,7 @@ class SequenceType(StructureType):
 
     def __getitem__(self, key):
         # If key is a string, return child with the corresponding data.
-        if isinstance(key, string_types):
+        if isinstance(key, str):
             return self._getitem_string(key)
 
         # If it's a tuple, return a new `SequenceType` with selected children.
@@ -723,11 +722,11 @@ class GridType(StructureType):
 
     def __getitem__(self, key):
         # Return a child.
-        if isinstance(key, string_types):
+        if isinstance(key, str):
             return self._getitem_string(key)
 
         # Return a new `GridType` with part of the data.
-        elif isinstance(key, tuple) and all(isinstance(name, string_types) for name in key):
+        elif isinstance(key, tuple) and all(isinstance(name, str) for name in key):
             out = self._getitem_string_tuple(key)
             for var in out.children():
                 var.data = self[var.name].data

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -169,7 +169,8 @@ therefore highly recommended.
 
 import operator
 import copy
-from six.moves import reduce, map
+from six.moves import map
+from functools import reduce
 from six import string_types
 import numpy as np
 from collections import OrderedDict

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -169,7 +169,6 @@ therefore highly recommended.
 
 import operator
 import copy
-from six.moves import map
 from functools import reduce
 import numpy as np
 from collections import OrderedDict

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -6,7 +6,8 @@ import ssl
 from requests.exceptions import (MissingSchema, InvalidSchema,
                                  Timeout)
 
-from six.moves.urllib.parse import urlsplit, urlunsplit
+from requests.utils import urlparse, urlunparse
+
 
 from .lib import DEFAULT_TIMEOUT
 
@@ -22,8 +23,8 @@ def GET(url, application=None, session=None, timeout=DEFAULT_TIMEOUT,
     Optionally open a URL to a local WSGI application
     """
     if application:
-        _, _, path, query, fragment = urlsplit(url)
-        url = urlunsplit(('', '', path, query, fragment))
+        _, _, path, _, query, fragment = urlparse(url)
+        url = urlunparse(('', '', path, '', query, fragment))
 
     response = follow_redirect(url, application=application, session=session,
                                timeout=timeout, verify=verify)

--- a/src/pydap/parsers/__init__.py
+++ b/src/pydap/parsers/__init__.py
@@ -11,8 +11,6 @@ import ast
 
 from requests.utils import unquote
 
-from six.moves import map
-
 from ..exceptions import ConstraintExpressionError
 from ..lib import get_var
 

--- a/src/pydap/parsers/__init__.py
+++ b/src/pydap/parsers/__init__.py
@@ -9,7 +9,8 @@ import re
 import operator
 import ast
 
-from six.moves.urllib.parse import unquote
+from requests.utils import unquote
+
 from six.moves import map
 
 from ..exceptions import ConstraintExpressionError

--- a/src/pydap/parsers/das.py
+++ b/src/pydap/parsers/das.py
@@ -10,7 +10,7 @@ import re
 import ast
 import operator
 
-from six.moves import reduce
+from functools import reduce
 
 from . import SimpleParser
 from ..lib import walk

--- a/src/pydap/responses/ascii.py
+++ b/src/pydap/responses/ascii.py
@@ -12,7 +12,6 @@ except ImportError:
 import copy
 
 import numpy as np
-from six.moves import zip
 
 from ..model import (BaseType,
                      SequenceType, StructureType)

--- a/src/pydap/responses/das.py
+++ b/src/pydap/responses/das.py
@@ -13,7 +13,6 @@ except ImportError:
     from singledispatch import singledispatch
 
 from collections.abc import Iterable
-from six import string_types, integer_types
 from six.moves import map
 
 import numpy as np
@@ -113,7 +112,7 @@ def build_attributes(attr, values, level=0):
         type = get_type(values)
 
         # encode values
-        if (isinstance(values, string_types) or
+        if (isinstance(values, str) or
            not isinstance(values, Iterable) or
            getattr(values, 'shape', None) == ()):
             values = [encode(values)]
@@ -136,7 +135,7 @@ def get_type(values):
     """
     if hasattr(values, 'dtype'):
         return NUMPY_TO_DAP2_TYPEMAP[values.dtype.char]
-    elif isinstance(values, string_types) or not isinstance(values, Iterable):
+    elif isinstance(values, str) or not isinstance(values, Iterable):
         return type_convert(values)
     else:
         # if there are several values, they may have different types, so we
@@ -155,7 +154,7 @@ def type_convert(obj):
     """
     if isinstance(obj, float):
         return 'Float64'
-    elif isinstance(obj, integer_types):
+    elif isinstance(obj, int):
         return 'Int32'
     else:
         return 'String'

--- a/src/pydap/responses/das.py
+++ b/src/pydap/responses/das.py
@@ -13,7 +13,6 @@ except ImportError:
     from singledispatch import singledispatch
 
 from collections.abc import Iterable
-from six.moves import map
 
 import numpy as np
 

--- a/src/pydap/responses/dds.py
+++ b/src/pydap/responses/dds.py
@@ -13,8 +13,6 @@ try:
 except ImportError:
     from singledispatch import singledispatch
 
-from six.moves import zip
-
 from ..model import (DatasetType, BaseType,
                      SequenceType, StructureType,
                      GridType)

--- a/src/pydap/responses/dds.py
+++ b/src/pydap/responses/dds.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     from singledispatch import singledispatch
 
-from six.moves import map, zip
+from six.moves import zip
 
 from ..model import (DatasetType, BaseType,
                      SequenceType, StructureType,

--- a/src/pydap/responses/dods.py
+++ b/src/pydap/responses/dods.py
@@ -12,7 +12,6 @@ uses Numpy directly since it's faster.
 import copy
 
 import numpy as np
-from six import string_types
 
 from ..model import (BaseType,
                      SequenceType, StructureType)
@@ -120,7 +119,7 @@ def _sequencetype(var):
                 out = []
                 padded = []
                 for value in record:
-                    if isinstance(value, string_types):
+                    if isinstance(value, str):
                         length = len(value) or 1
                         out.append(length)
                         padded.append(length + (-length % 4))

--- a/src/pydap/responses/error.py
+++ b/src/pydap/responses/error.py
@@ -8,7 +8,7 @@ formated as a DAP error response.
 from traceback import print_exception
 
 from webob import Response
-from six import StringIO
+from io import StringIO
 
 from ..lib import encode, __version__
 

--- a/src/pydap/responses/error.py
+++ b/src/pydap/responses/error.py
@@ -8,7 +8,7 @@ formated as a DAP error response.
 from traceback import print_exception
 
 from webob import Response
-from six import StringIO, text_type
+from six import StringIO
 
 from ..lib import encode, __version__
 
@@ -30,7 +30,7 @@ class ErrorResponse(object):
 
         # build error message
         code = getattr(info[0], 'code', -1)
-        self.body = text_type('''Error {{
+        self.body = str('''Error {{
     code = {0};
     message = {1};
 }}''').format(code, message)

--- a/src/pydap/responses/html/__init__.py
+++ b/src/pydap/responses/html/__init__.py
@@ -9,7 +9,7 @@ from jinja2 import Environment, PackageLoader, ChoiceLoader
 from webob import Response
 from webob.dec import wsgify
 from webob.exc import HTTPSeeOther
-from six.moves.urllib.parse import unquote
+from requests.utils import unquote
 
 from ..lib import BaseResponse
 from ...lib import __version__

--- a/src/pydap/responses/version.py
+++ b/src/pydap/responses/version.py
@@ -1,7 +1,6 @@
 """Response with information about pydap version."""
 
 import sys
-from six import text_type
 
 from webob import Response
 from json import dumps
@@ -42,7 +41,7 @@ class VersionResponse(object):
 
     def __call__(self, environ, start_response):
         res = Response()
-        res.text = text_type(self.body)
+        res.text = str(self.body)
         res.status = '200 OK'
         res.content_type = 'application/json'
         res.charset = 'utf-8'

--- a/src/pydap/tests/test_handlers_lib.py
+++ b/src/pydap/tests/test_handlers_lib.py
@@ -1,7 +1,6 @@
 """Test basic handler functions."""
 
 import copy
-from six import text_type
 
 from webtest import AppError
 from webtest import TestApp as App
@@ -238,7 +237,7 @@ class TestConstraintExpression(unittest.TestCase):
     def test_unicode(self):
         """Test unicode representation."""
         ce = ConstraintExpression("a>1")
-        self.assertEqual(text_type(ce), "a>1")
+        self.assertEqual(str(ce), "a>1")
 
     def test_and(self):
         """Test CE addition."""

--- a/src/pydap/tests/test_handlers_netcdf.py
+++ b/src/pydap/tests/test_handlers_netcdf.py
@@ -1,7 +1,6 @@
 """Test the DAP handler, which forms the core of the client."""
 
 import numpy as np
-from six.moves import zip
 from pydap.handlers.dap import DAPHandler
 import pytest
 

--- a/src/pydap/tests/test_lib.py
+++ b/src/pydap/tests/test_lib.py
@@ -1,7 +1,7 @@
 """Test the basic DAP functions."""
 
 import numpy as np
-from six import MAXSIZE
+from sys import maxsize as MAXSIZE
 from pydap.model import (DatasetType, BaseType,
                          StructureType)
 from pydap.exceptions import ConstraintExpressionError

--- a/src/pydap/tests/test_wsgi_ssf.py
+++ b/src/pydap/tests/test_wsgi_ssf.py
@@ -1,7 +1,6 @@
 """Tests for the server-side function WSGI middleware."""
 
 import sys
-from six import next
 
 from webtest import TestApp as App
 import numpy as np

--- a/src/pydap/wsgi/app.py
+++ b/src/pydap/wsgi/app.py
@@ -27,7 +27,7 @@ from webob.dec import wsgify
 from webob.exc import HTTPNotFound, HTTPForbidden
 from webob.static import FileApp, DirectoryApp
 import pkg_resources
-from six.moves.urllib.parse import unquote
+from requests.utils import unquote
 from six import string_types
 
 from ..lib import __version__

--- a/src/pydap/wsgi/app.py
+++ b/src/pydap/wsgi/app.py
@@ -28,7 +28,6 @@ from webob.exc import HTTPNotFound, HTTPForbidden
 from webob.static import FileApp, DirectoryApp
 import pkg_resources
 from requests.utils import unquote
-from six import string_types
 
 from ..lib import __version__
 from ..handlers.lib import get_handler, load_handlers
@@ -204,7 +203,7 @@ class StaticMiddleware(object):
         req.path_info_pop()
 
         # statically serve the directory
-        if isinstance(self.static, string_types):
+        if isinstance(self.static, str):
             return req.get_response(DirectoryApp(self.static))
 
         # otherwise, load resource from package

--- a/src/pydap/wsgi/ssf.py
+++ b/src/pydap/wsgi/ssf.py
@@ -13,7 +13,7 @@ import ast
 from webob import Request
 from pkg_resources import iter_entry_points
 import numpy as np
-from six.moves import reduce, map
+from six.moves import reduce
 
 from ..model import DatasetType, SequenceType
 from ..parsers import parse_ce

--- a/src/pydap/wsgi/ssf.py
+++ b/src/pydap/wsgi/ssf.py
@@ -13,7 +13,7 @@ import ast
 from webob import Request
 from pkg_resources import iter_entry_points
 import numpy as np
-from six.moves import reduce
+from functools import reduce
 
 from ..model import DatasetType, SequenceType
 from ..parsers import parse_ce

--- a/src/pydap/wsgi/ssf.py
+++ b/src/pydap/wsgi/ssf.py
@@ -14,7 +14,6 @@ from webob import Request
 from pkg_resources import iter_entry_points
 import numpy as np
 from six.moves import reduce, map
-from six import string_types
 
 from ..model import DatasetType, SequenceType
 from ..parsers import parse_ce
@@ -67,7 +66,7 @@ class ServerSideFunctions(object):
         # check if there are any functions calls in the request
         called = (
             any(s for s in selection if FUNCTION.match(s)) or
-            any(p for p in projection if isinstance(p, string_types)))
+            any(p for p in projection if isinstance(p, str)))
 
         # ignore DAS requests and requests without functions
         path, response = req.path.rsplit('.', 1)
@@ -130,8 +129,8 @@ class ServerSideFunctions(object):
         # now apply projection
         if projection:
             projection = fix_shorthand(projection, dataset)
-            base = [p for p in projection if not isinstance(p, string_types)]
-            func = [p for p in projection if isinstance(p, string_types)]
+            base = [p for p in projection if not isinstance(p, str)]
+            func = [p for p in projection if isinstance(p, str)]
 
             # apply non-function projection
             out = apply_projection(base, dataset)


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes issue #303 
- [x] All tests pass on a local environment. No need to add extra tests.

I followed [this as guide](https://readthedocs.org/projects/six/downloads/pdf/stable/) to understand how to remove all explicit `six` dependency.

The package `six` provides compatibility with python 2.7 and python 3.x versions. And so removing `six` is a refactor since pydap is no longer compatible with python versions <3.7
