### PR TITLE
Point to `main` branch on GH/workflows

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,5 +4,5 @@ The following Pull Request:
 
 - [ ] Closes an already existing opened issue #xxxx for fixing a bug, requesting
 a new feature, etc.
-- [ ] Tests are added to demostrate the new or fixed behavior, and all tests pass
+- [ ] Tests are added to demonstrate the new or fixed behavior, and all tests pass
 on a local environment.

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/run_tests_macos.yml
+++ b/.github/workflows/run_tests_macos.yml
@@ -23,7 +23,12 @@ jobs:
     - name: install hdf5
       run: |
         brew install hdf5
-    - name: Install dependencies python -m pip install --upgrade pip python -m pip install -U pip setuptools python -m pip install -e .[tests,netcdf,client] conda list
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -U pip setuptools
+        python -m pip install -e .[tests,netcdf,client]
+        conda list
 
     - name: Run tests with pytest
       run: |

--- a/.github/workflows/run_tests_macos.yml
+++ b/.github/workflows/run_tests_macos.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -U pip setuptools
-        python -m pip install -e .[tests,netcdf,client]
+        pip -e .[tests,netcdf,client]
 
     - name: Run tests with pytest
       run: |

--- a/.github/workflows/run_tests_macos.yml
+++ b/.github/workflows/run_tests_macos.yml
@@ -23,7 +23,8 @@ jobs:
     - name: install hdf5
       run: |
         brew install hdf5
+    - name: Install dependencies python -m pip install --upgrade pip python -m pip install -U pip setuptools python -m pip install -e .[tests,netcdf,client] conda list
+
     - name: Run tests with pytest
       run: |
-        pip install -e .[tests,netcdf,client]
         pytest

--- a/.github/workflows/run_tests_macos.yml
+++ b/.github/workflows/run_tests_macos.yml
@@ -28,7 +28,6 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install -U pip setuptools
         python -m pip install -e .[tests,netcdf,client]
-        conda list
 
     - name: Run tests with pytest
       run: |

--- a/.github/workflows/run_tests_macos.yml
+++ b/.github/workflows/run_tests_macos.yml
@@ -2,10 +2,10 @@ name: Run Python Tests on MacOS
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   build:

--- a/.github/workflows/run_tests_macos.yml
+++ b/.github/workflows/run_tests_macos.yml
@@ -23,12 +23,6 @@ jobs:
     - name: install hdf5
       run: |
         brew install hdf5
-    - name: Install dependencies
-      run: |
-        pip3 install -U pip setuptools
-        pip3 install -U "werkzeug<2.1"
-        pip3 install -U numpy webtest gsw coards
-        pip3 install -U netCDF4 pytest Webob Jinja2 docopt-ng beautifulsoup4 requests testresources
     - name: Run tests with pytest
       run: |
         pip install -e .[tests,netcdf,client]

--- a/.github/workflows/run_tests_macos.yml
+++ b/.github/workflows/run_tests_macos.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -U pip setuptools
-        pip -e .[tests,netcdf,client]
+        pip install -e .[tests,netcdf,client]
 
     - name: Run tests with pytest
       run: |

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -U pip setuptools
-        python -m pip install -e .[tests,netcdf,client]
+        pip -e .[tests,netcdf,client]
 
     - name: Run tests with pytest
       run: |

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -25,7 +25,6 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install -U pip setuptools
         python -m pip install -e .[tests,netcdf,client]
-        conda list
 
     - name: Run tests with pytest
       run: |

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -U pip setuptools
-        pip -e .[tests,netcdf,client]
+        pip install -e .[tests,netcdf,client]
 
     - name: Run tests with pytest
       run: |

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -20,7 +20,12 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies python -m pip install --upgrade pip python -m pip install -U pip setuptools python -m pip install -e .[tests,netcdf,client] conda list
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -U pip setuptools
+        python -m pip install -e .[tests,netcdf,client]
+        conda list
 
     - name: Run tests with pytest
       run: |

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -20,13 +20,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip3 install -U pip setuptools
-        pip3 install -U "werkzeug>=2.2.2" cryptography
-        pip3 install -U numpy webtest gsw coards
-        pip3 install -U netCDF4 pytest Webob Jinja2 docopt-ng beautifulsoup4 requests testresources
     - name: Run tests with pytest
       run: |
         pip install -e .[tests,netcdf,client]

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -2,10 +2,10 @@ name: Run Python Tests
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   build:

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -20,9 +20,8 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Run tests with pytest
-      run: |
-        pip install -e .[tests,netcdf,client]
+    - name: Install dependencies python -m pip install --upgrade pip python -m pip install -U pip setuptools python -m pip install -e .[tests,netcdf,client] conda list
+
     - name: Run tests with pytest
       run: |
         pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # https://pre-commit.com/
 ci:
   autofix_prs: false
-  autoupdate_branch: 'master'
+  autoupdate_branch: 'main'
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
   autoupdate_schedule: weekly
   skip: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,9 @@ tests = [
   'flake8',
   'werkzeug>= 2.2.2',
   'gunicorn',
-  'cryptography'
+  'cryptography',
+  'gsw',
+  'coards'
 ]
 
 [tool.isort]


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Points all checks under `github/workflows` to the renamed branch `main`. 
- [x] Also fixes some unnecessary dependency installations for running tests. Those dependencies are already set to be installed in `pyproject.toml `