### PR TITLE
Simplify the Dataset model in DAP4

### DIFF
--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -224,8 +224,6 @@ class DAPHandler(pydap.handlers.lib.BaseHandler):
                 session=self.session,
                 timeout=self.timeout,
             )
-        for var in walk(self.dataset, pydap.model.GridType):
-            var.set_output_grid(self.output_grid)
 
     def add_dap2_proxies(self):
         # now add data proxies

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -260,7 +260,6 @@ class BaseType(DapType):
         # these are set when not data is present (eg, when parsing a DDS)
         self._dtype = None
         self._shape = ()
-        self._Maps = ()  # must be fully qualifying name
 
     def __repr__(self):
         return "<%s with data %s>" % (type(self).__name__, repr(self.data))
@@ -330,6 +329,7 @@ class BaseType(DapType):
         out.data = self._get_data_index(index)
         if type(self.data).__name__ == "BaseProxyDap4":
             out.attributes["checksum"] = self.data.checksum
+            out.attributes["Maps"] = self.Maps
         return out
 
     def __len__(self):

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -260,6 +260,7 @@ class BaseType(DapType):
         # these are set when not data is present (eg, when parsing a DDS)
         self._dtype = None
         self._shape = ()
+        self._Maps = ()  # must be fully qualifying name
 
     def __repr__(self):
         return "<%s with data %s>" % (type(self).__name__, repr(self.data))

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -889,7 +889,3 @@ class GroupType(StructureType):
 
         for child in self.children():
             child.id = child.name
-
-
-class MapType(StructureType):
-    pass

--- a/src/pydap/parsers/dmr.py
+++ b/src/pydap/parsers/dmr.py
@@ -2,7 +2,6 @@
 
 import ast
 import collections
-import copy
 import re
 from xml.etree import ElementTree as ET
 
@@ -121,14 +120,6 @@ def get_dim_sizes(element):
     return dimension_sizes
 
 
-def has_map(element):
-    maps = element.findall("Map")
-    if len(maps) > 0:
-        return True
-    else:
-        return False
-
-
 def dmr_to_dataset(dmr):
     """Return a dataset object from a DMR representation."""
 
@@ -154,7 +145,6 @@ def dmr_to_dataset(dmr):
         variable["attributes"] = get_attributes(variable["element"], {})
         variable["dtype"] = get_dtype(variable["element"])
         variable["dims"] = get_dim_names(variable["element"])
-        variable["has_map"] = has_map(variable["element"])
         variable["shape"] = get_dim_sizes(variable["element"])
 
     # Add size entry for dimension variables
@@ -167,7 +157,6 @@ def dmr_to_dataset(dmr):
                 "size": size,
                 "dims": [name],
                 "dtype": "int",
-                "has_map": False,
                 "attributes": {},
                 "shape": (),
             }
@@ -197,13 +186,9 @@ def dmr_to_dataset(dmr):
             data=data,
             dimensions=variable["dims"],
         )
-        if variable["has_map"]:
-            var = pydap.model.GridType(name=var_name)
-            var[var_name] = array
-            for dim in variable["dims"]:
-                var[dim] = copy.copy(dataset[dim])
-        else:
-            var = array
+
+        var = array
+
         var.attributes = variable["attributes"]
         if "parent" in variable.keys() and variable["parent"] in [
             "Sequence",

--- a/src/pydap/responses/dmr.py
+++ b/src/pydap/responses/dmr.py
@@ -111,3 +111,11 @@ def _basetype(var, level=0, path="/"):
         )
         yield "{indent}</Attribute>\n".format(indent=(level + 1) * INDENT)
     yield "{indent}</{type}>\n".format(indent=level * INDENT, type=_vartype)
+
+    # get maps
+    if "Maps" in var.attributes.keys():
+        Maps = var.Maps
+        for _map in Maps:
+            yield '{indent}<Map name="{name}">\n'.format(
+                indent=(level + 1) * INDENT, name=_map
+            )

