### PR TITLE
get Dap objects function and a fix 

### DIFF
--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -215,7 +215,6 @@ class DAPHandler(BaseHandler):
                 var_name = var.path + "/" + var.name
             else:
                 var_name = var.name
-            print(var_name)
             var.data = BaseProxyDap4(
                 self.base_url,
                 var_name,

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -215,6 +215,7 @@ class DAPHandler(BaseHandler):
                 var_name = var.path + "/" + var.name
             else:
                 var_name = var.name
+            print(var_name)
             var.data = BaseProxyDap4(
                 self.base_url,
                 var_name,
@@ -223,6 +224,7 @@ class DAPHandler(BaseHandler):
                 application=self.application,
                 session=self.session,
                 timeout=self.timeout,
+                verify=self.verify,
             )
 
         # apply projections to BaseType only
@@ -247,6 +249,7 @@ class DAPHandler(BaseHandler):
                 application=self.application,
                 session=self.session,
                 timeout=self.timeout,
+                verify=self.verify,
             )
         for var in walk(self.dataset, SequenceType):
             template = copy.copy(var)
@@ -257,6 +260,7 @@ class DAPHandler(BaseHandler):
                 application=self.application,
                 session=self.session,
                 timeout=self.timeout,
+                verify=self.verify,
             )
 
         # apply projections

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -298,8 +298,8 @@ def walk(var, type=object):
     if isinstance(var, type):
         yield var
     for child in var.children():
-        for var in walk(child, type):
-            yield var
+        for subvar in walk(child, type):
+            yield subvar
 
 
 def tree(template, prefix=""):

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -577,12 +577,11 @@ class DatasetType(StructureType):
             current = self._dict
             for j in range(N - 1):
                 if parts[j] not in current:
-                    # print(parts)
-                    # This current approach works when parsing a DMR
-                    # with only Groups and arrays. Need to enable
-                    # Sequences and Structures. This works with all
-                    # DAP4 when creating Dataset manally.
-                    current[parts[j]] = GroupType(parts[j])  # path here!!
+                    #     # This current approach works when parsing a DMR
+                    #     # with only Groups and arrays. Need to enable
+                    #     # Sequences and Structures. This works with all
+                    #     # DAP4 when creating Dataset manally.
+                    current[parts[j]] = GroupType(parts[j])
                 current = current[parts[j]]
             current[parts[-1]] = item
         else:

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -535,7 +535,8 @@ class StructureType(DapType, Mapping):
         """Returns fqn for all (nested) groups"""
         out = {}
         for var in walk(self, GroupType):
-            out.update({var.name: var.path})
+            if var.type == "Group":
+                out.update({var.name: var.path})
         return out
 
     def sequences(self):
@@ -576,12 +577,12 @@ class DatasetType(StructureType):
             current = self._dict
             for j in range(N - 1):
                 if parts[j] not in current:
-                    print(parts)
+                    # print(parts)
                     # This current approach works when parsing a DMR
                     # with only Groups and arrays. Need to enable
                     # Sequences and Structures. This works with all
                     # DAP4 when creating Dataset manally.
-                    current[parts[j]] = GroupType(parts[j])
+                    current[parts[j]] = GroupType(parts[j])  # path here!!
                 current = current[parts[j]]
             current[parts[-1]] = item
         else:
@@ -716,7 +717,7 @@ class DatasetType(StructureType):
         if name[0] != "/":
             name = "/" + name
         if len(name.split("/")) > 2:
-            path = ("/").join(name.split("/")[:-1])
+            path = ("/").join(name.split("/")[:-1]) + "/"
         return self.createDapType(GroupType, name, **attrs, path=path)
 
     def createVariable(self, name, **attrs):
