### PR TITLE
Quick patchwork to parse TDS DAP4 responses

### DIFF
--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -334,10 +334,10 @@ def safe_dmr_and_data(r, user_charset, url):
 
     dmr = dmr[4:] + b"</Dataset>"
     dmr = dmr.decode(get_charset(r, user_charset))
-    if 'thredds' in url.split('/') or 'dap4' in url.split('/'):
+    if "thredds" in url.split("/") or "dap4" in url.split("/"):
         i0 = 2
     else:
-        i0=3
+        i0 = 3
     data = data[i0:]  # for hyrax this is 3, for TDS this is 2 (not anymore?)
     return dmr, data
 

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -335,9 +335,9 @@ def safe_dmr_and_data(r, user_charset, url):
     dmr = dmr[4:] + b"</Dataset>"
     dmr = dmr.decode(get_charset(r, user_charset))
     if "thredds" in url.split("/") or "dap4" in url.split("/"):
-        data = data[2:] # TDS
+        data = data[2:]  # TDS
     else:
-        data = data[3:] # Hyrax
+        data = data[3:]  # Hyrax
     return dmr, data
 
 

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -338,8 +338,9 @@ def safe_dmr_and_data(r, user_charset, url):
     if "thredds" in url.split("/") or "dap4" in url.split("/"):
         data = data[2:]  # TDS
         warnings.warn(
-            "Full DAP4 support for TDS data servers remains under development."
-            "We recommend to continue to use DAP2 protocol. See pydap/issues#401",
+            "Full DAP4 support for TDS data servers remains under development"
+            " for pydap. We recommend to continue to use DAP2 protocol instead."
+            " See: https://github.com/pydap/pydap/issues/401",
             UserWarning,
         )
     else:

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -16,6 +16,7 @@ import logging
 import pprint
 import re
 import sys
+import warnings
 import warnings as _warnings
 from io import BytesIO
 from itertools import chain
@@ -336,6 +337,11 @@ def safe_dmr_and_data(r, user_charset, url):
     dmr = dmr.decode(get_charset(r, user_charset))
     if "thredds" in url.split("/") or "dap4" in url.split("/"):
         data = data[2:]  # TDS
+        warnings.warn(
+            "Full DAP4 support for TDS data servers remains under development."
+            "We recommend to continue to use DAP2 protocol. See pydap/issues#401",
+            UserWarning,
+        )
     else:
         data = data[3:]  # Hyrax
     return dmr, data

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -335,10 +335,9 @@ def safe_dmr_and_data(r, user_charset, url):
     dmr = dmr[4:] + b"</Dataset>"
     dmr = dmr.decode(get_charset(r, user_charset))
     if "thredds" in url.split("/") or "dap4" in url.split("/"):
-        i0 = 2
+        data = data[2:] # TDS
     else:
-        i0 = 3
-    data = data[i0:]  # for hyrax this is 3, for TDS this is 2 (not anymore?)
+        data = data[3:] # Hyrax
     return dmr, data
 
 

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -311,7 +311,7 @@ def safe_dds_and_data(r, user_charset):
     return dds.decode(get_charset(r, user_charset)), data
 
 
-def safe_dmr_and_data(r, user_charset):
+def safe_dmr_and_data(r, user_charset, url):
     if r.content_encoding == "gzip":
         raw = gzip.GzipFile(fileobj=BytesIO(r.body)).read()
     else:
@@ -334,7 +334,11 @@ def safe_dmr_and_data(r, user_charset):
 
     dmr = dmr[4:] + b"</Dataset>"
     dmr = dmr.decode(get_charset(r, user_charset))
-    data = data[3:]
+    if 'thredds' in url.split('/') or 'dap4' in url.split('/'):
+        i0 = 2
+    else:
+        i0=3
+    data = data[i0:]  # for hyrax this is 3, for TDS this is 2 (not anymore?)
     return dmr, data
 
 
@@ -484,7 +488,7 @@ class BaseProxyDap4(BaseProxyDap2):
         )
 
         raise_for_status(r)
-        dmr, data = safe_dmr_and_data(r, self.user_charset)
+        dmr, data = safe_dmr_and_data(r, self.user_charset, self.baseurl)
 
         # Parse received dataset:
         dataset = dmr_to_dataset(dmr)


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

This is a quick patchwork so that pydap CAN parse DAP4 responses from TDS.  See #401 

There are a couple of issues related to parsing DAP responses from a TDS. This PR solves:

a) Correctly split DMR from binary data in the response. There are very small differences in how the 2 servers split the dmr from the binary data:

### Hyrax
```
"... </Dataset>\n\r\n<binary data>"
```
### TDS
```
"... </Dataset>\r\n<binary data>"
```
DAP4 support within pydap has been written to accomodate Hyrax. The vary small difference between the two servers means that returning data from a TDS via DAP4 results in error.



With this PR, now there is no error but there is a "UserWarning" to inform users to use DAP2 protocol with TDS. The reason for that is this PR still does not fix another discrepancy between TDS and Hyrax servers. The discrepancy may be small, but relates to at least partially with how `endianness` is specified in the response.

For example, when reading from [this data_URL](http://test.opendap.org:8080/opendap/tds/OR_ABI-L2-SSTF-M6_G16_s20242820000206_e20242820059514_c20242820104416.nc.dmr.html) on Hyrax you CORRECTLY get:

```python
ds = open_url(data_url, protocol='dap4')
ds['y'][:]
>>> <BaseType with data array([   0,    1,    2, ..., 5421, 5422, 5423], dtype=int16)>
```
The same `data_url` running on TDS gets you:

```python
ds = open_url(data_url, protocol='dap4')
ds['y'][:]
UserWarning: Full DAP4 support for TDS data servers remains under development for pydap. We recommend to continue to use DAP2 protocol instead. See: https://github.com/pydap/pydap/issues/401
>>> <BaseType with data array([     0,    256,    512, ..., -26107, -25851, -25595], dtype='>i2')
```

The issue is NOT JUST endianness. And so for now passing a useful UserWarning is enough, while we spend some time working with the tds folks on resolving this issue.














