### PR TITLE
broaden dmr parser to allow multiple values on single attribute

### DIFF
--- a/src/pydap/parsers/dmr.py
+++ b/src/pydap/parsers/dmr.py
@@ -89,17 +89,19 @@ def get_atomic_attr(element):
     Int_types = ["Int16", "Int32", "Int64", "int", "Int8"]
     uInt_types = ["uInt16", "uInt32", "uInt64", "uint", "uInt8", "Char"]
     name = element.get("name")
-    value = [val.text for val in element.findall("Value")]
+    value = []
+    ii = 0  # default
+    if element.get("value") is not None:
+        value.append(element.get("value"))
+        ii = 1  # need to shift indexes
+    value += [val.text for val in element.findall("Value")]
     if value.count(None) > 0:
         # This could be because server is TDS.
         # If value is None still, then data is missing
         indexes = [i for i, x in enumerate(value) if x is None]
         vals = [val for val in element.findall("Value")]
-        if isinstance(indexes, list):
-            for i in indexes:
-                value[i] = vals[i].get("value")
-        else:
-            value[indexes] = vals[indexes].get("value")
+        for i in indexes:
+            value[i] = vals[i - ii].get("value")
     _type = element.get("type")
     if _type in dmr_atomic_types:
         if _type in Float_types:

--- a/src/pydap/parsers/dmr.py
+++ b/src/pydap/parsers/dmr.py
@@ -96,8 +96,7 @@ def get_atomic_attr(element):
         ii = 1  # need to shift indexes
     value += [val.text for val in element.findall("Value")]
     if value.count(None) > 0:
-        # This could be because server is TDS.
-        # If value is None still, then data is missing
+        # may be a False None -> various ways to define the attr value
         indexes = [i for i, x in enumerate(value) if x is None]
         vals = [val for val in element.findall("Value")]
         for i in indexes:

--- a/src/pydap/parsers/dmr.py
+++ b/src/pydap/parsers/dmr.py
@@ -89,7 +89,7 @@ def get_atomic_attr(element):
     if value.count(None) > 0:
         # This could be because server is TDS.
         # If value is None still, then data is missing
-        indexes = value.index(None)
+        indexes = [i for i, x in enumerate(value) if x is None]
         vals = [val for val in element.findall("Value")]
         if isinstance(indexes, list):
             for i in indexes:
@@ -100,10 +100,10 @@ def get_atomic_attr(element):
     if _type in dmr_atomic_types:
         if _type in Float_types:
             # keep float-type of value
-            value = [float(val) for val in value if val is not None]
+            value = [float(val) if val is not None else val for val in value]
         elif _type in Int_types or _type in uInt_types:
             # keeps integer-type of value
-            value = [int(val) for val in value if val is not None]
+            value = [int(val) if val is not None else val for val in value]
         else:
             try:
                 value = [ast.literal_eval(val) for val in value if val is not None]

--- a/src/pydap/responses/dmr.py
+++ b/src/pydap/responses/dmr.py
@@ -126,13 +126,23 @@ def _basetype(var, level=0):
         )
     for key, value in var.attributes.items():
         if key != "dims":
-            _type = type(value).__name__
-            yield '{indent}<Attribute name="{name}" type="{type}">\n'.format(
-                indent=(level + 1) * INDENT, name=key, type=_type
-            )
-            yield "{indent}<Value>{val}</Value>\n".format(
-                indent=(level + 2) * INDENT, val=value
-            )
+            if isinstance(value, list):
+                _type = type(value[0]).__name__
+                yield '{indent}<Attribute name="{name}" type="{type}">\n'.format(
+                    indent=(level + 1) * INDENT, name=key, type=_type
+                )
+                for val in value:
+                    yield "{indent}<Value>{val}</Value>\n".format(
+                        indent=(level + 2) * INDENT, val=val
+                    )
+            else:
+                _type = type(value).__name__
+                yield '{indent}<Attribute name="{name}" type="{type}">\n'.format(
+                    indent=(level + 1) * INDENT, name=key, type=_type
+                )
+                yield "{indent}<Value>{val}</Value>\n".format(
+                    indent=(level + 2) * INDENT, val=value
+                )
             yield "{indent}</Attribute>\n".format(indent=(level + 1) * INDENT)
     yield "{indent}</{type}>\n".format(indent=level * INDENT, type=_vartype)
 