--- a/src/pydap/tests/data/dmrs/SWOT_GPR.dmr
+++ b/src/pydap/tests/data/dmrs/SWOT_GPR.dmr
@@ -1,0 +1,1455 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xml:base="https://opendap.earthdata.nasa.gov/collections/C2799438313-POCLOUD/granules/SWOT_GPR_2PfP507_010_20230501_003247_20230501_012352" dapVersion="4.0" dmrVersion="1.0" name="SWOT_GPR_2PfP507_010_20230501_003247_20230501_012352.nc">
+    <Attribute name="Conventions" type="String">
+        <Value>CF-1.7</Value>
+    </Attribute>
+    <Attribute name="title" type="String">
+        <Value>GDR - Reduced dataset</Value>
+    </Attribute>
+    <Attribute name="source" type="String">
+        <Value>Processing Baseline F v1.04</Value>
+    </Attribute>
+    <Attribute name="contact" type="String">
+        <Value>CNES aviso@altimetry.fr, JPL podaac@podaac.jpl.nasa.gov</Value>
+    </Attribute>
+    <Attribute name="reference_document" type="String">
+        <Value>SWOT Nadir Altimeter Products Handbook, SALP-MU-M-OP-xxxxx-CN</Value>
+    </Attribute>
+    <Attribute name="mission_name" type="String">
+        <Value>SWOT</Value>
+    </Attribute>
+    <Attribute name="altimeter_sensor_name" type="String">
+        <Value>Poseidon-3C</Value>
+    </Attribute>
+    <Attribute name="radiometer_sensor_name" type="String">
+        <Value>AMR</Value>
+    </Attribute>
+    <Attribute name="doris_sensor_name" type="String">
+        <Value>DGXX-S</Value>
+    </Attribute>
+    <Attribute name="gpsr_sensor_name" type="String">
+        <Value>GPSP</Value>
+    </Attribute>
+    <Attribute name="institution" type="String">
+        <Value>CNES</Value>
+    </Attribute>
+    <Attribute name="history" type="String">
+        <Value>2023-11-05 02:51:32 : Creation</Value>
+    </Attribute>
+    <Attribute name="references" type="String">
+        <Value>L1_library=V5.8.4,_L2_library=V6.10p1p2p3p4,_Processing_Pilot=5.1.0</Value>
+    </Attribute>
+    <Attribute name="processing_center" type="String">
+        <Value>SALP</Value>
+    </Attribute>
+    <Attribute name="cycle_number" type="Int32">
+        <Value>507</Value>
+    </Attribute>
+    <Attribute name="absolute_rev_number" type="Int32">
+        <Value>1492</Value>
+    </Attribute>
+    <Attribute name="pass_number" type="Int32">
+        <Value>10</Value>
+    </Attribute>
+    <Attribute name="absolute_pass_number" type="Int32">
+        <Value>14178</Value>
+    </Attribute>
+    <Attribute name="equator_time" type="String">
+        <Value>2023-05-01T00:58:18.063Z</Value>
+    </Attribute>
+    <Attribute name="equator_longitude" type="Float64">
+        <Value>86.75</Value>
+    </Attribute>
+    <Attribute name="first_meas_time" type="String">
+        <Value>2023-05-01 00:32:47.216902</Value>
+    </Attribute>
+    <Attribute name="last_meas_time" type="String">
+        <Value>2023-05-01 01:23:52.053959</Value>
+    </Attribute>
+    <Attribute name="xref_telemetry" type="String">
+        <Value>SWOT_KRX_20230501T021312_20230430T230019_20230501T004156_O_APID1040.PTM_0, SWOT_KRX_20230501T035617_20230501T004156_20230501T020231_O_APID1040.PTM_0, SWOT_KRX_20230501T002859_20230430T215304_20230430T230021_O_APID1183.PTM_0 SWOT_KRX_20230501T021312_20230430T230021_20230501T004156_O_APID1183.PTM_0, SWOT_HBX_20230501T042425_20230501T020230_20230501T034308_O_APID1183.PTM_0 SWOT_KRX_20230501T021312_20230430T230021_20230501T004156_O_APID1183.PTM_0 SWOT_KRX_20230501T035617_20230501T004157_20230501T020230_O_APID1183.PTM_0</Value>
+    </Attribute>
+    <Attribute name="xref_altimeter_characterisation" type="String">
+        <Value>PSWOT_CH1_AXVCNE20220919_100000_20200101_000000_20401231_235959</Value>
+    </Attribute>
+    <Attribute name="xref_altimeter_ltm" type="String">
+        <Value>PSWOT_FI1_AXXCNE20231101_130120_20230116_114211_20231031_180836.nc, PSWOT_IQ1_AXXCNE20231101_130120_20230116_113952_20231031_174830.nc</Value>
+    </Attribute>
+    <Attribute name="xref_radiometer_level2" type="String">
+        <Value>SWOT_GPRAD_2PaP507_010_20230501_003243_20230501_012356_PGC0_01.nc</Value>
+    </Attribute>
+    <Attribute name="xref_doris_uso" type="String">
+        <Value>SWOT_OS1_AXXCNE20230620_103300_20230113_115757_20230620_031623</Value>
+    </Attribute>
+    <Attribute name="xref_orbit_data" type="String">
+        <Value>SWOT_VOR_AXVCNE20231003_082438_20230430_225923_20230502_005923.nc</Value>
+    </Attribute>
+    <Attribute name="xref_pf_data" type="String">
+        <Value>SWOT_VPF_AXVCNE20231003_082600_20230430_225923_20230502_005923</Value>
+    </Attribute>
+    <Attribute name="xref_pole_location" type="String">
+        <Value>SMM_PO1_AXXCNE20230620_200000_19900101_000000_20231218_000000</Value>
+    </Attribute>
+    <Attribute name="xref_orf_data" type="String">
+        <Value>SWOT_ORF_AXXCNE20230710_103400_20230115_060150_20230725_080808</Value>
+    </Attribute>
+    <Attribute name="xref_meteorological_files" type="String">
+        <Value>SMM_APA_AXVCNE20230501_050916_20230501_000000_20230501_000000, SMM_APA_AXVCNE20230501_145742_20230501_060000_20230501_060000, SMM_PMA_AXVCNE20230501_050916_20230501_000000_20230501_000000, SMM_PMA_AXVCNE20230501_145742_20230501_060000_20230501_060000, SMM_PRA_AXVCNE20230501_050916_20230501_000000_20230501_000000, SMM_PRA_AXVCNE20230501_145742_20230501_060000_20230501_060000, SMM_UWA_AXVCNE20230501_050916_20230501_000000_20230501_000000, SMM_UWA_AXVCNE20230501_145742_20230501_060000_20230501_060000, SMM_VWA_AXVCNE20230501_050916_20230501_000000_20230501_000000, SMM_VWA_AXVCNE20230501_145742_20230501_060000_20230501_060000, SMM_WEA_AXVCNE20230501_050916_20230501_000000_20230501_000000, SMM_WEA_AXVCNE20230501_145742_20230501_060000_20230501_060000, SMM_ALT_AXVCNE20110430_180000_20110504_100000_20301231_235959, SMM_ALT_AXVCNE20110430_180000_20110504_100000_20301231_235959, SMM_PSA_AXVCNE20230501_054035_20230501_000000_20230501_000000, SMM_PSA_AXVCNE20230501_174034_20230501_060000_20230501_060000, SMM_ORA_AXVCNE20230501_054035_20230501_000000_20230501_000000, SMM_ORA_AXVCNE20230501_174034_20230501_060000_20230501_060000, SMM_T3A_AXVCNE20230501_054035_20230501_000000_20230501_000000, SMM_T3A_AXVCNE20230501_174034_20230501_060000_20230501_060000, SMM_Q3A_AXVCNE20230501_054035_20230501_000000_20230501_000000, SMM_Q3A_AXVCNE20230501_174034_20230501_060000_20230501_060000, SMM_L3A_AXVCNE20230501_054035_20230501_000000_20230501_000000, SMM_L3A_AXVCNE20230501_174034_20230501_060000_20230501_060000, SMM_CRR_AXFCNE20230501_065533_20230501_000000_20230501_000000.grb, SMM_CRR_AXFCNE20230501_065533_20230501_060000_20230501_060000.grb, SMM_LSR_AXFCNE20230501_065533_20230501_000000_20230501_000000.grb, SMM_LSR_AXFCNE20230501_065533_20230501_060000_20230501_060000.grb</Value>
+    </Attribute>
+    <Attribute name="xref_sst_data" type="String">
+        <Value>SMM_SST_AXVCNE20230516_170511_20230501_000000_20230501_235959.nc</Value>
+    </Attribute>
+    <Attribute name="xref_wave_model_data" type="String">
+        <Value>SMM_WMA_AXPCNE20230501_072011_20230430_030000_20230501_000000.grb, SMM_WMA_AXPCNE20230502_072012_20230501_030000_20230502_000000.grb</Value>
+    </Attribute>
+    <Attribute name="xref_utc_tai_data" type="String">
+        <Value>SMM_TUC_AXVCNE20161214_152427_19900101_000000_20380118_000000</Value>
+    </Attribute>
+    <Attribute name="xref_gim_data" type="String">
+        <Value>SWOT_ION_AXPCNE20230502_063337_20230501_000000_20230501_235959</Value>
+    </Attribute>
+    <Attribute name="xref_mog2d_data" type="String">
+        <Value>SMM_MOG_AXVCNE20230521_070000_20230501_000000_20230501_000000, SMM_MOG_AXVCNE20230521_190000_20230501_060000_20230501_060000</Value>
+    </Attribute>
+    <Attribute name="xref_polar_ice_data" type="String">
+        <Value>SMM_ICN_AXPCNE20230517_100318_20230501_000000_20230501_235959.nc, SMM_ICS_AXPCNE20230517_100317_20230501_000000_20230501_235959.nc</Value>
+    </Attribute>
+    <Attribute name="ellipsoid_axis" type="Float64">
+        <Value>6378137.</Value>
+    </Attribute>
+    <Attribute name="ellipsoid_flattening" type="Float64">
+        <Value>0.0033528106647474801</Value>
+    </Attribute>
+    <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="build_dmrpp" type="String">
+            <Value>3.20.13-664</Value>
+        </Attribute>
+        <Attribute name="bes" type="String">
+            <Value>3.20.13-664</Value>
+        </Attribute>
+        <Attribute name="libdap" type="String">
+            <Value>libdap-3.20.11-198</Value>
+        </Attribute>
+        <Attribute name="configuration" type="String">
+            <Value>
+# TheBESKeys::get_as_config()
+AllowedHosts=^https?:\/\/
+BES.Catalog.catalog.FollowSymLinks=Yes
+BES.Catalog.catalog.RootDirectory=/tmp/tmpx5ew4gwg/
+BES.Catalog.catalog.TypeMatch=dmrpp:.*\.(dmrpp)$;
+BES.Catalog.catalog.TypeMatch+=h5:.*(\.bz2|\.gz|\.Z)?$;
+BES.Data.RootDirectory=/dev/null
+BES.LogName=./bes.log
+BES.UncompressCache.dir=/tmp/hyrax_ux
+BES.UncompressCache.prefix=ux_
+BES.UncompressCache.size=500
+BES.module.cmd=/usr/lib64/bes/libdap_xml_module.so
+BES.module.dap=/usr/lib64/bes/libdap_module.so
+BES.module.dmrpp=/usr/lib64/bes/libdmrpp_module.so
+BES.module.fonc=/usr/lib64/bes/libfonc_module.so
+BES.module.h5=/usr/lib64/bes/libhdf5_module.so
+BES.module.nc=/usr/lib64/bes/libnc_module.so
+BES.modules=dap,cmd,h5,dmrpp,nc,fonc
+FONc.ClassicModel=false
+FONc.NoGlobalAttrs=true
+H5.EnableCF=false
+H5.EnableCheckNameClashing=true
+</Value>
+        </Attribute>
+        <Attribute name="invocation" type="String">
+            <Value>build_dmrpp -c /tmp/bes_conf_lLpj -f /tmp/tmpx5ew4gwg//SWOT_GPR_2PfP507_010_20230501_003247_20230501_012352.nc -r /tmp/dmr__ZLaNkM -u OPeNDAP_DMRpp_DATA_ACCESS_URL -M</Value>
+        </Attribute>
+    </Attribute>
+    <Group name="data_01">
+        <Dimension name="time" size="2880"/>
+        <Float64 name="time">
+            <Dim name="/data_01/time"/>
+            <Attribute name="long_name" type="String">
+                <Value>time in UTC</Value>
+            </Attribute>
+            <Attribute name="standard_name" type="String">
+                <Value>time</Value>
+            </Attribute>
+            <Attribute name="calendar" type="String">
+                <Value>gregorian</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>seconds since 2000-01-01 00:00:00.0</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Time of measurement in seconds in the UTC time scale since 1 Jan 2000 00:00:00 UTC. [tai_utc_difference] is the difference between TAI and UTC reference time (seconds) for the first measurement of the data set. If a leap second occurs within the data set, the attribute [leap_second] is set to the UTC time at which the leap second occurs</Value>
+            </Attribute>
+            <Attribute name="tai_utc_difference" type="Float64">
+                <Value>37.</Value>
+            </Attribute>
+            <Attribute name="leap_second" type="String">
+                <Value>0000-00-00 00:00:00</Value>
+            </Attribute>
+        </Float64>
+        <Int32 name="longitude">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int32">
+                <Value>2147483647</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>longitude</Value>
+            </Attribute>
+            <Attribute name="standard_name" type="String">
+                <Value>longitude</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>degrees_east</Value>
+            </Attribute>
+            <Attribute name="scale_factor" type="Float64">
+                <Value>9.9999999999999995e-07</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>East longitude relative to Greenwich meridian. See SWOT Nadir Altimeter User Handbook. Associated quality flag is orb_state_diode_flag for the OGDR products, orb_state_rest_flag for the IGDR and GDR products</Value>
+            </Attribute>
+        </Int32>
+        <Int32 name="latitude">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int32">
+                <Value>2147483647</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>latitude</Value>
+            </Attribute>
+            <Attribute name="standard_name" type="String">
+                <Value>latitude</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>degrees_north</Value>
+            </Attribute>
+            <Attribute name="scale_factor" type="Float64">
+                <Value>9.9999999999999995e-07</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Positive latitude is North latitude, negative latitude is South latitude. See SWOT Nadir Altimeter User Handbook. Associated quality flag is orb_state_diode_flag for the OGDR products, orb_state_rest_flag for the IGDR and GDR products</Value>
+            </Attribute>
+        </Int32>
+        <Int8 name="rad_side_2_rain_flag">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int8">
+                <Value>127</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>radiometer rain flag from second radiometer</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>no_rain rain</Value>
+            </Attribute>
+            <Attribute name="flag_values" type="Int8">
+                <Value>0</Value>
+                <Value>1</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>See SWOT Nadir Altimeter User Handbook</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int8>
+        <Int16 name="rad_wet_tropo_cor">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int16">
+                <Value>32767</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>radiometer wet tropospheric correction</Value>
+            </Attribute>
+            <Attribute name="standard_name" type="String">
+                <Value>altimeter_range_correction_due_to_wet_troposphere</Value>
+            </Attribute>
+            <Attribute name="source" type="String">
+                <Value>AMR</Value>
+            </Attribute>
+            <Attribute name="institution" type="String">
+                <Value>NASA/JPL</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>m</Value>
+            </Attribute>
+            <Attribute name="scale_factor" type="Float64">
+                <Value>0.0001</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>A wet tropospheric correction must be added (negative value) to the instrument range to correct this range measurement for wet tropospheric range delays of the radar pulse</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int16>
+        <Int32 name="depth_or_elevation">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int32">
+                <Value>2147483647</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>ocean depth/land elevation</Value>
+            </Attribute>
+            <Attribute name="source" type="String">
+                <Value>ACE2</Value>
+            </Attribute>
+            <Attribute name="institution" type="String">
+                <Value>EAPRS Laboratory</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>m</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int32>
+        <Int8 name="rad_qual">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int8">
+                <Value>127</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>radiometer quality flag</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>good bad</Value>
+            </Attribute>
+            <Attribute name="flag_values" type="Int8">
+                <Value>0</Value>
+                <Value>1</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Compilation of all radiometer flags except radiometer surface type : Set to default in the current issue</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int8>
+        <Int16 name="rad_water_vapor">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int16">
+                <Value>32767</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>radiometer water vapor content</Value>
+            </Attribute>
+            <Attribute name="standard_name" type="String">
+                <Value>atmosphere_water_vapor_content</Value>
+            </Attribute>
+            <Attribute name="source" type="String">
+                <Value>AMR</Value>
+            </Attribute>
+            <Attribute name="institution" type="String">
+                <Value>NASA/JPL</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>kg/m^2</Value>
+            </Attribute>
+            <Attribute name="scale_factor" type="Float64">
+                <Value>0.10000000000000001</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Should not be used over land</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int16>
+        <Int8 name="rad_side_2_sea_ice_flag">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int8">
+                <Value>127</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>radiometer sea-ice flag from second radiometer</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>no_sea_ice sea_ice</Value>
+            </Attribute>
+            <Attribute name="flag_values" type="Int8">
+                <Value>0</Value>
+                <Value>1</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>See SWOT Nadir Altimeter User Handbook</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int8>
+        <Int16 name="pole_tide">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int16">
+                <Value>32767</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>geocentric pole tide height</Value>
+            </Attribute>
+            <Attribute name="standard_name" type="String">
+                <Value>sea_surface_height_amplitude_due_to_pole_tide</Value>
+            </Attribute>
+            <Attribute name="source" type="String">
+                <Value>Desai, S., Wahr, J. &amp; Beckley, B. J Geod [2015] 89: 1233</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>m</Value>
+            </Attribute>
+            <Attribute name="scale_factor" type="Float64">
+                <Value>0.0001</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>See SWOT Nadir Altimeter User Handbook</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int16>
+        <Int16 name="model_dry_tropo_cor_zero_altitude">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int16">
+                <Value>32767</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>model dry tropospheric correction at zero altitude</Value>
+            </Attribute>
+            <Attribute name="standard_name" type="String">
+                <Value>altimeter_range_correction_due_to_dry_troposphere</Value>
+            </Attribute>
+            <Attribute name="source" type="String">
+                <Value>European Center for Medium Range Weather Forecasting</Value>
+            </Attribute>
+            <Attribute name="institution" type="String">
+                <Value>ECMWF</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>m</Value>
+            </Attribute>
+            <Attribute name="scale_factor" type="Float64">
+                <Value>0.0001</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Computed at Mean Sea Level Pressure at the altimeter time-tag from the interpolation of 2 meteorological fields that surround the altimeter time-tag. A dry tropospheric correction must be added (negative value) to the instrument range to correct this range measurement for dry tropospheric range delays of the radar pulse. See SWOT Nadir Altimeter User Handbook</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int16>
+        <Int16 name="solid_earth_tide">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int16">
+                <Value>32767</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>solid earth tide height</Value>
+            </Attribute>
+            <Attribute name="standard_name" type="String">
+                <Value>sea_surface_height_amplitude_due_to_earth_tide</Value>
+            </Attribute>
+            <Attribute name="source" type="String">
+                <Value>Cartwright and Edden [1973] Corrected tables of tidal harmonics - J. Geophys. J. R. Astr. Soc., 33, 253-264.</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>m</Value>
+            </Attribute>
+            <Attribute name="scale_factor" type="Float64">
+                <Value>0.0001</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Calculated using Cartwright and Tayler tables and consisting of the second and third degree constituents. The permanent tide (zero frequency) is not included. See SWOT Nadir Altimeter User Handbook</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int16>
+        <Int16 name="dac">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int16">
+                <Value>32767</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>dynamic atmospheric correction</Value>
+            </Attribute>
+            <Attribute name="institution" type="String">
+                <Value>LEGOS/CLS/CNES</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>m</Value>
+            </Attribute>
+            <Attribute name="scale_factor" type="Float64">
+                <Value>0.0001</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Sum of the high frequency fluctuations correction and of the low frequency inverted barometer correction (inv_bar_cor). See SWOT Nadir Altimeter User Handbook</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int16>
+        <Int8 name="rad_side_1_surface_type_flag">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int8">
+                <Value>127</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>radiometer surface type from first radiometer</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>open_ocean near_coast land</Value>
+            </Attribute>
+            <Attribute name="flag_values" type="Int8">
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>2</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int8>
+        <Int8 name="surface_classification_flag">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int8">
+                <Value>127</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>surface classification</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>open_ocean land continental_water aquatic_vegetation continental_ice_snow floating_ice salted_basin</Value>
+            </Attribute>
+            <Attribute name="flag_values" type="Int8">
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>3</Value>
+                <Value>4</Value>
+                <Value>5</Value>
+                <Value>6</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Computed from a mask built with MODIS and GlobCover data</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int8>
+        <Float64 name="time_tai">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Float64">
+                <Value>1.8446744073709552e+19</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>time in TAI</Value>
+            </Attribute>
+            <Attribute name="standard_name" type="String">
+                <Value>time</Value>
+            </Attribute>
+            <Attribute name="calendar" type="String">
+                <Value>gregorian</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>seconds since 2000-01-01 00:00:00.0</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Time of measurement in seconds in the TAI time scale since 1 Jan 2000 00:00:00 TAI. This time scale contains no leap seconds. The difference (in seconds) with time in UTC is given by the attribute [time:tai_utc_difference]</Value>
+            </Attribute>
+            <Map name="/data_01/time"/>
+        </Float64>
+        <Int32 name="altitude">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int32">
+                <Value>2147483647</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>1 Hz altitude of satellite</Value>
+            </Attribute>
+            <Attribute name="standard_name" type="String">
+                <Value>height_above_reference_ellipsoid</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>m</Value>
+            </Attribute>
+            <Attribute name="add_offset" type="Float64">
+                <Value>800000.</Value>
+            </Attribute>
+            <Attribute name="scale_factor" type="Float64">
+                <Value>0.0001</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Altitude of satellite above the reference ellipsoid. Associated quality flag is orb_state_diode_flag for the OGDR products, orb_state_rest_flag for the IGDR and GDR products</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int32>
+        <Int8 name="rad_side_1_rain_flag">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int8">
+                <Value>127</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>radiometer rain flag from first radiometer</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>no_rain rain</Value>
+            </Attribute>
+            <Attribute name="flag_values" type="Int8">
+                <Value>0</Value>
+                <Value>1</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>See SWOT Nadir Altimeter User Handbook</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int8>
+        <Int8 name="rad_side_1_sea_ice_flag">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int8">
+                <Value>127</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>radiometer sea-ice flag from first radiometer</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>no_sea_ice sea_ice</Value>
+            </Attribute>
+            <Attribute name="flag_values" type="Int8">
+                <Value>0</Value>
+                <Value>1</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>See SWOT Nadir Altimeter User Handbook</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int8>
+        <Int8 name="ice_flag">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int8">
+                <Value>127</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>ice flag</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>no_ice ice</Value>
+            </Attribute>
+            <Attribute name="flag_values" type="Int8">
+                <Value>0</Value>
+                <Value>1</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>See SWOT Nadir Altimeter User Handbook</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int8>
+        <Int8 name="rad_wet_tropo_cor_interp_qual">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int8">
+                <Value>127</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>radiometer wet tropospheric correction interpolation quality flag</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>good degraded bad</Value>
+            </Attribute>
+            <Attribute name="flag_values" type="Int8">
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>2</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>See SWOT Nadir Altimeter User Handbook</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int8>
+        <Int16 name="inv_bar_cor">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int16">
+                <Value>32767</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>inverted barometer height correction</Value>
+            </Attribute>
+            <Attribute name="standard_name" type="String">
+                <Value>sea_surface_height_correction_due_to_air_pressure_at_low_frequency</Value>
+            </Attribute>
+            <Attribute name="source" type="String">
+                <Value>European Center for Medium Range Weather Forecasting</Value>
+            </Attribute>
+            <Attribute name="institution" type="String">
+                <Value>ECMWF</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>m</Value>
+            </Attribute>
+            <Attribute name="scale_factor" type="Float64">
+                <Value>0.0001</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Computed at the altimeter time-tag from the interpolation of 2 meteorological fields that surround the altimeter time-tag. See SWOT Nadir Altimeter User Handbook</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int16>
+        <Int32 name="ocean_tide_fes">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int32">
+                <Value>2147483647</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>geocentric ocean tide height (FES solution)</Value>
+            </Attribute>
+            <Attribute name="standard_name" type="String">
+                <Value>sea_surface_height_amplitude_due_to_geocentric_ocean_tide</Value>
+            </Attribute>
+            <Attribute name="source" type="String">
+                <Value>FES2014b</Value>
+            </Attribute>
+            <Attribute name="institution" type="String">
+                <Value>LEGOS/NOVELTIS/CNES/CLS</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>m</Value>
+            </Attribute>
+            <Attribute name="scale_factor" type="Float64">
+                <Value>0.0001</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Includes the equilibrium long-period ocean tide height and only the short-period part of the corresponding loading tide. The permanent tide (zero frequency) is not included in this parameter because it is included in the geoid and mean sea surface (geoid, mean_sea_surface_cnescls). To get the total geocentric tide height (FES solution), do: ocean_tide_fes + ocean_tide_non_eq. See SWOT Nadir Altimeter User Handbook</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int32>
+        <Int32 name="mean_dynamic_topography">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int32">
+                <Value>2147483647</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>mean dynamic topography above geoid</Value>
+            </Attribute>
+            <Attribute name="source" type="String">
+                <Value>MDT_CNES_CLS-2018</Value>
+            </Attribute>
+            <Attribute name="institution" type="String">
+                <Value>CLS/CNES</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>m</Value>
+            </Attribute>
+            <Attribute name="scale_factor" type="Float64">
+                <Value>0.0001</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>See SWOT Nadir Altimeter User Handbook</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int32>
+        <Int8 name="rad_side_2_surface_type_flag">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int8">
+                <Value>127</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>radiometer surface type from second radiometer</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>open_ocean near_coast land</Value>
+            </Attribute>
+            <Attribute name="flag_values" type="Int8">
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>2</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int8>
+        <Int8 name="alt_qual">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int8">
+                <Value>127</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>altimeter quality flag</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>good bad</Value>
+            </Attribute>
+            <Attribute name="flag_values" type="Int8">
+                <Value>0</Value>
+                <Value>1</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Compilation of all altimeter flags except altimeter echo type : Set to default in the current issue</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int8>
+        <Int16 name="internal_tide_hret">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int16">
+                <Value>32767</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>internal tide height</Value>
+            </Attribute>
+            <Attribute name="source" type="String">
+                <Value>E. D. Zaron. Baroclinic tidal sea level from exact-repeat mission altimetry. Journal of Physical Oceanography, 49(1):193-210, 2019.</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>m</Value>
+            </Attribute>
+            <Attribute name="scale_factor" type="Float64">
+                <Value>0.0001</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>See SWOT Nadir Altimeter User Handbook</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int16>
+        <Int8 name="meteo_map_availability_flag">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int8">
+                <Value>127</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>ECMWF meteorological map availability</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>2_maps_nominal 2_maps_degraded 1_map_closest_used no_valid_map</Value>
+            </Attribute>
+            <Attribute name="flag_values" type="Int8">
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>3</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Possible values are: 0 meaning \342\200\2312 maps, nominal\342\200\231 (six hours apart), 1 meaning \342\200\2312 maps, degraded\342\200\231 (more than six hours apart), 2 meaning \342\200\2311 map, closest map used\342\200\231, 3 meaning \342\200\231no valid map\342\200\231</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int8>
+        <Int16 name="wind_speed_alt">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int16">
+                <Value>32767</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>altimeter wind speed</Value>
+            </Attribute>
+            <Attribute name="standard_name" type="String">
+                <Value>wind_speed</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>m/s</Value>
+            </Attribute>
+            <Attribute name="scale_factor" type="Float64">
+                <Value>0.01</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Should not be used over land. See SWOT Nadir Altimeter User Handbook. A calibration bias of +0.06 dB has been added to the Ku band backscatter coefficient (/data_01/ku/sig0_ocean) before computing the wind speed</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int16>
+        <Int16 name="wind_speed_alt_mle3">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int16">
+                <Value>32767</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>altimeter wind speed (MLE3 retracking)</Value>
+            </Attribute>
+            <Attribute name="standard_name" type="String">
+                <Value>wind_speed</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>m/s</Value>
+            </Attribute>
+            <Attribute name="scale_factor" type="Float64">
+                <Value>0.01</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Should not be used over land. See SWOT Nadir Altimeter User Handbook. A calibration bias of +0.109 dB has been added to the Ku band backscatter coefficient (/data_01/ku/sig0_ocean_mle3) before computing the wind speed</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int16>
+        <Int8 name="rain_flag">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int8">
+                <Value>127</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>rain flag</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>no_rain rain high_rain_probability_from_altimeter high_probability_of_no_rain_from_altimeter ambiguous_situation_possibility_of_ice evaluation_not_possible</Value>
+            </Attribute>
+            <Attribute name="flag_values" type="Int8">
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>3</Value>
+                <Value>4</Value>
+                <Value>5</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>See SWOT Nadir Altimeter User Handbook</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int8>
+        <Int32 name="mean_sea_surface_cnescls">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int32">
+                <Value>2147483647</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>mean sea surface height (CNES/CLS solution) above reference ellipsoid</Value>
+            </Attribute>
+            <Attribute name="source" type="String">
+                <Value>MSS_CNES_CLS-2015</Value>
+            </Attribute>
+            <Attribute name="institution" type="String">
+                <Value>CLS/CNES</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>m</Value>
+            </Attribute>
+            <Attribute name="scale_factor" type="Float64">
+                <Value>0.0001</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>See SWOT Nadir Altimeter User Handbook</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int32>
+        <Int8 name="geo_qual">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int8">
+                <Value>127</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>geophysical quality flag</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>good bad</Value>
+            </Attribute>
+            <Attribute name="flag_values" type="Int8">
+                <Value>0</Value>
+                <Value>1</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Check on validity of all geophysical fields : Set to default in the current issue</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int8>
+        <Int16 name="rad_cloud_liquid_water">
+            <Dim name="/data_01/time"/>
+            <Attribute name="_FillValue" type="Int16">
+                <Value>32767</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>radiometer liquid water content</Value>
+            </Attribute>
+            <Attribute name="standard_name" type="String">
+                <Value>atmosphere_cloud_liquid_water_content</Value>
+            </Attribute>
+            <Attribute name="source" type="String">
+                <Value>AMR</Value>
+            </Attribute>
+            <Attribute name="institution" type="String">
+                <Value>NASA/JPL</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>kg/m^2</Value>
+            </Attribute>
+            <Attribute name="scale_factor" type="Float64">
+                <Value>0.01</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>longitude latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>Should not be used over land</Value>
+            </Attribute>
+            <Map name="/data_01/longitude"/>
+            <Map name="/data_01/latitude"/>
+        </Int16>
+        <Group name="ku">
+            <Int16 name="iono_cor_alt_filtered_mle3">
+                <Dim name="/data_01/time"/>
+                <Attribute name="_FillValue" type="Int16">
+                    <Value>32767</Value>
+                </Attribute>
+                <Attribute name="long_name" type="String">
+                    <Value>filtered altimeter ionospheric correction on Ku band (MLE3 retracking)</Value>
+                </Attribute>
+                <Attribute name="standard_name" type="String">
+                    <Value>altimeter_range_correction_due_to_ionosphere</Value>
+                </Attribute>
+                <Attribute name="source" type="String">
+                    <Value>Poseidon-3C</Value>
+                </Attribute>
+                <Attribute name="institution" type="String">
+                    <Value>CNES</Value>
+                </Attribute>
+                <Attribute name="units" type="String">
+                    <Value>m</Value>
+                </Attribute>
+                <Attribute name="scale_factor" type="Float64">
+                    <Value>0.0001</Value>
+                </Attribute>
+                <Attribute name="coordinates" type="String">
+                    <Value>/data_01/longitude /data_01/latitude</Value>
+                </Attribute>
+                <Attribute name="comment" type="String">
+                    <Value>An ionospheric correction must be added (negative value) to the instrument range to correct this range measurement for ionospheric range delays of the radar pulse. See SWOT Nadir Altimeter User Handbook</Value>
+                </Attribute>
+                <Map name="/data_01/longitude"/>
+                <Map name="/data_01/latitude"/>
+            </Int16>
+            <Int16 name="sea_state_bias_mle3">
+                <Dim name="/data_01/time"/>
+                <Attribute name="_FillValue" type="Int16">
+                    <Value>32767</Value>
+                </Attribute>
+                <Attribute name="long_name" type="String">
+                    <Value>sea state bias correction in Ku band (MLE3 retracking)</Value>
+                </Attribute>
+                <Attribute name="standard_name" type="String">
+                    <Value>sea_surface_height_bias_due_to_sea_surface_roughness</Value>
+                </Attribute>
+                <Attribute name="source" type="String">
+                    <Value>Empirical solution fitted on Jason-2 GDR_C data</Value>
+                </Attribute>
+                <Attribute name="institution" type="String">
+                    <Value>CLS/CNES</Value>
+                </Attribute>
+                <Attribute name="units" type="String">
+                    <Value>m</Value>
+                </Attribute>
+                <Attribute name="scale_factor" type="Float64">
+                    <Value>0.0001</Value>
+                </Attribute>
+                <Attribute name="coordinates" type="String">
+                    <Value>/data_01/longitude /data_01/latitude</Value>
+                </Attribute>
+                <Attribute name="comment" type="String">
+                    <Value>A sea state bias correction must be added (negative value) to the instrument range to correct this range measurement for sea state delays of the radar pulse. This element should not be used over land. See SWOT Nadir Altimeter User Handbook</Value>
+                </Attribute>
+                <Map name="/data_01/longitude"/>
+                <Map name="/data_01/latitude"/>
+            </Int16>
+            <Int8 name="wvf_main_class">
+                <Dim name="/data_01/time"/>
+                <Attribute name="_FillValue" type="Int8">
+                    <Value>127</Value>
+                </Attribute>
+                <Attribute name="long_name" type="String">
+                    <Value>1 Hz Ku band waveform main class</Value>
+                </Attribute>
+                <Attribute name="flag_meanings" type="String">
+                    <Value>brown_ocean peaky noise strong_peak brown_peak_trailing_edge brown_peak_leading_edge brown_flat_trailing_eadge peak_end trash brown_noise two_leading_edges shifted_brown brown_noise_leading_edge linear_positive_slope linear_negative_slope</Value>
+                </Attribute>
+                <Attribute name="flag_values" type="Int8">
+                    <Value>1</Value>
+                    <Value>2</Value>
+                    <Value>3</Value>
+                    <Value>4</Value>
+                    <Value>5</Value>
+                    <Value>6</Value>
+                    <Value>7</Value>
+                    <Value>8</Value>
+                    <Value>9</Value>
+                    <Value>10</Value>
+                    <Value>11</Value>
+                    <Value>12</Value>
+                    <Value>13</Value>
+                    <Value>15</Value>
+                    <Value>18</Value>
+                </Attribute>
+                <Attribute name="coordinates" type="String">
+                    <Value>/data_01/longitude /data_01/latitude</Value>
+                </Attribute>
+                <Attribute name="comment" type="String">
+                    <Value>Waveform classification : main class selected by classification neural network trained on shape features of the waveforms</Value>
+                </Attribute>
+                <Map name="/data_01/longitude"/>
+                <Map name="/data_01/latitude"/>
+            </Int8>
+            <Int16 name="iono_cor_alt_filtered">
+                <Dim name="/data_01/time"/>
+                <Attribute name="_FillValue" type="Int16">
+                    <Value>32767</Value>
+                </Attribute>
+                <Attribute name="long_name" type="String">
+                    <Value>filtered altimeter ionospheric correction on Ku band</Value>
+                </Attribute>
+                <Attribute name="standard_name" type="String">
+                    <Value>altimeter_range_correction_due_to_ionosphere</Value>
+                </Attribute>
+                <Attribute name="source" type="String">
+                    <Value>Poseidon-3C</Value>
+                </Attribute>
+                <Attribute name="institution" type="String">
+                    <Value>CNES</Value>
+                </Attribute>
+                <Attribute name="units" type="String">
+                    <Value>m</Value>
+                </Attribute>
+                <Attribute name="scale_factor" type="Float64">
+                    <Value>0.0001</Value>
+                </Attribute>
+                <Attribute name="coordinates" type="String">
+                    <Value>/data_01/longitude /data_01/latitude</Value>
+                </Attribute>
+                <Attribute name="comment" type="String">
+                    <Value>An ionospheric correction must be added (negative value) to the instrument range to correct this range measurement for ionospheric range delays of the radar pulse. See SWOT Nadir Altimeter User Handbook</Value>
+                </Attribute>
+                <Map name="/data_01/longitude"/>
+                <Map name="/data_01/latitude"/>
+            </Int16>
+            <Int32 name="range_ocean">
+                <Dim name="/data_01/time"/>
+                <Attribute name="_FillValue" type="Int32">
+                    <Value>2147483647</Value>
+                </Attribute>
+                <Attribute name="long_name" type="String">
+                    <Value>1 Hz Ku band corrected altimeter range</Value>
+                </Attribute>
+                <Attribute name="standard_name" type="String">
+                    <Value>altimeter_range</Value>
+                </Attribute>
+                <Attribute name="units" type="String">
+                    <Value>m</Value>
+                </Attribute>
+                <Attribute name="add_offset" type="Float64">
+                    <Value>800000.</Value>
+                </Attribute>
+                <Attribute name="scale_factor" type="Float64">
+                    <Value>0.0001</Value>
+                </Attribute>
+                <Attribute name="coordinates" type="String">
+                    <Value>/data_01/longitude /data_01/latitude</Value>
+                </Attribute>
+                <Attribute name="comment" type="String">
+                    <Value>All instrumental corrections included, i.e. distance antenna-COG (/data_01/range_cor_cog), USO drift correction (/data_01/range_cor_uso), internal path correction (range_cor_internal_path), Doppler correction (range_cor_doppler), modeled instrumental errors correction (range_cor_ocean_model_instr) and system bias</Value>
+                </Attribute>
+                <Map name="/data_01/longitude"/>
+                <Map name="/data_01/latitude"/>
+            </Int32>
+            <Int16 name="ssha_mle3">
+                <Dim name="/data_01/time"/>
+                <Attribute name="_FillValue" type="Int16">
+                    <Value>32767</Value>
+                </Attribute>
+                <Attribute name="long_name" type="String">
+                    <Value>sea surface height anomaly (MLE3 retracking)</Value>
+                </Attribute>
+                <Attribute name="standard_name" type="String">
+                    <Value>sea_surface_height_above_sea_level</Value>
+                </Attribute>
+                <Attribute name="source" type="String">
+                    <Value>Poseidon-3C</Value>
+                </Attribute>
+                <Attribute name="institution" type="String">
+                    <Value>CNES</Value>
+                </Attribute>
+                <Attribute name="units" type="String">
+                    <Value>m</Value>
+                </Attribute>
+                <Attribute name="scale_factor" type="Float64">
+                    <Value>0.001</Value>
+                </Attribute>
+                <Attribute name="coordinates" type="String">
+                    <Value>/data_01/longitude /data_01/latitude</Value>
+                </Attribute>
+                <Attribute name="comment" type="String">
+                    <Value>= altitude of satellite (/data_01/altitude) - Ku band corrected altimeter range (range_ocean_mle3) - filtered altimeter ionospheric correction on Ku band (iono_cor_alt_filtered_mle3) - model dry tropospheric correction (/data_01/model_dry_tropo_cor_zero_altitude) - radiometer wet tropospheric correction (/data_01/rad_wet_tropo_cor) - sea state bias correction in Ku band (sea_state_bias_mle3) - solid earth tide height (/data_01/solid_earth_tide) - geocentric ocean tide height from FES solution (/data_01/ocean_tide_fes) - non-equilibrium long-period ocean tide height (/data_01/ocean_tide_non_eq) - geocentric pole tide height (/data_01/pole_tide) - internal tide (/data_01/internal_tide_hret) - dynamic atmospheric correction (/data_01/dac) - mean sea surface from CNES/CLS solution (/data_01/mean_sea_surface_cnescls). Set to default if the waveform classification (wvf_main_class) is not set to 1 = brown ocean, 12 = shifted brown, 13 = brown noise leading edge or 15 = linear positive_slope, or if the radiometer wet tropospheric interpolation quality flag (/data_01/rad_wet_tropo_cor_interp_qual) is set to 2 = fail</Value>
+                </Attribute>
+                <Map name="/data_01/longitude"/>
+                <Map name="/data_01/latitude"/>
+            </Int16>
+            <Int16 name="sig0_ocean">
+                <Dim name="/data_01/time"/>
+                <Attribute name="_FillValue" type="Int16">
+                    <Value>32767</Value>
+                </Attribute>
+                <Attribute name="long_name" type="String">
+                    <Value>Ku band corrected backscatter coefficient</Value>
+                </Attribute>
+                <Attribute name="standard_name" type="String">
+                    <Value>surface_backwards_scattering_coefficient_of_radar_wave</Value>
+                </Attribute>
+                <Attribute name="units" type="String">
+                    <Value>dB</Value>
+                </Attribute>
+                <Attribute name="scale_factor" type="Float64">
+                    <Value>0.01</Value>
+                </Attribute>
+                <Attribute name="coordinates" type="String">
+                    <Value>/data_01/longitude /data_01/latitude</Value>
+                </Attribute>
+                <Attribute name="comment" type="String">
+                    <Value>All instrumental corrections included, excepted the system bias, i.e. AGC instrumental errors correction, internal calibration correction (sig0_cor_calibration), modeled instrumental errors correction (sig0_cor_ocean_model_instr) and atmospheric attenuation (sig0_cor_atm)</Value>
+                </Attribute>
+                <Map name="/data_01/longitude"/>
+                <Map name="/data_01/latitude"/>
+            </Int16>
+            <Int16 name="sig0_ocean_mle3">
+                <Dim name="/data_01/time"/>
+                <Attribute name="_FillValue" type="Int16">
+                    <Value>32767</Value>
+                </Attribute>
+                <Attribute name="long_name" type="String">
+                    <Value>Ku band corrected backscatter coefficient (MLE3 retracking)</Value>
+                </Attribute>
+                <Attribute name="standard_name" type="String">
+                    <Value>surface_backwards_scattering_coefficient_of_radar_wave</Value>
+                </Attribute>
+                <Attribute name="units" type="String">
+                    <Value>dB</Value>
+                </Attribute>
+                <Attribute name="scale_factor" type="Float64">
+                    <Value>0.01</Value>
+                </Attribute>
+                <Attribute name="coordinates" type="String">
+                    <Value>/data_01/longitude /data_01/latitude</Value>
+                </Attribute>
+                <Attribute name="comment" type="String">
+                    <Value>All instrumental corrections included, excepted the system bias, i.e. AGC instrumental errors correction, internal calibration correction (sig0_cor_calibration), modeled instrumental errors correction (sig0_cor_ocean_mle3_model_instr) and atmospheric attenuation (sig0_cor_atm)</Value>
+                </Attribute>
+                <Map name="/data_01/longitude"/>
+                <Map name="/data_01/latitude"/>
+            </Int16>
+            <Int16 name="sea_state_bias">
+                <Dim name="/data_01/time"/>
+                <Attribute name="_FillValue" type="Int16">
+                    <Value>32767</Value>
+                </Attribute>
+                <Attribute name="long_name" type="String">
+                    <Value>sea state bias correction in Ku band</Value>
+                </Attribute>
+                <Attribute name="standard_name" type="String">
+                    <Value>sea_surface_height_bias_due_to_sea_surface_roughness</Value>
+                </Attribute>
+                <Attribute name="source" type="String">
+                    <Value>Tran2020 empirical solution fitted on one year of Jason-3 GDR_F data from MLE4 retracking</Value>
+                </Attribute>
+                <Attribute name="institution" type="String">
+                    <Value>CLS/CNES</Value>
+                </Attribute>
+                <Attribute name="units" type="String">
+                    <Value>m</Value>
+                </Attribute>
+                <Attribute name="scale_factor" type="Float64">
+                    <Value>0.0001</Value>
+                </Attribute>
+                <Attribute name="coordinates" type="String">
+                    <Value>/data_01/longitude /data_01/latitude</Value>
+                </Attribute>
+                <Attribute name="comment" type="String">
+                    <Value>A sea state bias correction must be added (negative value) to the instrument range to correct this range measurement for sea state delays of the radar pulse. This element should not be used over land. See SWOT Nadir Altimeter User Handbook</Value>
+                </Attribute>
+                <Map name="/data_01/longitude"/>
+                <Map name="/data_01/latitude"/>
+            </Int16>
+            <Int16 name="swh_ocean">
+                <Dim name="/data_01/time"/>
+                <Attribute name="_FillValue" type="Int16">
+                    <Value>32767</Value>
+                </Attribute>
+                <Attribute name="long_name" type="String">
+                    <Value>Ku band corrected significant waveheight</Value>
+                </Attribute>
+                <Attribute name="standard_name" type="String">
+                    <Value>sea_surface_wave_significant_height</Value>
+                </Attribute>
+                <Attribute name="units" type="String">
+                    <Value>m</Value>
+                </Attribute>
+                <Attribute name="scale_factor" type="Float64">
+                    <Value>0.001</Value>
+                </Attribute>
+                <Attribute name="coordinates" type="String">
+                    <Value>/data_01/longitude /data_01/latitude</Value>
+                </Attribute>
+                <Attribute name="comment" type="String">
+                    <Value>All instrumental corrections included, i.e. modeled instrumental errors correction (swh_cor_ocean_model_instr) and system bias</Value>
+                </Attribute>
+                <Map name="/data_01/longitude"/>
+                <Map name="/data_01/latitude"/>
+            </Int16>
+            <Int32 name="range_ocean_mle3">
+                <Dim name="/data_01/time"/>
+                <Attribute name="_FillValue" type="Int32">
+                    <Value>2147483647</Value>
+                </Attribute>
+                <Attribute name="long_name" type="String">
+                    <Value>1 Hz Ku band corrected altimeter range (MLE3 retracking)</Value>
+                </Attribute>
+                <Attribute name="standard_name" type="String">
+                    <Value>altimeter_range</Value>
+                </Attribute>
+                <Attribute name="units" type="String">
+                    <Value>m</Value>
+                </Attribute>
+                <Attribute name="add_offset" type="Float64">
+                    <Value>800000.</Value>
+                </Attribute>
+                <Attribute name="scale_factor" type="Float64">
+                    <Value>0.0001</Value>
+                </Attribute>
+                <Attribute name="coordinates" type="String">
+                    <Value>/data_01/longitude /data_01/latitude</Value>
+                </Attribute>
+                <Attribute name="comment" type="String">
+                    <Value>All instrumental corrections included, i.e. distance antenna-COG (/data_01/range_cor_cog), USO drift correction (/data_01/range_cor_uso), internal path correction (range_cor_internal_path), Doppler correction (range_cor_doppler), modeled instrumental errors correction (range_cor_ocean_mle3_model_instr) and system bias</Value>
+                </Attribute>
+                <Map name="/data_01/longitude"/>
+                <Map name="/data_01/latitude"/>
+            </Int32>
+            <Int16 name="ssha">
+                <Dim name="/data_01/time"/>
+                <Attribute name="_FillValue" type="Int16">
+                    <Value>32767</Value>
+                </Attribute>
+                <Attribute name="long_name" type="String">
+                    <Value>sea surface height anomaly</Value>
+                </Attribute>
+                <Attribute name="standard_name" type="String">
+                    <Value>sea_surface_height_above_sea_level</Value>
+                </Attribute>
+                <Attribute name="source" type="String">
+                    <Value>Poseidon-3C</Value>
+                </Attribute>
+                <Attribute name="institution" type="String">
+                    <Value>CNES</Value>
+                </Attribute>
+                <Attribute name="units" type="String">
+                    <Value>m</Value>
+                </Attribute>
+                <Attribute name="scale_factor" type="Float64">
+                    <Value>0.001</Value>
+                </Attribute>
+                <Attribute name="coordinates" type="String">
+                    <Value>/data_01/longitude /data_01/latitude</Value>
+                </Attribute>
+                <Attribute name="comment" type="String">
+                    <Value>= altitude of satellite (/data_01/altitude) - Ku band corrected altimeter range (range_ocean) - filtered altimeter ionospheric correction on Ku band (iono_cor_alt_filtered) - model dry tropospheric correction (/data_01/model_dry_tropo_cor_zero_altitude) - radiometer wet tropospheric correction (/data_01/rad_wet_tropo_cor) - sea state bias correction in Ku band (sea_state_bias) - solid earth tide height (/data_01/solid_earth_tide) - geocentric ocean tide height from FES solution (/data_01/ocean_tide_fes) - non-equilibrium long-period ocean tide height (/data_01/ocean_tide_non_eq) - geocentric pole tide height (/data_01/pole_tide) - internal tide (/data_01/internal_tide_hret) - dynamic atmospheric correction (/data_01/dac) - mean sea surface from CNES/CLS solution (/data_01/mean_sea_surface_cnescls). Set to default if the waveform classification (wvf_main_class) is not set to 1 = brown ocean, 12 = shifted brown, 13 = brown noise leading edge or 15 = linear positive_slope, or if the radiometer wet tropospheric interpolation quality flag (/data_01/rad_wet_tropo_cor_interp_qual) is set to 2 = fail</Value>
+                </Attribute>
+                <Map name="/data_01/longitude"/>
+                <Map name="/data_01/latitude"/>
+            </Int16>
+            <Int16 name="swh_ocean_mle3">
+                <Dim name="/data_01/time"/>
+                <Attribute name="_FillValue" type="Int16">
+                    <Value>32767</Value>
+                </Attribute>
+                <Attribute name="long_name" type="String">
+                    <Value>Ku band corrected significant waveheight (MLE3 retracking)</Value>
+                </Attribute>
+                <Attribute name="standard_name" type="String">
+                    <Value>sea_surface_wave_significant_height</Value>
+                </Attribute>
+                <Attribute name="units" type="String">
+                    <Value>m</Value>
+                </Attribute>
+                <Attribute name="scale_factor" type="Float64">
+                    <Value>0.001</Value>
+                </Attribute>
+                <Attribute name="coordinates" type="String">
+                    <Value>/data_01/longitude /data_01/latitude</Value>
+                </Attribute>
+                <Attribute name="comment" type="String">
+                    <Value>All instrumental corrections included, i.e. modeled instrumental errors correction (swh_cor_ocean_mle3_model_instr) and system bias</Value>
+                </Attribute>
+                <Map name="/data_01/longitude"/>
+                <Map name="/data_01/latitude"/>
+            </Int16>
+        </Group>
+    </Group>
+</Dataset>

