### PR TITLE
Implicit discovery of entry points

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -9,6 +9,7 @@ dependencies:
 - pytest-env
 - codecov
 - scipy
+- pre-commit
 - pip
 - pip:
   - werkzeug >= 2.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
   "docopt-ng",
   "beautifulsoup4",
   "lxml",
-  "requests"
+  "requests",
+  "importlib-metadata"
 ]
 description = "A pure python implementation of the Data Access Protocol."
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
   "beautifulsoup4",
   "lxml",
   "requests",
-  "importlib-metadata"
+  "importlib-metadata",
+  "importlib-resources"
 ]
 description = "A pure python implementation of the Data Access Protocol."
 dynamic = ["version"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,5 @@ markers =
     good_url
     auth
 filterwarnings =
-    ignore:.*:DeprecationWarning
     ignore:.*:UserWarning
     ignore:.*blockwise.*:UserWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,5 +8,6 @@ markers =
     good_url
     auth
 filterwarnings =
+    ignore:.*:DeprecationWarning
     ignore:.*:UserWarning
     ignore:.*blockwise.*:UserWarning

--- a/src/pydap/handlers/csv/__init__.py
+++ b/src/pydap/handlers/csv/__init__.py
@@ -9,8 +9,6 @@ import time
 from email.utils import formatdate
 from stat import ST_MTIME
 
-from pkg_resources import get_distribution
-
 from ...exceptions import OpenFileError
 from ...handlers.lib import BaseHandler, IterData
 from ...model import BaseType, DatasetType, SequenceType
@@ -106,7 +104,6 @@ class CSVHandler(BaseHandler):
         >>> temp_file.remove()
     """
 
-    __version__ = get_distribution("pydap").version
     extensions = re.compile(r"^.*\.csv$", re.IGNORECASE)
 
     def __init__(self, filepath):

--- a/src/pydap/handlers/lib.py
+++ b/src/pydap/handlers/lib.py
@@ -14,20 +14,14 @@ import itertools
 import operator
 import re
 import sys
-from importlib.metadata import entry_points
 
 import numpy as np
+from importlib_metadata import entry_points
 from numpy.lib import Arrayterator
 from webob import Request
 
 from pydap.exceptions import ConstraintExpressionError, ExtensionNotSupportedError
-from pydap.lib import (
-    encode,
-    fix_shorthand,
-    get_var,
-    load_from_entry_point_relative,
-    walk,
-)
+from pydap.lib import encode, fix_shorthand, get_var, walk
 from pydap.model import BaseType, DatasetType, GridType, SequenceType, StructureType
 from pydap.parsers import parse_ce, parse_selection
 from pydap.responses.error import ErrorResponse
@@ -44,9 +38,9 @@ def load_handlers():
     eps = entry_points(group="pydap.handler")
     Rs = [r for r in eps if r.module[:5] == "pydap"]
     nRs = [r for r in eps if r.module[:5] != "pydap"]
-    base_dict = dict(load_from_entry_point_relative(r, "pydap") for r in Rs)
+    base_dict = dict((r.name, r.load()) for r in Rs)
 
-    opts_dict = dict(load_from_entry_point_relative(r, "pydap") for r in nRs)
+    opts_dict = dict((r.name, r.load()) for r in nRs)
     base_dict.update(opts_dict)
     return base_dict.values()
 

--- a/src/pydap/handlers/netcdf/__init__.py
+++ b/src/pydap/handlers/netcdf/__init__.py
@@ -8,7 +8,6 @@ from email.utils import formatdate
 from stat import ST_MTIME
 
 import numpy as np
-from pkg_resources import get_distribution
 
 from pydap.exceptions import OpenFileError
 from pydap.handlers.lib import BaseHandler
@@ -35,7 +34,6 @@ class NetCDFHandler(BaseHandler):
     Here's a standard dataset for testing sequential data:
     """
 
-    __version__ = get_distribution("pydap").version
     extensions = re.compile(r"^.*\.(nc|cdf)$", re.IGNORECASE)
 
     def __init__(self, filepath):

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -368,17 +368,7 @@ def decode_np_strings(numpy_var):
 
 def load_from_entry_point_relative(r, package):
     try:
-        loaded = getattr(
-            __import__(
-                r.module_name.replace(package + ".", "", 1),
-                globals(),
-                None,
-                [r.attrs[0]],
-                1,
-            ),
-            r.attrs[0],
-        )
-        return r.name, loaded
+        return r.name, r.load()
     except ImportError:
         # This is only used in handlers testing:
         return r.name, r.load()

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -366,14 +366,6 @@ def decode_np_strings(numpy_var):
         return numpy_var
 
 
-def load_from_entry_point_relative(r, package):
-    try:
-        return r.name, r.load()
-    except ImportError:
-        # This is only used in handlers testing:
-        return r.name, r.load()
-
-
 class StreamReader(object):
     """Class to allow reading a `urllib3.HTTPResponse`."""
 

--- a/src/pydap/responses/lib.py
+++ b/src/pydap/responses/lib.py
@@ -10,21 +10,20 @@ KML, WMS, JSON, etc., installed as third-party Python packages that declare the
 
 """
 
-from importlib.metadata import entry_points
+from importlib_metadata import entry_points
 
-from ..lib import __version__, load_from_entry_point_relative
+from ..lib import __version__
 from ..model import DatasetType
 
 
 def load_responses():
     """Load all available responses from the system, returning a dictionary."""
-
     eps = entry_points(group="pydap.response")
     Rs = [r for r in eps if r.module[:5] == "pydap"]
     nRs = [r for r in eps if r.module[:5] != "pydap"]
-    base_dict = dict(load_from_entry_point_relative(r, "pydap") for r in Rs)
+    base_dict = dict((r.name, r.load()) for r in Rs)
 
-    opts_dict = dict(load_from_entry_point_relative(r, "pydap") for r in nRs)
+    opts_dict = dict((r.name, r.load()) for r in nRs)
     base_dict.update(opts_dict)
     return base_dict
 

--- a/src/pydap/responses/lib.py
+++ b/src/pydap/responses/lib.py
@@ -10,7 +10,7 @@ KML, WMS, JSON, etc., installed as third-party Python packages that declare the
 
 """
 
-from pkg_resources import iter_entry_points
+from importlib.metadata import entry_points
 
 from ..lib import __version__, load_from_entry_point_relative
 from ..model import DatasetType
@@ -18,19 +18,13 @@ from ..model import DatasetType
 
 def load_responses():
     """Load all available responses from the system, returning a dictionary."""
-    # Relative import of responses:
-    package = "pydap"
-    entry_points = "pydap.response"
-    base_dict = dict(
-        load_from_entry_point_relative(r, package)
-        for r in iter_entry_points(entry_points)
-        if r.module_name.startswith(package)
-    )
-    opts_dict = dict(
-        (r.name, r.load())
-        for r in iter_entry_points(entry_points)
-        if not r.module_name.startswith(package)
-    )
+
+    eps = entry_points(group="pydap.response")
+    Rs = [r for r in eps if r.module[:5] == "pydap"]
+    nRs = [r for r in eps if r.module[:5] != "pydap"]
+    base_dict = dict(load_from_entry_point_relative(r, "pydap") for r in Rs)
+
+    opts_dict = dict(load_from_entry_point_relative(r, "pydap") for r in nRs)
     base_dict.update(opts_dict)
     return base_dict
 

--- a/src/pydap/responses/version.py
+++ b/src/pydap/responses/version.py
@@ -1,11 +1,9 @@
 """Response with information about pydap version."""
 
 import sys
-
-# from pkg_resources import iter_entry_points
-from importlib.metadata import entry_points
 from json import dumps
 
+from importlib_metadata import entry_points
 from webob import Response
 
 from ..lib import __dap__, __version__

--- a/src/pydap/responses/version.py
+++ b/src/pydap/responses/version.py
@@ -1,9 +1,11 @@
 """Response with information about pydap version."""
 
 import sys
+
+# from pkg_resources import iter_entry_points
+from importlib.metadata import entry_points
 from json import dumps
 
-from pkg_resources import iter_entry_points
 from webob import Response
 
 from ..lib import __dap__, __version__
@@ -24,15 +26,15 @@ class VersionResponse(object):
             "dap": __dap__,
             "handlers": dict(
                 (ep.name, getattr(ep.load(), "__version__", "Unknown"))
-                for ep in iter_entry_points("pydap.handler")
+                for ep in entry_points(group="pydap.handler")
             ),
             "responses": dict(
                 (ep.name, getattr(ep.load(), "__version__", "Unknown"))
-                for ep in iter_entry_points("pydap.response")
+                for ep in entry_points(group="pydap.response")
             ),
             "functions": dict(
                 (ep.name, getattr(ep.load(), "__version__", "Unknown"))
-                for ep in iter_entry_points("pydap.function")
+                for ep in entry_points(group="pydap.function")
             ),
             "python": sys.version,
         }

