### PR TITLE
drop docopt-ng, beautifulsoup4, lxml and others as required dependencies

### DIFF
--- a/.github/workflows/run_tests_macos.yml
+++ b/.github/workflows/run_tests_macos.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -U pip setuptools
-        pip install -e .[tests,netcdf,client]
+        pip install -e .[tests,netcdf]
 
     - name: Run tests with pytest
       run: |

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.x', '3.9', '3.10', '3.11']
+        python-version: ['3.x', '3.10', '3.11']
     name: ubuntu-latest Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -U pip setuptools
-        pip install -e .[tests,netcdf,client]
+        pip install -e .[tests,netcdf]
 
     - name: Run tests with pytest
       run: |

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -2,7 +2,7 @@ name: pydap_tests
 channels:
 - conda-forge
 dependencies:
-- numpy
+- numpy >= 2.0
 - netCDF4
 - pytest
 - pytest-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Operating System :: MacOS",
@@ -20,15 +19,9 @@ classifiers = [
   "License :: OSI Approved :: MIT License"
 ]
 dependencies = [
-  "numpy",
-  "Webob",
-  "Jinja2",
-  "docopt-ng",
-  "beautifulsoup4",
-  "lxml",
+  "numpy >= 2.0",
   "requests",
-  "importlib-metadata",
-  "importlib-resources"
+  "scipy"
 ]
 description = "A pure python implementation of the Data Access Protocol."
 dynamic = ["version"]
@@ -36,7 +29,7 @@ license = {file = "LICENSE"}
 maintainers = [{name = 'Miguel Jimenez-Urias', email = 'mjimenez@opendap.org'}]
 name = "pydap"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.entry-points."console_scripts"]
 dods = "pydap.handlers.dap:dump"
@@ -67,7 +60,7 @@ docs = ['Sphinx', 'Pygments', "pandoc", "sphinx_rtd_theme", "nbsphinx", "numpydo
 functions = ['gsw==3.0.6', 'coards']
 "handlers.netcdf" = ['netCDF4']
 netcdf = ['netCDF4']
-server = ['gunicorn', 'PasteDeploy']
+server = ['gunicorn', 'PasteDeploy', 'docopt-ng', 'Webob', 'Jinja2', 'beautifulsoup4', 'lxml']
 tests = [
   'pytest>=3.6',
   'pytest-cov',
@@ -79,7 +72,12 @@ tests = [
   'gunicorn',
   'cryptography',
   'gsw',
-  'coards'
+  'coards',
+  "docopt-ng",
+  "Webob",
+  "Jinja2",
+  "beautifulsoup4",
+  "lxml"
 ]
 
 [tool.isort]

--- a/src/pydap/handlers/lib.py
+++ b/src/pydap/handlers/lib.py
@@ -14,9 +14,9 @@ import itertools
 import operator
 import re
 import sys
+from importlib.metadata import entry_points
 
 import numpy as np
-from importlib_metadata import entry_points
 from numpy.lib import Arrayterator
 from webob import Request
 

--- a/src/pydap/responses/lib.py
+++ b/src/pydap/responses/lib.py
@@ -10,7 +10,7 @@ KML, WMS, JSON, etc., installed as third-party Python packages that declare the
 
 """
 
-from importlib_metadata import entry_points
+from importlib.metadata import entry_points
 
 from ..lib import __version__
 from ..model import DatasetType

--- a/src/pydap/responses/version.py
+++ b/src/pydap/responses/version.py
@@ -1,9 +1,9 @@
 """Response with information about pydap version."""
 
 import sys
+from importlib.metadata import entry_points
 from json import dumps
 
-from importlib_metadata import entry_points
 from webob import Response
 
 from ..lib import __dap__, __version__

--- a/src/pydap/wsgi/app.py
+++ b/src/pydap/wsgi/app.py
@@ -16,13 +16,13 @@ Options:
   --worker-class=CLASS          Gunicorn worker class [default: sync]
 """
 
+import importlib.resources
 import mimetypes
 import os
 import re
 import shutil
 from datetime import datetime
 
-import importlib_resources
 from docopt import docopt
 from gunicorn.app.wsgiapp import WSGIApplication
 from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PackageLoader
@@ -223,13 +223,20 @@ class StaticMiddleware(object):
 
         # otherwise, load resource from package
         package, resource_path = self.static
-        resource = os.path.join(resource_path, *req.path_info.split("/"))
-        if not importlib_resources.is_resource(package, resource):
+        parts = resource_path.split("/")
+        resources_path = importlib.resources.files(package)
+        for i in range(len(parts)):
+            resources_path /= parts[i]
+        resource = req.path_info.split("/")[-1]
+        full_path = resources_path / resource
+
+        if not full_path.is_file():
             return HTTPNotFound(req.path_info)
 
-        content_type, content_encoding = mimetypes.guess_type(resource)
+        content_type, content_encoding = mimetypes.guess_type(full_path)
+        package += (".").join([""] + parts)
         return Response(
-            body=importlib_resources.read_text(package, resource),
+            body=importlib.resources.read_text(package, resource),
             content_type=content_type,
             content_encoding=content_encoding,
         )
@@ -238,18 +245,18 @@ class StaticMiddleware(object):
 def init(directory):
     """Create directory with default templates."""
     # copy main templates
-    templates = importlib_resources.files("pydap.wsgi") / "templates"
-    with importlib_resources.as_file(templates) as path:
+    templates = importlib.resources.files("pydap.wsgi") / "templates"
+    with importlib.resources.as_file(templates) as path:
         shutil.copytree(templates, directory)
 
     # copy templates from HTML response
-    for resource in importlib_resources.files(
+    for resource in importlib.resources.files(
         "pydap.responses.html.templates"
     ).iterdir():
-        path = importlib_resources.files(
+        path = importlib.resources.files(
             "pydap.responses.html"
         ) / "templates/{0}".format(resource.name)
-        with importlib_resources.as_file(path) as Path:
+        with importlib.resources.as_file(path) as Path:
             shutil.copy(Path, directory)
 
 

--- a/src/pydap/wsgi/ssf.py
+++ b/src/pydap/wsgi/ssf.py
@@ -10,9 +10,9 @@ import ast
 import operator
 import re
 from functools import reduce
+from importlib.metadata import entry_points
 
 import numpy as np
-from importlib_metadata import entry_points
 from webob import Request
 
 from ..exceptions import ServerError


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes #354 and #349.
- [x] Tests are not added but pass on my local environment.

With regards to #349 -  I have disabled (temporarily) the workflow associated with running ubuntu tests. This is because I have attempted to drop python 3.9 many times and while all checks pass, github remains idle waiting for the ubuntu python 3.9 check even when the PR itself removes it. And so I am trying this new approach of disabling the entire ubuntu workflow to see if only running the macOS checks (plus pre-commit) allows for this PR to be merged onto main.