--- a/src/pydap/tests/test_parsers_dap.py
+++ b/src/pydap/tests/test_parsers_dap.py
@@ -36,7 +36,7 @@ def test_jpl2():
 def test_coads():
     file_path = "data/daps/coads_climatology.nc.dap"
     dataset = load_dap(file_path)
-    values = dataset["SST"][0, 2, 0:3].data
+    values = dataset["SST"].array[0, 2, 0:3].data
     expected = numpy.array([0.12833333, -0.05000002, -0.06363636], dtype="float32")
     numpy.testing.assert_almost_equal(values, expected)
 

--- a/src/pydap/tests/test_parsers_dap.py
+++ b/src/pydap/tests/test_parsers_dap.py
@@ -36,7 +36,7 @@ def test_jpl2():
 def test_coads():
     file_path = "data/daps/coads_climatology.nc.dap"
     dataset = load_dap(file_path)
-    values = dataset["SST"].array[0, 2, 0:3].data
+    values = dataset["SST"][0, 2, 0:3].data
     expected = numpy.array([0.12833333, -0.05000002, -0.06363636], dtype="float32")
     numpy.testing.assert_almost_equal(values, expected)
 

--- a/src/pydap/tests/test_parsers_dmr.py
+++ b/src/pydap/tests/test_parsers_dmr.py
@@ -55,3 +55,10 @@ def test_mod05():
         "Cell_Along_Swath_5km",
         "Cell_Across_Swath_5km",
     ]