@@ -1015,13 +1016,12 @@ class GroupType(StructureType):
 
     """
 
-    def __setitem__(self, key, item, dimensions=dict()):
+    def __setitem__(self, key, item):
         StructureType.__setitem__(self, key, item)
 
         # The Group name does (not) go into the children ids.
 
         item.id = item.name
-        self.dimensions = dimensions or dict()
         # self._dict[key] = item
 
         # # # By default added keys are visible:

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -523,6 +523,35 @@ class StructureType(DapType, Mapping):
     def type(self):
         return "Structure"
 
+    def structures(self):
+        out = {}
+        Gs = [key for key in self.children() if isinstance(key, StructureType)]
+        Strs = [key for key in Gs if key.type == "Structure"]
+        for var in Strs:
+            out.update({var.name: [key.name for key in var.children()]})
+        return out
+
+    def groups(self):
+        """Returns fqn for all (nested) groups"""
+        out = {}
+        for var in walk(self, GroupType):
+            out.update({var.name: var.path})
+        return out
+
+    def sequences(self):
+        out = {}
+        Sqns = [key for key in self.children() if isinstance(key, SequenceType)]
+        for var in Sqns:
+            out.update({var.name: [key.name for key in var.children()]})
+        return out
+
+    def base(self):
+        out = {}
+        Bcs = [key for key in self.children() if isinstance(key, BaseType)]
+        for var in Bcs:
+            out.update({var.name: var.dtype})
+        return out
+
 
 class DatasetType(StructureType):
     """A root Dataset.
@@ -547,6 +576,7 @@ class DatasetType(StructureType):
             current = self._dict
             for j in range(N - 1):
                 if parts[j] not in current:
+                    print(parts)
                     # This current approach works when parsing a DMR
                     # with only Groups and arrays. Need to enable
                     # Sequences and Structures. This works with all
@@ -635,6 +665,10 @@ class DatasetType(StructureType):
         self._dict = OrderedDict((k, self._dict[k]) for k in order)
 
     @property
+    def type(self):
+        return ()
+
+    @property
     def nbytes(self):
         """Returns the number of bytes occupied in aggregation by all
         uncompressed, BaseType data in the DatasetType. Attributes are
@@ -678,7 +712,12 @@ class DatasetType(StructureType):
 
         Also: https://docs.opendap.org/index.php/DAP4:_Specification_Volume_1
         """
