### PR TITLE
drop python 3.9

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,5 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
     - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/run_tests_macos.yml
+++ b/.github/workflows/run_tests_macos.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.x', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.x']
     name: macos-latest Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.x', '3.9', '3.10', '3.11']
+        python-version: ['3.x', '3.10', '3.11']
     name: ubuntu-latest Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.x', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.x']
     name: ubuntu-latest Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Operating System :: MacOS",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,7 @@ dependencies = [
   "docopt-ng",
   "beautifulsoup4",
   "lxml",
-  "requests",
-  "importlib-metadata",
-  "importlib-resources"
+  "requests"
 ]
 description = "A pure python implementation of the Data Access Protocol."
 dynamic = ["version"]
@@ -36,7 +34,7 @@ license = {file = "LICENSE"}
 maintainers = [{name = 'Miguel Jimenez-Urias', email = 'mjimenez@opendap.org'}]
 name = "pydap"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.entry-points."console_scripts"]
 dods = "pydap.handlers.dap:dump"

--- a/src/pydap/handlers/lib.py
+++ b/src/pydap/handlers/lib.py
@@ -14,9 +14,9 @@ import itertools
 import operator
 import re
 import sys
+from importlib.metadata import entry_points
 
 import numpy as np
-from importlib_metadata import entry_points
 from numpy.lib import Arrayterator
 from webob import Request
 

--- a/src/pydap/parsers/dmr.py
+++ b/src/pydap/parsers/dmr.py
@@ -3,6 +3,7 @@
 import ast
 import collections
 import re
+import warnings
 from xml.etree import ElementTree as ET
 
 import numpy as np
@@ -101,7 +102,7 @@ def get_attributes(element, attributes={}):
                     value = ast.literal_eval(value)
                 except ValueError:
                     # leaves value as string
-                    raise Warning(
+                    warnings.warn(
                         """
                         Pydap could not turn the non-string Attribute: `{}`
                         with value `{}` into a numeric type during parsing
@@ -112,7 +113,8 @@ def get_attributes(element, attributes={}):
                         DAP4:_Specification_Volume_1#Atomic_Types
                         """.format(
                             name, value
-                        )
+                        ),
+                        UserWarning,
                     )
         attributes[name] = value
     return attributes

--- a/src/pydap/responses/lib.py
+++ b/src/pydap/responses/lib.py
@@ -10,7 +10,7 @@ KML, WMS, JSON, etc., installed as third-party Python packages that declare the
 
 """
 
-from importlib_metadata import entry_points
+from importlib.metadata import entry_points
 
 from ..lib import __version__
 from ..model import DatasetType

--- a/src/pydap/responses/version.py
+++ b/src/pydap/responses/version.py
@@ -1,9 +1,9 @@
 """Response with information about pydap version."""
 
 import sys
+from importlib.metadata import entry_points
 from json import dumps
 
-from importlib_metadata import entry_points
 from webob import Response
 
 from ..lib import __dap__, __version__

--- a/src/pydap/tests/test_parsers_dmr.py
+++ b/src/pydap/tests/test_parsers_dmr.py
@@ -49,7 +49,7 @@ class DMRParser(unittest.TestCase):
                 <Attribute name="missing_value" type="Byte">\n
                             <Value>x00</Value>\n        </Attribute>\n
                                 </Int32>\n</Dataset>"""
-        with self.assertRaises(Warning):
+        with self.assertWarns(UserWarning):
             dmr_to_dataset(byte_dmr)
 
     def test_coads_climatology2(self):

--- a/src/pydap/wsgi/ssf.py
+++ b/src/pydap/wsgi/ssf.py
@@ -10,9 +10,9 @@ import ast
 import operator
 import re
 from functools import reduce
+from importlib.metadata import entry_points
 
 import numpy as np
-from importlib_metadata import entry_points
 from webob import Request
 
 from ..exceptions import ServerError


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes #349
- [x] Drops `importlib_metadata` and `importlib_resources` as dependencies necessary for Python 3.9
- [x] Tests pass locally .