### PR TITLE
Removes deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,8 @@ tests = [
   'WebTest',
   'flake8',
   'werkzeug>= 2.2.2',
-  'gunicorn'
+  'gunicorn',
+  'cryptography'
 ]
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ tests = [
   'WebTest',
   'flake8',
   'werkzeug>= 2.2.2',
-  'pyopenssl',
   'gunicorn'
 ]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,7 @@ markers =
     prod_url
     good_url
     auth
+filterwarnings =
+    ignore:.*:DeprecationWarning
+    ignore:.*:UserWarning
+    ignore:.*blockwise.*:UserWarning

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -169,7 +169,6 @@ therefore highly recommended.
 
 import copy
 import operator
-import warnings
 from collections import OrderedDict
 from collections.abc import Mapping
 from functools import reduce
@@ -719,28 +718,9 @@ class SequenceType(StructureType):
             yield tuple(map(decode_np_strings, line))
 
     def __iter__(self):
-        # This method should be removed in pydap 3.4
-        warnings.warn(
-            "Starting with pydap 3.4 "
-            "``for val in sequence: ...`` "
-            "will give children names. "
-            "To iterate over data the construct "
-            "``for val in sequence.iterdata(): ...``"
-            "is available now and will be supported in the"
-            "future to iterate over data.",
-            PendingDeprecationWarning,
-        )
         return self.iterdata()
 
     def __len__(self):
-        # This method should be removed in pydap 3.4
-        warnings.warn(
-            "Starting with pydap 3.4, "
-            "``len(sequence)`` will give "
-            "the number of children and not the "
-            "length of the data.",
-            PendingDeprecationWarning,
-        )
         return len(self.data)
 
     def items(self):

--- a/src/pydap/tests/test_model.py
+++ b/src/pydap/tests/test_model.py
@@ -384,12 +384,10 @@ def test_SequenceType_data(sequence_example):
     )
 
 
-def test_SequenceType_len(sequence_example, recwarn):
+def test_SequenceType_len(sequence_example):
     """Test that length is read from the data attribute."""
     assert len(list(sequence_example.keys())) == 3
     assert len(sequence_example) == 4
-    assert len(recwarn) == 1
-    assert recwarn.pop(PendingDeprecationWarning)
 
 
 def test_SequenceType_iterdata(sequence_example):
@@ -405,14 +403,6 @@ def test_SequenceType_iter(sequence_example):
     for a, b in zip(iter(sequence_example), sequence_example.data):
         for sub_a, sub_b in zip(a, b):
             assert sub_a == sub_b
-
-
-def test_SequenceType_iter_deprecation(sequence_example, recwarn):
-    """Test that direct iteration over data attribute is deprecated."""
-    # Remove in pydap 3.4
-    iter(sequence_example)
-    assert len(recwarn) == 1
-    assert recwarn.pop(PendingDeprecationWarning)
 
 
 def test_SequenceType_items(sequence_example):

--- a/src/pydap/tests/test_server_devel_ssl.py
+++ b/src/pydap/tests/test_server_devel_ssl.py
@@ -9,7 +9,6 @@ it could work with more data formats.
 
 import ssl
 import sys
-import warnings
 
 import numpy as np
 import pytest
@@ -59,10 +58,11 @@ def test_open(sequence_type_data):
     )
 
 
+@pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")
 @server
 def test_verify_open_url(sequence_type_data):
     """Test that open_url raises the correct SSLError"""
-    warnings.simplefilter("always")
+    # warnings.simplefilter("always")
 
     TestDataset = DatasetType("Test")
     TestDataset["sequence"] = sequence_type_data


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Partially closes an already existing opened issue #319. Many of these I have already resolved, but there were a couple of ones that were happening within pydap tests. 
- [x] Finishes and closes PR #289 started (thanks @facutuesca !): pyOpenSSL was deprecated but tests kept failing for macOS even though it wasn't explicitly being used. Turns out `pyOpenSSL` needed to be replaced with `cryptography` for tests to pass. See [pyca/pyopenss#1249](https://github.com/pyca/pyopenssl/issues/1249).  
- [x] Tests are added to demonstrate the new or fixed behavior, and all tests pass
on a local environment.


The reasoning behind muting Deprecation warnings is that these show up in many packages that have pydap as a dependency, for example [dfm_tools#803](https://github.com/Deltares/dfm_tools/issues/803), and that many of these Deprecation Warnings come from pydap internally (producing DeprecationWarnings, and failing to capture some other warnings).


Feel free to suggest a different approach to filtering these warnings. 

