### PR TITLE
Decode chunk header to set length of DMR in a generic way and endianness of data

### DIFF
--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -118,7 +118,7 @@ def open_dmr_file(file_path):
 
 
 def open_dap_file(file_path):
-    """Open a file downloaded from a `.dap` (dap4) response, retunring a
+    """Open a file downloaded from a `.dap` (dap4) response, returning a
     dataset.
     """
     with open(file_path, "rb") as f:

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -145,7 +145,6 @@ def open_dap_file(file_path, das_path=None):
 
     with open(file_path, "rb") as f:
         dmr_len = get_dmr_length(file_path)
-        # if f.peek()[0:2] == b'\x04\x00':
         f.seek(dmr_len)
         _ = f.read(4)
         pydap.handlers.dap.unpack_dap4_data(f.read(), dataset)

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -46,7 +46,6 @@ lazy mechanism for function call, supporting any function. Eg, to call the
 
 from io import BytesIO, open
 
-import numpy
 from requests.utils import urlparse, urlunparse
 
 import pydap.handlers.dap
@@ -56,6 +55,7 @@ import pydap.net
 import pydap.parsers.das
 import pydap.parsers.dds
 import pydap.parsers.dmr
+from pydap.handlers.dap import UNPACKDAP4DATA
 from pydap.lib import DEFAULT_TIMEOUT as DEFAULT_TIMEOUT
 
 
@@ -105,50 +105,20 @@ def open_file(file_path, das_path=None):
         return open_dmr_file(file_path=file_path)
 
 
-def get_dmr_length(file_path):
-    with open(file_path, "rb") as f:
-        # First two bytes are CRLF
-        if f.peek()[0:2] == b"\x04\x00":
-            f.seek(2)
-            dmr_len = numpy.frombuffer(f.read(2), dtype=">u2")[0]
-        else:
-            dap = f.read()
-            dmr = b"<?xml" + dap.split(b"<?xml")[1]
-            dmr = dmr.split(b"</Dataset>")[0] + b"</Dataset>\n\r\n"
-            dmr_len = len(dmr)
-    return dmr_len
-
-
 def open_dmr_file(file_path):
-    dmr_len = get_dmr_length(file_path)
     with open(file_path, "rb") as f:
-        if f.peek()[0:2] == b"\x04\x00":
-            # First 2 bytes are CRLF, second two bytes give the length of the
-            # DMR; we skip over them
-            f.seek(4)
-            # We read the DMR minus the CRLF and newline (3 bytes)
-        dmr = f.read(dmr_len)
+        dmr = UNPACKDAP4DATA(f).dmr
     dmr = dmr.decode("ascii")
     dataset = pydap.parsers.dmr.dmr_to_dataset(dmr)
     return dataset
 
 
-def open_dap_file(file_path, das_path=None):
+def open_dap_file(file_path):
     """Open a file downloaded from a `.dap` (dap4) response, retunring a
     dataset.
-
-    Optionally, read also the `.das` response to assign attributes to the
-    dataset.
     """
-
-    dataset = open_dmr_file(file_path)
-
     with open(file_path, "rb") as f:
-        dmr_len = get_dmr_length(file_path)
-        f.seek(dmr_len)
-        _ = f.read(4)
-        pydap.handlers.dap.unpack_dap4_data(f.read(), dataset)
-    return dataset
+        return UNPACKDAP4DATA(f).dataset
 
 
 def open_dods_file(file_path, das_path=None):

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -106,8 +106,12 @@ def open_file(file_path, das_path=None):
 
 
 def open_dmr_file(file_path):
+    """
+    Opens a DMR. This differs from a dap response, since it is a single chunk,
+    and there is no chunk header at the top of the file.
+    """
     with open(file_path, "rb") as f:
-        dmr = UNPACKDAP4DATA(f).dmr
+        dmr = f.read()
     dmr = dmr.decode("ascii")
     dataset = pydap.parsers.dmr.dmr_to_dataset(dmr)
     return dataset

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -859,15 +859,15 @@ class UNPACKDAP4DATA(object):
     """
     Unpacks DAP4 response, remote or local, which is split into chunks. The
     first chunk contains the DMR response, and the endianness is defined in the first