--- a/src/pydap/tests/data/dmrs/SimpleGroup.dmr
+++ b/src/pydap/tests/data/dmrs/SimpleGroup.dmr
@@ -18,6 +18,10 @@
             <Attribute name="_FillValue" type="float">
                 <Value>inf</Value>
             </Attribute>
+            <Attribute name='Valid Range' type="int">
+                <Value>-10</Value>
+                <Value value="100"/>
+            </Attribute>
         </Float32>
         <Float32 name="Salinity">
             <Dim name="/time"/>
@@ -29,6 +33,11 @@
             <Attribute name="_FillValue" type="float">
                 <Value>nan</Value>
             </Attribute>
+            <Attribute name='Valid Range' type="float">
+                <Value>0.0</Value>
+                <Value value="50.0"/>
+            </Attribute>
+
         </Float32>
         <Int16 name="Y">
             <Dim name="/SimpleGroup/Y"/>

--- a/src/pydap/tests/data/dmrs/SimpleGroup.dmr
+++ b/src/pydap/tests/data/dmrs/SimpleGroup.dmr
@@ -18,9 +18,9 @@
             <Attribute name="_FillValue" type="float">
                 <Value>inf</Value>
             </Attribute>
-            <Attribute name='Valid Range' type="int">
+            <Attribute name="ValidRange" type="int">
                 <Value>-10</Value>
-                <Value value="100"/>
+                <Value>100</Value>
             </Attribute>
         </Float32>
         <Float32 name="Salinity">
@@ -33,11 +33,10 @@
             <Attribute name="_FillValue" type="float">
                 <Value>nan</Value>
             </Attribute>
-            <Attribute name='Valid Range' type="float">
+            <Attribute name="ValidRange" type="float">
                 <Value>0.0</Value>
-                <Value value="50.0"/>
+                <Value>50.0</Value>
             </Attribute>
-
         </Float32>
         <Int16 name="Y">
             <Dim name="/SimpleGroup/Y"/>