-        return self.createDapType(GroupType, name, **attrs)
+        path = "/"
+        if name[0] != "/":
+            name = "/" + name
+        if len(name.split("/")) > 2:
+            path = ("/").join(name.split("/")[:-1])
+        return self.createDapType(GroupType, name, **attrs, path=path)
 
     def createVariable(self, name, **attrs):
         """

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -546,7 +546,7 @@ class StructureType(DapType, Mapping):
             out.update({var.name: [key.name for key in var.children()]})
         return out
 
-    def base(self):
+    def variables(self):
         out = {}
         Bcs = [key for key in self.children() if isinstance(key, BaseType)]
         for var in Bcs:

--- a/src/pydap/parsers/dmr.py
+++ b/src/pydap/parsers/dmr.py
@@ -166,6 +166,7 @@ def get_groups(node, prefix="/"):
                     "attributes": get_attributes(group, {}),
                     "Maps": get_maps(group),
                     "dimensions": {k: v for k, v in global_dimensions},
+                    "path": prefix,
                 }
             }
         )
@@ -253,9 +254,8 @@ def dmr_to_dataset(dmr):
             else:
                 dapType = pydap.model.StructureType
             if parent_name not in dataset[path].keys():
-                dataset[path + parent_name] = dapType(parent_name)
+                dataset[path + parent_name] = dapType(parent_name, path=path)
             dataset[("/").join(parts)] = var
-
         else:
             dataset[name] = var
     return dataset

--- a/src/pydap/parsers/dmr.py
+++ b/src/pydap/parsers/dmr.py
@@ -159,7 +159,7 @@ def get_groups(node, prefix="/"):
         named_dimensions = get_named_dimensions(group)
         global_dimensions = []
         for name, size in named_dimensions.items():
-            global_dimensions.append([name, size])
+            global_dimensions.append([name.split("/")[-1], size])
         out.update(
             {
                 fqname: {

--- a/src/pydap/responses/dmr.py
+++ b/src/pydap/responses/dmr.py
@@ -68,6 +68,17 @@ def _(var, level=0):
     for child in var.children():
         for line in dmr(child, level + 1):
             yield line
+    for key, value in var.attributes.items():
+        if key != "dimensions":
+            _type = type(value).__name__
+            yield '{indent}<Attribute name="{name}" type="{type}">\n'.format(
+                indent=(level + 1) * INDENT, name=key, type=_type
+            )
+            yield "{indent}<Value>{val}</Value>\n".format(
+                indent=(level + 2) * INDENT, val=value
+            )
+            yield "{indent}</Attribute>\n".format(indent=(level + 1) * INDENT)
+
     yield "{indent}</Dataset>\n".format(indent=level * INDENT)
 
 
@@ -88,6 +99,16 @@ def _grouptype(var, level=0):
         yield '{indent}<Dimension name="{name}" size="{size}"/>\n'.format(
             indent=(level + 1) * INDENT, name=dim, size=size
         )
+    for key, value in var.attributes.items():
+        if key not in ["dimensions", "path"]:
+            _type = type(value).__name__
+            yield '{indent}<Attribute name="{name}" type="{type}">\n'.format(
+                indent=(level + 1) * INDENT, name=key, type=_type
+            )
+            yield "{indent}<Value>{val}</Value>\n".format(
+                indent=(level + 2) * INDENT, val=value
+            )
+            yield "{indent}</Attribute>\n".format(indent=(level + 1) * INDENT)
     for child in var.children():
         for line in dmr(child, level + 1):
             yield line

--- a/src/pydap/tests/data/dmrs/SimpleGroup.dmr
+++ b/src/pydap/tests/data/dmrs/SimpleGroup.dmr
@@ -33,6 +33,9 @@
         <Int16 name="X">
             <Dim name="/SimpleGroup/X"/>
         </Int16>
+        <Attribute name="Description" type="String">
+            <Value>Test group with numerical data</Value>
+        </Attribute>
     </Group>
     <Float32 name="time">
         <Dim name="/time"/>

--- a/src/pydap/tests/data/dmrs/SimpleGroup.dmr
+++ b/src/pydap/tests/data/dmrs/SimpleGroup.dmr
@@ -5,6 +5,9 @@
     <Group name="SimpleGroup">
         <Dimension name="Y" size="4"/>
         <Dimension name="X" size="4"/>
+        <Attribute name="Description" type="str">
+            <Value>Test group with numerical data</Value>
+        </Attribute>
         <Float32 name="Temperature">
             <Dim name="/time"/>
             <Dim name="/SimpleGroup/Y"/>
@@ -33,9 +36,6 @@
         <Int16 name="X">
             <Dim name="/SimpleGroup/X"/>
         </Int16>
-        <Attribute name="Description" type="String">
-            <Value>Test group with numerical data</Value>
-        </Attribute>
     </Group>
     <Float32 name="time">
         <Dim name="/time"/>
@@ -50,4 +50,7 @@
         <Dim name="/time"/>
         <Dim name="/nv"/>
     </Float32>
+    <Attribute name="Description" type="str">
+        <Value>A simple group for testing.</Value>
+    </Attribute>
 </Dataset>

--- a/src/pydap/tests/datasets.py
+++ b/src/pydap/tests/datasets.py
@@ -222,7 +222,11 @@ SimpleGroup = DatasetType(
     description="A simple group for testing.",
     dimensions={"time": 1, "nv": 2},
 )
-SimpleGroup.createGroup("SimpleGroup", dimensions={"Y": 4, "X": 4})
+SimpleGroup.createGroup(
+    "SimpleGroup",
+    dimensions={"Y": 4, "X": 4},
+    Description="Test group with numerical data",
+)
 SimpleGroup.createVariable(
     name="/SimpleGroup/Temperature",
     data=np.arange(10, 26, 1, dtype="f4").reshape(1, 4, 4),

--- a/src/pydap/tests/datasets.py
+++ b/src/pydap/tests/datasets.py
@@ -219,7 +219,7 @@ SimpleGrid["y"] = SimpleGrid["SimpleGrid"]["y"] = BaseType(
 
 SimpleGroup = DatasetType(
     "example dataset",
-    description="A simple group for testing.",
+    Description="A simple group for testing.",
     dimensions={"time": 1, "nv": 2},
 )
 SimpleGroup.createGroup(

--- a/src/pydap/tests/test_model.py
+++ b/src/pydap/tests/test_model.py
@@ -503,6 +503,41 @@ def test_DatasetType_fails_createDAPType():
     assert "Group2" not in dataset
 
 
+def test_DatasetType_groups(sequence_example):
+    dataset = DatasetType("dataset")
+    dataset.createGroup("/Group1")
+    dataset.createGroup("/Group1/SubGroup1")
+    dataset.createGroup("/Group2")
+    dataset.createGroup("/Group2/SubGroup2")
+    groups = dataset.groups()
+    values = {
+        "Group1": "/",
+        "SubGroup1": "/Group1/",
+        "Group2": "/",
+        "SubGroup2": "/Group2/",
+    }
+    assert groups == values
+
+
+def test_DatasetType_sequences(sequence_example):
+    dataset = DatasetType("dataset")
+    dataset.createGroup("/Group1")
+    dataset["/Group1/example"] = sequence_example
+    seq_root_level = dataset.sequences()
+    sqns = dataset["/Group1"].sequences()
+    assert seq_root_level == {}
+    assert sqns == {"example": ["index", "temperature", "site"]}
+
+
+def test_DatasetType_variables():
+    dataset = DatasetType("dataset")
+    dataset.createGroup("/Group1")
+    dataset.createVariable("/root_variable", dtype=np.float32)
+    dataset.createVariable("/Group1/other_variable", dtype=np.int64)
+    assert dataset.variables() == {"root_variable": np.dtype("float32")}
+    assert dataset["/Group1"].variables() == {"other_variable": np.dtype("int64")}
+
+
 # Test pydap grids.
 @pytest.fixture()
 def gridtype_example():

--- a/src/pydap/tests/test_responses_dmr.py
+++ b/src/pydap/tests/test_responses_dmr.py
@@ -58,7 +58,7 @@ class TestDMRResponseGroup(unittest.TestCase):
                         "Access-Control-Allow-Headers",
                         "Origin, X-Requested-With, Content-Type",
                     ),
-                    ("Content-Length", "1734"),
+                    ("Content-Length", "1977"),
                 ]
             ),
         )

--- a/src/pydap/tests/test_responses_html.py
+++ b/src/pydap/tests/test_responses_html.py
@@ -180,7 +180,7 @@ class TestHTMLResponseSimpleGroup(unittest.TestCase):
                     ("OPeNDAP-Server", "pydap/" + __version__),
                     ("Content-description", "DAP_form"),
                     ("Content-type", "text/html; charset=utf-8"),
-                    ("Content-Length", "8416"),
+                    ("Content-Length", "8500"),
                 ]
             ),
         )

--- a/src/pydap/tests/test_responses_html.py
+++ b/src/pydap/tests/test_responses_html.py
@@ -180,7 +180,7 @@ class TestHTMLResponseSimpleGroup(unittest.TestCase):
                     ("OPeNDAP-Server", "pydap/" + __version__),
                     ("Content-description", "DAP_form"),
                     ("Content-type", "text/html; charset=utf-8"),
-                    ("Content-Length", "8368"),
+                    ("Content-Length", "8416"),
                 ]
             ),
         )


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->
# Draft PR - need to add some additional testing

The following Pull Request:

- [x] Closes #370 - implements a new feature to pydap: ability to extract all object types of a particular class.
- [x] Closes #374 by fixing a bug: attributes are now correctly defined in nested groups. 
- [x] Tests are added to demonstrate the new or fixed behavior, and all tests pass
on a local environment.






With regards to issue #374 the example described there now yields (correctly):

```python
pds['/gt1r'].attributes
```
```python
{'Description': 'Each group contains the segments for one Ground Track. As ICESat-2 orbits the earth, sequential transmit pulses illuminate six ground tracks on the surface of the earth.  The track width is approximately 14m.  Each ground track is numbered, according to the laser spot number that generates a given ground track.  Ground tracks are numbered from the left to the right in the direction of spacecraft travel as: 1L, 1R in the left-most pair of beams; 2L, 2R for the center pair of beams; and 3L, 3R for the right-most pair of beams.',
 'atlas_pce': 'pce3',
 'atlas_beam_type': 'strong',
 'groundtrack_id': 'gt1r',
 'atmosphere_profile': 'profile_1',
 'atlas_spot_number': '5',
 'sc_orientation': 'Forward',
 'dimensions': {'delta_time': 4102521},
 'Maps': (),
 'path': '/'}
```
and
```python
pds['/gt1r/bckgrd_atlas'].attributes
```
```python
{'Description': 'Contains data related to the 50-shot background count, including telemetry and range windows.',
 'dimensions': {'delta_time': 89490},
 'Maps': (),
 'path': '/gt1r/'}
```
where `path` displays like `parent` directory.