-    4 bytes before the DMR. Once the endianness is set, is kept unfixed. This makes
-    the assumption that the all variables within dataset have the same endianness.
+    4 bytes before the DMR. Once the endianness is set, it remains unchanged. This
+    makes the assumption that the all variables within dataset have the same endianness.
 
     Parameters:
     -----------
-        r: dap response.
+        r: contains the dap response.
             May be a Webob.response.Response created from pydap.net.GET if the dataset
-            is remote, or a `io.BufferedReader` if the data is local within a
-            filesystem.
+            is remote (from a url), or a `io.BufferedReader` if the data is local within
+            a filesystem. See `pydap.net.get.open_dap_file`
     """
 
     def __init__(self, r, user_charset="ascii"):
@@ -888,7 +888,8 @@ class UNPACKDAP4DATA(object):
             raise TypeError(
                 """
                 Unrecognized file type object for unpacking dap4 binary data.
-                Acceptable formats are Webob.response and io.BufferedReader
+                Acceptable formats are `webob.response.Response` and
+                `io.BufferedReader`
                 """
             )
         self.dmr, self.data, self.endianness = self.safe_dmr_and_data()

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -872,7 +872,7 @@ class UNPACKDAP4DATA(object):
 
     def __init__(self, r, user_charset="ascii"):
         self.user_charset = user_charset
-        if isinstance(r, Response):
+        if isinstance(r, Response):  # a Webob response
             self.r = r
             if self.r.content_encoding == "gzip":
                 self.raw = BytesReader(
@@ -885,7 +885,12 @@ class UNPACKDAP4DATA(object):
             self.r = Response()  # make empty response
             self.raw = BytesReader(r.read())
         else:
-            print("warning that type not recognized")
+            raise TypeError(
+                """
+                Unrecognized file type object for unpacking dap4 binary data.
+                Acceptable formats are Webob.response and io.BufferedReader
+                """
+            )
         self.dmr, self.data, self.endianness = self.safe_dmr_and_data()
         # need to split dmr from data
         dataset = dmr_to_dataset(self.dmr)

--- a/src/pydap/tests/test_parsers_dap.py
+++ b/src/pydap/tests/test_parsers_dap.py
@@ -2,13 +2,12 @@ import os
 
 import numpy
 
-import pydap.client
+from ..client import open_dap_file
 
 
 def load_dap(file_path):
     abs_path = os.path.join(os.path.dirname(__file__), file_path)
-    dataset = pydap.client.open_dap_file(abs_path)
-    return dataset
+    return open_dap_file(abs_path)
 
 
 def test_jpl1():

--- a/src/pydap/tests/test_parsers_dmr.py
+++ b/src/pydap/tests/test_parsers_dmr.py
@@ -7,6 +7,7 @@ from xml.etree import ElementTree as ET
 
 import numpy as np
 
+from ..client import open_dmr_file
 from ..lib import walk
 from ..model import BaseType
 from ..parsers.dmr import dmr_to_dataset, get_groups
@@ -14,10 +15,7 @@ from ..parsers.dmr import dmr_to_dataset, get_groups
 
 def load_dmr_file(file_path):
     abs_path = os.path.join(os.path.dirname(__file__), file_path)
-    with open(abs_path, "r") as dmr_file:
-        dmr = dmr_file.read()
-    dataset = dmr_to_dataset(dmr)
-    return dataset
+    return open_dmr_file(abs_path)
 
 
 class TestDMRParser(unittest.TestCase):


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request: ~(DRAFT)~

- [x] Closes an already existing opened issue #xxxx for fixing a bug, requesting
a new feature, etc.
- [x] Tests are added to demonstrate the new or fixed behavior, and all tests pass
on a local environment.

Splits the dap response into dmr (first chunk) and data in a generic way, taking into account the first 4 bytes of the response. 