--- a/src/pydap/tests/test_handlers_lib.py
+++ b/src/pydap/tests/test_handlers_lib.py
@@ -11,12 +11,9 @@ from pydap.exceptions import ConstraintExpressionError
 from pydap.handlers.lib import (
     BaseHandler,
     ConstraintExpression,
-    ExtensionNotSupportedError,
     IterData,
     apply_projection,
     apply_selection,
-    get_handler,
-    load_handlers,
 )
 from pydap.lib import walk
 from pydap.model import BaseType, SequenceType, StructureType
@@ -29,31 +26,6 @@ from pydap.tests.datasets import (
     SimpleStructure,
     VerySimpleSequence,
 )
-
-
-class TestHandlersLib(unittest.TestCase):
-    """Test handler loading."""
-
-    def test_load_handlers(self):
-        """Test that handlers can be loaded correctly.
-
-        We use a mock working set, since by default no handlers are installed
-        with pydap.
-
-        """
-        handlers = load_handlers(MockWorkingSet())
-        self.assertTrue(MockHandler in handlers)
-
-    def test_get_handler(self):
-        """Test that we can load a specific handler."""
-        handlers = load_handlers(MockWorkingSet())
-        handler = get_handler("file.foo", handlers)
-        self.assertIsInstance(handler, MockHandler)
-
-    def test_no_handler_available(self):
-        """Test exception raised when file not supported."""
-        with self.assertRaises(ExtensionNotSupportedError):
-            get_handler("file.bar")
 
 
 class TestBaseHandler(unittest.TestCase):