--- a/src/pydap/tests/datasets.py
+++ b/src/pydap/tests/datasets.py
@@ -233,6 +233,7 @@ SimpleGroup.createVariable(
     units="degrees_celsius",
     dimensions=("/time", "/SimpleGroup/Y", "/SimpleGroup/X"),
     _FillValue=np.inf,
+    ValidRange=[-10, 100],
 )
 SimpleGroup.createVariable(
     name="/SimpleGroup/Salinity",
@@ -240,6 +241,7 @@ SimpleGroup.createVariable(
     units="psu",
     dimensions=("/time", "/SimpleGroup/Y", "/SimpleGroup/X"),
     _FillValue=np.nan,
+    ValidRange=[0.0, 50.0],
 )
 SimpleGroup.createVariable(
     name="/SimpleGroup/Y", data=np.arange(4, dtype="i2"), dimensions=("/SimpleGroup/Y",)

--- a/src/pydap/tests/test_parsers_dmr.py
+++ b/src/pydap/tests/test_parsers_dmr.py
@@ -265,3 +265,12 @@ class TestAttrsTypesDMRParser(unittest.TestCase):
                                 </Int32>\n</Dataset>"""
         ds = dmr_to_dataset(dmr)
         assert isinstance(ds["x"].attributes["attr"], float)
+
+    def test_multiple_entries(self):
+        dmr = """<Dataset name="foo">\n    <Int32 name="x">\n
+        <Attribute name="attr" type="Float32">\n
+                    <Value>-1</Value>\n        <Value value="1"/>\n</Attribute>\n
+                        </Int32>\n</Dataset>"""
+
+        ds = dmr_to_dataset(dmr)
+        assert ds["x"].attributes["attr"] == [-1.0, 1.0]

--- a/src/pydap/tests/test_parsers_dmr.py
+++ b/src/pydap/tests/test_parsers_dmr.py
@@ -272,5 +272,21 @@ class TestAttrsTypesDMRParser(unittest.TestCase):
                     <Value>-1</Value>\n        <Value value="1"/>\n</Attribute>\n
                         </Int32>\n</Dataset>"""
 
+        dmr2 = """<Dataset name="foo">\n    <Int32 name="x">\n
+        <Attribute name="attr" type="Float32">\n
+                    <Value value="-1"/>\n        <Value>1</Value>\n</Attribute>\n
+                        </Int32>\n</Dataset>"""
+
         ds = dmr_to_dataset(dmr)
+        ds2 = dmr_to_dataset(dmr2)
         assert ds["x"].attributes["attr"] == [-1.0, 1.0]
+        assert ds2["x"].attributes["attr"] == [-1.0, 1.0]
+
+    def test_multiple_entries2(self):
+        dmr = """<Dataset name="foo">\n    <Int32 name="x">\n
+        <Attribute name="attr" type="Float32">\n
+                    <Value></Value>\n        <Value>2</Value>\n
+                            <Value value="1"/>\n</Attribute>\n
+                        </Int32>\n</Dataset>"""
+        ds = dmr_to_dataset(dmr)
+        assert ds["x"].attributes["attr"] == [None, 2.0, 1.0]

--- a/src/pydap/tests/test_parsers_dmr.py
+++ b/src/pydap/tests/test_parsers_dmr.py
@@ -284,12 +284,12 @@ class TestAttrsTypesDMRParser(unittest.TestCase):
 
     def test_multiple_entries2(self):
         dmr = """<Dataset name="foo">\n    <Int32 name="x">\n
-        <Attribute name="attr" type="Float32">\n
+        <Attribute name="attr" type="Float32" value="100">\n
                     <Value></Value>\n        <Value>2</Value>\n
                             <Value value="1"/>\n</Attribute>\n
                         </Int32>\n</Dataset>"""
         ds = dmr_to_dataset(dmr)
-        assert ds["x"].attributes["attr"] == [None, 2.0, 1.0]
+        assert ds["x"].attributes["attr"] == [100, None, 2.0, 1.0]
 
     def test_string(self):
         dmr = """<Dataset name="foo">\n    <String name="bears">\n
@@ -299,3 +299,13 @@ class TestAttrsTypesDMRParser(unittest.TestCase):
         ds = dmr_to_dataset(dmr)
         assert "bears" in ds.variables()
         assert ds["bears"].dtype == "S128"
+
+    def test_attr_InlineValue(self):
+        dmr = """
+        <Dataset name="foo">\n
+        <String name="bears">\n
+            <Attribute name="attr" type="Float32" value="100"/>\n
+        </String>\n
+        </Dataset>"""
+        ds = dmr_to_dataset(dmr)
+        assert ds["bears"].attributes["attr"] == 100.0

--- a/src/pydap/tests/test_responses_dmr.py
+++ b/src/pydap/tests/test_responses_dmr.py
@@ -58,7 +58,7 @@ class TestDMRResponseGroup(unittest.TestCase):
                         "Access-Control-Allow-Headers",
                         "Origin, X-Requested-With, Content-Type",
                     ),
-                    ("Content-Length", "1977"),
+                    ("Content-Length", "2276"),
                 ]
             ),
         )

--- a/src/pydap/tests/test_responses_html.py
+++ b/src/pydap/tests/test_responses_html.py
@@ -180,7 +180,7 @@ class TestHTMLResponseSimpleGroup(unittest.TestCase):
                     ("OPeNDAP-Server", "pydap/" + __version__),
                     ("Content-description", "DAP_form"),
                     ("Content-type", "text/html; charset=utf-8"),
-                    ("Content-Length", "8101"),
+                    ("Content-Length", "8224"),
                 ]
             ),
         )


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

~This is a draft~
The following Pull Request:

- [x] Closes  #406. Correctly parses an attribute with multiple values to generate a list of values.
- [x] Tests are added to demonstrate the new or fixed behavior, and all tests pass
on a local environment.



### example
This is included in the testing

```python
dmr = """
<Dataset name="foo">\n
<Int32 name="x">\n
    <Attribute name="attr" type="Float32">\n
        <Value></Value>\n
        <Value>2</Value>\n
        <Value value="1"/>\n</Attribute>\n
</Int32>\n
</Dataset>
"""
dom_et = DMRParser(dmr).node
dataset = DMRParser(dmr).init_dataset()
variables = get_variables(dom_et)
get_attributes(variables['x']['element'])['attr']
```
the last line returns the list for attribute `'attr'`. All values, excep None, are Float32, associated with variable `'x'` of type int32

```python
[None, 2.0, 1.0]
```
