### PR TITLE
correctly define `named dimensions` at `root` level

### DIFF
--- a/src/pydap/parsers/dmr.py
+++ b/src/pydap/parsers/dmr.py
@@ -216,8 +216,6 @@ def dmr_to_dataset(dmr):
         if "maps" in variable.keys():
             array.Maps = variable["maps"]
         var = array
-        if "skip_proxy" in variable.keys():
-            variable["attributes"]["skip"] = True
         var.attributes = variable["attributes"]
         if "parent" in variable.keys() and variable["parent"] in [
             "Sequence",

--- a/src/pydap/parsers/dmr.py
+++ b/src/pydap/parsers/dmr.py
@@ -162,6 +162,14 @@ def dmr_to_dataset(dmr):
     variables = get_variables(dom_et)
     named_dimensions = get_named_dimensions(dom_et)
 
+    # get Global dimensions at root level
+    global_dimensions = []
+    for name, size in named_dimensions.items():
+        if len(name.split("/")) == 1:
+            global_dimensions.append([name, size])
+
+    dataset.dimensions = tuple(tuple(item) for item in global_dimensions)
+
     # Add size entry for dimension variables
     for name, size in named_dimensions.items():
         if name in variables:

--- a/src/pydap/tests/data/dmrs/SimpleGroup.dmr
+++ b/src/pydap/tests/data/dmrs/SimpleGroup.dmr
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xml:base="http://localhost:8001" dapVersion="4.0" dmrVersion="1.0" name="example%20dataset">
+    <Dimension name="time" size="1"/>
+    <Dimension name="nv" size="2"/>
     <Group name="SimpleGroup">
-        <Dimension name="X" size="4"/>
         <Dimension name="Y" size="4"/>
+        <Dimension name="X" size="4"/>
         <Float32 name="Temperature">
-            <Dim name="/SimpleGroup/X"/>
+            <Dim name="/time"/>
             <Dim name="/SimpleGroup/Y"/>
+            <Dim name="/SimpleGroup/X"/>
             <Attribute name="units" type="str">
                 <Value>degrees_celsius</Value>
             </Attribute>
@@ -14,8 +17,9 @@
             </Attribute>
         </Float32>
         <Float32 name="Salinity">
-            <Dim name="/SimpleGroup/X"/>
+            <Dim name="/time"/>
             <Dim name="/SimpleGroup/Y"/>
+            <Dim name="/SimpleGroup/X"/>
             <Attribute name="units" type="str">
                 <Value>psu</Value>
             </Attribute>
@@ -23,11 +27,24 @@
                 <Value>nan</Value>
             </Attribute>
         </Float32>
-        <Int16 name="X">
-            <Dim name="/SimpleGroup/X"/>
-        </Int16>
         <Int16 name="Y">
             <Dim name="/SimpleGroup/Y"/>
         </Int16>
+        <Int16 name="X">
+            <Dim name="/SimpleGroup/X"/>
+        </Int16>
     </Group>
+    <Float32 name="time">
+        <Dim name="/time"/>
+        <Attribute name="standard_name" type="str">
+            <Value>time</Value>
+        </Attribute>
+        <Attribute name="bounds" type="str">
+            <Value>time_bnds</Value>
+        </Attribute>
+    </Float32>
+    <Float32 name="time_bnds">
+        <Dim name="/time"/>
+        <Dim name="/nv"/>
+    </Float32>
 </Dataset>

--- a/src/pydap/tests/datasets.py
+++ b/src/pydap/tests/datasets.py
@@ -224,24 +224,44 @@ SimpleGrid["y"] = SimpleGrid["SimpleGrid"]["y"] = BaseType(
     "y", np.arange(2), axis="Y", units="degrees_north"
 )
 
-SimpleGroup = DatasetType("example dataset", description="A simple group for testing.")
-SimpleGroup["SimpleGroup"] = GroupType("SimpleGroup", dimensions=("X", "Y"))
-SimpleGroup["SimpleGroup"]["Temperature"] = BaseType(
+SimpleGroup = DatasetType(
+    "example dataset",
+    description="A simple group for testing.",
+    dimensions=(("time", 1), ("nv", 2)),
+)
+SimpleGroup["SimpleGroup"] = GroupType("SimpleGroup", dimensions=(("Y", 4), ("X", 4)))
+SimpleGroup["/SimpleGroup/Temperature"] = BaseType(
     "Temperature",
-    np.arange(10, 26, 1, dtype="f4").reshape(4, 4),
+    np.arange(10, 26, 1, dtype="f4").reshape(1, 4, 4),
     units="degrees_celsius",
-    dimensions=("X", "Y"),
+    dims=("/time", "/SimpleGroup/Y", "/SimpleGroup/X"),
     _FillValue=np.inf,
 )
-SimpleGroup["SimpleGroup"]["Salinity"] = BaseType(
+SimpleGroup["/SimpleGroup/Salinity"] = BaseType(
     "Salinity",
-    30 * np.ones(16, dtype="f4").reshape(4, 4),
+    30 * np.ones(16, dtype="f4").reshape(1, 4, 4),
     units="psu",
-    dimensions=("X", "Y"),
+    dims=("/time", "/SimpleGroup/Y", "/SimpleGroup/X"),
     _FillValue=np.nan,
 )
-SimpleGroup["/SimpleGroup/X"] = BaseType("X", np.arange(4, dtype="i2"), dimensions="X")
-SimpleGroup["/SimpleGroup/Y"] = BaseType("Y", np.arange(4, dtype="i2"), dimensions="Y")
+SimpleGroup["/SimpleGroup/Y"] = BaseType(
+    "Y", np.arange(4, dtype="i2"), dims=("/SimpleGroup/Y",)
+)
+SimpleGroup["/SimpleGroup/X"] = BaseType(
+    "X", np.arange(4, dtype="i2"), dims=("/SimpleGroup/X",)
+)
+SimpleGroup["/time"] = BaseType(
+    "time",
+    np.array(0.5, dtype="f4"),
+    dims=("/time",),
+    attributes={
+        "standard_name": "time",
+        "bounds": "time_bnds",
+    },
+)
+SimpleGroup["/time_bnds"] = BaseType(
+    "time_bnds", np.arange(2, dtype="f4"), dims=("/time", "/nv")
+)
 
 
 # a faulty grid

--- a/src/pydap/tests/test_parsers_dmr.py
+++ b/src/pydap/tests/test_parsers_dmr.py
@@ -5,6 +5,8 @@ import unittest
 
 import numpy as np
 
+from ..lib import walk
+from ..model import BaseType
 from ..parsers.dmr import dmr_to_dataset
 
 
@@ -95,3 +97,24 @@ class DMRParser(unittest.TestCase):
         # pick a single variable Maps
         maps = ("/data_01/longitude", "/data_01/latitude")
         self.assertEqual(dataset["data_01/ku/swh_ocean"].Maps, maps)
+
+    def tests_global_dimensions(self):
+        dataset = load_dmr_file("data/dmrs/SimpleGroup.dmr")
+        # pick a single variable Maps
+        names = tuple([item[0] for item in dataset.dimensions])
+        sizes = tuple([item[1] for item in dataset.dimensions])
+        self.assertEqual(names, ("time", "nv"))
+        self.assertEqual(sizes, (1, 2))
+
+    def tests_named_dimension(self):
+        dataset = load_dmr_file("data/dmrs/SimpleGroup.dmr")
+        # get only names of dimensions
+        names = tuple([item[0] for item in dataset.dimensions])
+        # get all variables/arrays
+        variables = []
+        for var in walk(dataset, BaseType):
+            variables.append(var.name)
+        # assert nv is a Global dimension
+        self.assertIn("nv", names)
+        # assert nv is NOT a variable/array
+        self.assertNotIn("nv", variables)

--- a/src/pydap/tests/test_responses_dmr.py
+++ b/src/pydap/tests/test_responses_dmr.py
@@ -58,7 +58,7 @@ class TestDMRResponseSequence(unittest.TestCase):
                         "Access-Control-Allow-Headers",
                         "Origin, X-Requested-With, Content-Type",
                     ),
-                    ("Content-Length", "1219"),
+                    ("Content-Length", "1734"),
                 ]
             ),
         )


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes #347 by setting named dimensions at root level.
- [x] Improves how dimensions are defined at root level in `Responses` (local creation of data --> DMR)  
- [x] Add tests. In particular that: a) A named dimension (e.g.`nv`) does not get assigned a variable/array, b) `Global dimensions` are appropriately parsed in the DMR and defined at root level, and c) simple exaamplt testing response (DMR generation from local dataset)