--- a/src/pydap/wsgi/ssf.py
+++ b/src/pydap/wsgi/ssf.py
@@ -10,9 +10,9 @@ import ast
 import operator
 import re
 from functools import reduce
-from importlib.metadata import entry_points
 
 import numpy as np
+from importlib_metadata import entry_points
 from webob import Request
 
 from ..exceptions import ServerError

--- a/src/pydap/wsgi/ssf.py
+++ b/src/pydap/wsgi/ssf.py
@@ -17,7 +17,7 @@ from webob import Request
 
 from ..exceptions import ServerError
 from ..handlers.lib import BaseHandler, apply_projection
-from ..lib import fix_shorthand, load_from_entry_point_relative, walk
+from ..lib import fix_shorthand, walk
 from ..model import DatasetType, SequenceType
 from ..parsers import parse_ce
 
@@ -31,9 +31,9 @@ def load_functions():
     eps = entry_points(group="pydap.function")
     Rs = [r for r in eps if r.module[:5] == "pydap"]
     nRs = [r for r in eps if r.module[:5] != "pydap"]
-    base_dict = dict(load_from_entry_point_relative(r, "pydap") for r in Rs)
+    base_dict = dict((r.name, r.load()) for r in Rs)
 
-    opts_dict = dict(load_from_entry_point_relative(r, "pydap") for r in nRs)
+    opts_dict = dict((r.name, r.load()) for r in nRs)
     base_dict.update(opts_dict)
     return base_dict
 


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- Migrates away from the deprecated `pkg_resources` and adds `importlib-metadata` and `importlib-resources`, which remain compatible with Python 3.9. In the near future (when Python 3.9 is no longer actively maintained), we can drop these new dependencies. In theory we should be able to replace them with`importlib.metadata` and `importlib.resources` with very minimal syntax changes (`importlib is already included within `setuptools`, but changed behavior starting with Python 3.10).

Broadly,

- [x] Closes #319.
- [X] New Tests are not added but all tests pass on a local environment.

