### PR TITLE
Allow escaping of '[' and ']' characters when opening remote datasets with dap4 protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ pydap
 [![black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/pydap/pydap)
 [![pre-commit](https://results.pre-commit.ci/badge/github/pydap/pydap/master.svg)](https://results.pre-commit.ci/latest/github/pydap/pydap/master)
-[![Join the chat at https://gitter.im/pydap/pydap](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/pydap/pydap)
 
 
 

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -134,6 +134,8 @@ class DAPHandler(pydap.handlers.lib.BaseHandler):
                 self.fragment,
             )
         )
+        dmr_url = dmr_url.replace("[", "%5B").replace("]", "%5D")
+
         r = pydap.net.GET(
             dmr_url,
             self.application,
@@ -438,11 +440,14 @@ class BaseProxyDap4(BaseProxyDap2):
 
     def __getitem__(self, index):
         # build download url
-        index = combine_slices(self.slice, fix_slice(index, self.shape))
-        scheme, netloc, path, params, query, fragment = urlparse(self.baseurl)
-        ce = "dap4.ce=" + quote(self.id) + hyperslab(index) + query
-        url = urlunparse((scheme, netloc, path + ".dap", "", ce, fragment)).rstrip("&")
 
+        index = combine_slices(self.slice, fix_slice(index, self.shape))
+        scheme, netloc, path, _, query, fragment = urlparse(self.baseurl)
+        # ce = "dap4.ce=" + quote(self.id) + hyperslab(index) + query
+        # else:
+        ce = "dap4.ce=" + quote(self.id) + hyperslab(index)
+        url = urlunparse((scheme, netloc, path + ".dap", "", ce, fragment)).rstrip("&")
+        # I need to encode `[` and `]`
         # download and unpack data
         logger.info("Fetching URL: %s" % url)
 

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -31,11 +31,24 @@ def test_open_url(sequence_app):
 
 
 def test_open_url_dap4():
-    url = "http://test.opendap.org/opendap/hyrax/data/nc/test.nc"
-    constrain = "dap4.ce=/s33[0][0]"
-    data_original = open_url(url)
-    data_dap4 = open_url(url + "?" + constrain, protocol="dap4")
+    base_url = "http://test.opendap.org/opendap/hyrax/data/nc/test.nc"
+    data_original = open_url(base_url)
+
+    # test single data point
+    constrain1 = "dap4.ce=/s33[0][0]"
+    data_dap4 = open_url(base_url + "?" + constrain1, protocol="dap4")
     assert data_dap4["s33"][:].data == data_original["s33"][0, 0].data
+
+    # subset of vars
+    var1 = "/s33[0:][0:1:2];"
+    var2 = "/br34[0:1:1][0:1:2][0:1:3];"
+    var3 = "/s113[0:1:0][0:1:0][0:1:2]"
+    Vars = [var1, var2, var3]
+
+    url = base_url + "?dap4.ce=" + var1 + var2 + var3
+    dataset = open_url(url, protocol="dap4")
+    # check [vars1, vars2, vars3] only in dataset
+    assert len(dataset.keys()) == len(Vars)
 
 
 @pytest.mark.client

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -30,6 +30,14 @@ def test_open_url(sequence_app):
     assert list(dataset.keys()) == ["cast"]
 
 
+def test_open_url_dap4():
+    url = "http://test.opendap.org/opendap/hyrax/data/nc/test.nc"
+    constrain = "dap4.ce=/s33[0][0]"
+    data_original = open_url(url)
+    data_dap4 = open_url(url + "?" + constrain, protocol="dap4")
+    assert data_dap4["s33"][:].data == data_original["s33"][0, 0].data
+
+
 @pytest.mark.client
 def test_open_dods():
     """Open a file downloaded from the test server with the DAS."""


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes #306. It may also close PR #180 
- [x] Tests were included and pass locally in test environment.
