### PR TITLE
Fixes #207: Pydap can now use PasterApp and serve data 

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,15 @@ To run the server just issue the command:
 
 ```bash
 
-    $ pydap --data ./myserver/data/ --port 8001
+    $ pydap --data ./myserver/data/ --port 8001 --workers 4 --threads 4
 ```
 
-This will start a standalone server running on http://localhost:8001/,
+This will start a standalone server running on the default http://localhost:8001/,
 serving netCDF files from ``./myserver/data/``, similar to the test
 server at http://test.pydap.org/. Since the server uses the
-[WSGI](http://wsgi.org/) standard, it can easily be run behind
-Apache. The [server
+[WSGI](http://wsgi.org/) standard, pydap uses by default 1 worker and 1
+thread, but these can be defined by the user like in the case above (4 workers
+and 4 threads). Pydap can also easily be run behind Apache. The [server
 documentation](https://pydap.github.io/pydap/server.html) has
 more information on how to better deploy pydap.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,8 @@ tests = [
   'WebTest',
   'flake8',
   'werkzeug>= 2.2.2',
-  'pyopenssl'
+  'pyopenssl',
+  'gunicorn'
 ]
 
 [tool.isort]

--- a/src/pydap/tests/test_wsgi_app.py
+++ b/src/pydap/tests/test_wsgi_app.py
@@ -115,8 +115,11 @@ class TestPyDapApplication(unittest.TestCase):
         app = DapServer(data, templates)
         app.handlers = [DummyHandler]
         app = StaticMiddleware(app, os.path.join(templates, "static"))
-        nworks = multiprocessing.cpu_count() * 2 + 1
-        self.app = PyDapApplication(app, host="127.0.1", port="8001", workers=nworks)
+        nworks = multiprocessing.cpu_count() // 2
+        nthreads = multiprocessing.cpu_count() // 2
+        self.app = PyDapApplication(
+            app, host="127.0.1", port="8001", workers=nworks, threads=nthreads
+        )
 
     def tearDown(self):
         """Remove the installation."""
@@ -129,7 +132,11 @@ class TestPyDapApplication(unittest.TestCase):
 
     def test_app_cfgworkers(self):
         workers = self.app.cfg.settings["workers"].value
-        self.assertEqual(workers, multiprocessing.cpu_count() * 2 + 1)
+        self.assertEqual(workers, multiprocessing.cpu_count() // 2)
+
+    def test_app_cfgthreads(self):
+        threads = self.app.cfg.settings["threads"].value
+        self.assertEqual(threads, multiprocessing.cpu_count() // 2)
 
 
 class TestPackageAssets(unittest.TestCase):

--- a/src/pydap/tests/test_wsgi_app.py
+++ b/src/pydap/tests/test_wsgi_app.py
@@ -124,12 +124,12 @@ class TestPyDapApplication(unittest.TestCase):
 
     def test_app_bind(self):
         """Test the correct config."""
-        bind = self.app._config
-        self.assertEqual(bind["bind"], "127.0.1:8001")
+        bind = self.app.cfg.settings["bind"].value[0]
+        self.assertEqual(bind, "127.0.1:8001")
 
     def test_app_cfgworkers(self):
-        bind = self.app._config
-        self.assertEqual(bind["workers"], multiprocessing.cpu_count() * 2 + 1)
+        workers = self.app.cfg.settings["workers"].value
+        self.assertEqual(workers, multiprocessing.cpu_count() * 2 + 1)
 
 
 class TestPackageAssets(unittest.TestCase):

--- a/src/pydap/wsgi/app.py
+++ b/src/pydap/wsgi/app.py
@@ -249,6 +249,9 @@ def init(directory):
 
 
 class PyDapApplication(WSGIApplication):
+    """An application interface for configuring and loading
+    the various necessities for any given web framework."""
+
     def __init__(self, app, **local_config):
 
         self._app = app


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request is a continuation of PR #286 started by @raphaeljolivet (Thanks for the contribution!)

- [x] Closes #207 and #286.
- [x] Adds [gunicorn](https://gunicorn.org/) (python WGSI http server application) to dependencies (pack is used for testing). 
- [x] Tests are added to demonstrate the new or fixed behavior, and all tests pass
on a local environment.
- [x] Allow for multithreading and multiple processes when running `pydap` as a server app.
- [x] Update readme to show --workers and --threads are options. 
- [x] Change the defaults for workers [default: 1] and threads [default: 1]. These are added to the docstring and can be accessed on the command line via
```python
>>> pydap -h
A file-based pydap server running on Gunicorn.

Usage:
  pydap [options]

Options:
  -h --help                     Show this help message and exit
  --version                     Show pydap version
  -i --init DIR                 Create directory with templates
  -b ADDRESS --bind ADDRESS     The ip to listen to [default: 127.0.0.1]
  -p PORT --port PORT           The port to connect [default: 8001]
  -d DIR --data DIR             The directory with files [default: .]
  -t DIR --templates DIR        The directory with templates
  --workers INT                 Number of workers [default: 1]
  --threads INT                 Number of threads [default: 1]
  --worker-class=CLASS          Gunicorn worker class [default: sync]
```



With these changes, and gunicorn installed (any version), the following updated line in the README file works again:

```python
import multiprocessing
ncores = multiprocessing.cpu_count() * 2
pydap --data ./myserver/data/ --port 8001 --workers ncores
```



