### PR TITLE
resolve Numpy>1.25 deprecation error

### DIFF
--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -178,11 +178,10 @@ def encode(obj):
     if isinstance(obj, str) or isinstance(obj, np.ndarray) and obj.dtype.char in "SU":
         return '"{0}"'.format(obj)
 
-    # fix for DeprecationWarning: Conversion of an array with ndim > 0 to a 
+    # fix for DeprecationWarning: Conversion of an array with ndim > 0 to a
     # scalar is deprecated
     if isinstance(obj, np.ndarray) and np.ndim(obj) > 0:
         arr_str = np.array2string(obj, formatter={"float_kind": lambda x: f"{x:.6f}"})
-        # arr_str = np.array2string(obj, separator=' ', precision=7, suppress_small=True)
         return f'"[{arr_str[1:-1]}]"'
     else:
         try:

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -178,10 +178,17 @@ def encode(obj):
     if isinstance(obj, str) or isinstance(obj, np.ndarray) and obj.dtype.char in "SU":
         return '"{0}"'.format(obj)
 
-    try:
-        return "%.6g" % obj
-    except Exception:
-        return '"{0}"'.format(obj)
+    # fix for DeprecationWarning: Conversion of an array with ndim > 0 to a 
+    # scalar is deprecated
+    if isinstance(obj, np.ndarray) and np.ndim(obj) > 0:
+        arr_str = np.array2string(obj, formatter={"float_kind": lambda x: f"{x:.6f}"})
+        # arr_str = np.array2string(obj, separator=' ', precision=7, suppress_small=True)
+        return f'"[{arr_str[1:-1]}]"'
+    else:
+        try:
+            return "%.6g" % obj
+        except Exception:
+            return '"{0}"'.format(obj)
 
 
 def fix_slice(slice_, shape):

--- a/src/pydap/tests/test_lib.py
+++ b/src/pydap/tests/test_lib.py
@@ -82,7 +82,7 @@ class TestEncode(unittest.TestCase):
         # associated with Deprecation warning numpy > 1.25
         # see GH issue https://github.com/pydap/pydap/issues/319
         # also PR https://github.com/pydap/pydap/pull/343
-        array = np.array([(2.300110099991, 4.)])
+        array = np.array([(2.300110099991, 4.0)])
         self.assertEqual(encode(array), '"[[2.300110 4.000000]]"')
 
 

--- a/src/pydap/tests/test_lib.py
+++ b/src/pydap/tests/test_lib.py
@@ -77,6 +77,14 @@ class TestEncode(unittest.TestCase):
     def test_numpy_string(self):
         self.assertEqual(encode(np.array("1", dtype="<U1")), '"1"')
 
+    def test_numpy_ndim_gt_0(self):
+        # test a numpy array with ndim > 0
+        # associated with Deprecation warning numpy > 1.25
+        # see GH issue https://github.com/pydap/pydap/issues/319
+        # also PR https://github.com/pydap/pydap/pull/343
+        array = np.array([(2.300110099991, 4.)])
+        self.assertEqual(encode(array), '"[[2.300110 4.000000]]"')
+
 
 class TestFixSlice(unittest.TestCase):
     """Test the ``fix_slice`` function."""


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->


The following Pull Request:

- [x] Solves one of two pending Deprecation warnings described on issue #319.
- [x] Tests are added to demonstrate the new or fixed behavior, and all tests pass
on a local environment.