+
+
+def test_SWOT():
+    dataset = load_dmr_file("data/dmrs/SWOT_GPR.dmr")
+    # pick a single variable Maps
+    maps = ("/data_01/longitude", "/data_01/latitude")
+    assert dataset["data_01/ku/swh_ocean"].Maps == maps

--- a/src/pydap/tests/test_responses_dmr.py
+++ b/src/pydap/tests/test_responses_dmr.py
@@ -19,7 +19,7 @@ def load_dmr_file(file_path):
     return text
 
 
-class TestDDSResponseSequence(unittest.TestCase):
+class TestDMRResponseSequence(unittest.TestCase):
     """Test DRM response from sequences."""
 
     def setUp(self):


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes an already existing opened issue #326  for removing GridType arrays from dmr parsers, thus there are no longer GridArrays in DAP4 datasets (there are simply arrays). This simplifies the Dataset model.
- [x] Tests are adjusted to fix the lack of GridType arrays.

In the example in #326, now:
```python
url = "dap4://oceandata.sci.gsfc.nasa.gov/opendap/PACE_OCI/L3SMI/2024/0301/PACE_OCI.20240301_20240331.L3m.MO.CHL.V2_0.chlor_a.0p1deg.NRT.nc"
ds = open_url(url)
ds['chlor_a']
>>> <BaseType with data Dap4BaseProxy()...>
```
And ```ds.tree()``` yields:
```python
.PACE_OCI.20240301_20240331.L3m.MO.CHL.V2_0.chlor_a.0p1deg.NRT.nc
├──lat
├──lon
├──chlor_a
├──palette
├──rgb
└──eightbitcolor
```


 A much simpler `pydap` dataset model in DAP4. 

Am I correctly interpreting one of many differences between DAP4 & DAP2 @jgallagher59701 ?


