### PR TITLE
Include more python versions

### DIFF
--- a/.github/workflows/run_tests_macos.yml
+++ b/.github/workflows/run_tests_macos.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     name: macos-latest Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     name: ubuntu-latest Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Operating System :: MacOS",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: POSIX",


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Adds python 3.12 to the description of supported python versions. This this PR closes #409 
- [x] Adds python 3.13 to testing. 3.13 got a stable release last month. We should be testing against it. 
~- [ ] Tests are added to demonstrate the new or fixed behavior, and all tests pass
on a local environment.~ No test were added, but I ran the tests with 3.13 on my local machine (MacOS) and things ran smoothly (aside from some deprecation warnings)
