### PR TITLE
add functionality to parse dmr with String variables

### DIFF
--- a/src/pydap/parsers/dmr.py
+++ b/src/pydap/parsers/dmr.py
@@ -54,6 +54,10 @@ def get_variables(node, prefix="") -> dict:
                 name = prefix + "/" + name
             variables[name] = {"element": subnode, "parent": node.tag}
         variables.update(get_variables(subnode, prefix))
+    strings = node.findall("String")
+    for string in strings:
+        name = string.get("name")
+        variables[name] = {"element": string, "parent": node.tag}
     return variables
 
 

--- a/src/pydap/tests/test_parsers_dmr.py
+++ b/src/pydap/tests/test_parsers_dmr.py
@@ -265,3 +265,12 @@ class TestAttrsTypesDMRParser(unittest.TestCase):
                                 </Int32>\n</Dataset>"""
         ds = dmr_to_dataset(dmr)
         assert isinstance(ds["x"].attributes["attr"], float)
+
+    def test_string(self):
+        dmr = """<Dataset name="foo">\n    <String name="bears">\n
+                <Attribute name="attr" type="Float32">\n
+                            <Value></Value>\n        </Attribute>\n
+                                </String>\n</Dataset>"""
+        ds = dmr_to_dataset(dmr)
+        assert "bears" in ds.variables()
+        assert ds["bears"].dtype == "S128"


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes #422 
- [x] Tests are added to demonstrate the new or fixed behavior, and all tests pass
on a local environment.


### example
```python
from pydap.client import open_url
url = 'http://test.opendap.org:8080/opendap/data/nc/123bears.nc'
ds = open_url(url, protocol='dap4')
ds.tree()
```
yields now:
```
.123bears.nc
├──i
├──j
├──order
├──shot
├──aloan
├──cross
├──l
└──bears
```

where bears is a String array as denoted in the [dmr](http://test.opendap.org:8080/opendap/data/nc/123bears.nc.dmr) 