### PR TITLE
Drop Webob from client use of pydap

### DIFF
--- a/src/pydap/cas/urs.py
+++ b/src/pydap/cas/urs.py
@@ -1,33 +1,19 @@
-from . import get_cookies
+from warnings import warn
 
 
 def setup_session(username, password, check_url=None, session=None, verify=True):
     """
-    A special call to get_cookies.setup_session that is tailored for
-    URS EARTHDATA at NASA credentials.
-
-    Parameters:
-    ----------
-    username: str
-    password: str
-    check_url: str, None (default)
-    session: `requests.session`, None (default)
-    verify: bool, True (default)
-
-    Example Data Access and Authentification in:
-    see `https://opendap.github.io/documentation/tutorials/`
-
+    This function is deprecated and will be removed in version 1.0.0.
+    Please use new_function instead.
     """
-
-    if session is not None:
-        # URS connections cannot be kept alive at the moment.
-        session.headers.update({"Connection": "close"})
-    session = get_cookies.setup_session(
-        "https://urs.earthdata.nasa.gov",
-        username=username,
-        password=password,
-        session=session,
-        check_url=check_url,
-        verify=verify,
+    warn(
+        "`urs.setup_session` is deprecated and will be removed in the next release. "
+        "Instead, use a `.netrc` file instead for your EDL authentication credentials."
+        "With the `.netrc file`, authentication with URS EARTHDATA at NASA credentials"
+        "is now handled automatically by requests.session object. "
+        "See: \n"
+        "https://opendap.github.io/documentation/tutorials/ClientAuthentication.html",
+        DeprecationWarning,
+        stacklevel=2,
     )
-    return session
+    pass

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -173,7 +173,6 @@ def open_dods_url(
     """Open a `.dods` response directly, returning a dataset."""
 
     r = pydap.net.GET(url, application, session, timeout=timeout)
-    pydap.net.raise_for_status(r)
 
     dds, data = r.body.split(b"\nData:\n", 1)
     dds = dds.decode(r.content_encoding or "ascii")
@@ -187,7 +186,7 @@ def open_dods_url(
             (scheme, netloc, path[:-4] + "das", params, query, fragment)
         )
         r = pydap.net.GET(dasurl, application, session, timeout=timeout, verify=verify)
-        pydap.net.raise_for_status(r)
+
         das = pydap.parsers.das.parse_das(r.text)
         pydap.parsers.das.add_attributes(dataset, das)
 

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -25,9 +25,7 @@ from itertools import chain
 import numpy
 import requests
 from requests.utils import urlparse, urlunparse
-from requests.exceptions import HTTPError
 from webob.response import Response
-
 
 from pydap.handlers.lib import BaseHandler, ConstraintExpression, IterData
 from pydap.lib import (
@@ -388,7 +386,7 @@ class BaseProxyDap2(object):
             timeout=self.timeout,
             verify=self.verify,
         )
-    
+
         dds, data = safe_dds_and_data(r, self.user_charset)
 
         # Parse received dataset:
@@ -471,8 +469,6 @@ class BaseProxyDap4(BaseProxyDap2):
             verify=self.verify,
         )
 
-
-        
         dataset = UNPACKDAP4DATA(r, self.user_charset).dataset
         self.checksum = dataset[self.id].attributes["checksum"]
         self.data = dataset[self.id].data

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -305,8 +305,6 @@ def safe_charset_text(r, user_charset):
         else:
             r.charset = get_charset(r, user_charset)
     return r.text
-    # elif isinstance(r, requests.Response):
-    #     return r.text
 
 
 def safe_dds_and_data(r, user_charset):

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -23,9 +23,9 @@ from io import BufferedReader, BytesIO
 from itertools import chain
 
 import numpy
+import requests
 from requests.utils import urlparse, urlunparse
 from webob.response import Response
-import requests
 
 from pydap.handlers.lib import BaseHandler, ConstraintExpression, IterData
 from pydap.lib import (
@@ -314,7 +314,7 @@ def safe_dds_and_data(r, user_charset):
     Takes the raw response of a dap2 request and splits it into the dds and data.
     If the response is gzipped, it is decompressed first.
     """
-    dds,data = None, None # initialize
+    dds, data = None, None  # initialize
     if isinstance(r, Response):
         if r.content_encoding == "gzip":
             raw = gzip.GzipFile(fileobj=BytesIO(r.body)).read()
@@ -327,6 +327,7 @@ def safe_dds_and_data(r, user_charset):
         _dds, data = raw.split(b"\nData:\n", 1)
         dds = _dds.decode(user_charset)
     return dds, data
+
 
 class BaseProxyDap2(object):
     """A proxy for remote base types.
@@ -602,7 +603,7 @@ class SequenceProxy(object):
                 i = iter(i)
         elif isinstance(r, requests.Response):
             i = r.iter_content()
- 
+
         # Fast forward past the DDS header
         # the pattern could span chunk boundaries though so make sure to check
         pattern = b"Data:\n"
@@ -931,7 +932,9 @@ class UNPACKDAP4DATA(object):
         dmr_length = chunk_header & 0x00FFFFFF
         chunk_type = (chunk_header >> 24) & 0xFF
         if isinstance(self.r, Response):
-            dmr = self.raw.read(dmr_length).decode(get_charset(self.r, self.user_charset))
+            dmr = self.raw.read(dmr_length).decode(
+                get_charset(self.r, self.user_charset)
+            )
         else:
             dmr = self.raw.read(dmr_length).decode(self.user_charset)
         data = self.raw.data

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -25,6 +25,7 @@ from itertools import chain
 import numpy
 from requests.utils import urlparse, urlunparse
 from webob.response import Response
+import requests
 
 from pydap.handlers.lib import BaseHandler, ConstraintExpression, IterData
 from pydap.lib import (
@@ -294,25 +295,38 @@ def get_charset(r, user_charset):
 
 
 def safe_charset_text(r, user_charset):
-    if r.content_encoding == "gzip":
-        return (
-            gzip.GzipFile(fileobj=BytesIO(r.body))
-            .read()
-            .decode(get_charset(r, user_charset))
-        )
-    else:
-        r.charset = get_charset(r, user_charset)
-        return r.text
+    if isinstance(r, Response):
+        if r.content_encoding == "gzip":
+            return (
+                gzip.GzipFile(fileobj=BytesIO(r.body))
+                .read()
+                .decode(get_charset(r, user_charset))
+            )
+        else:
+            r.charset = get_charset(r, user_charset)
+    return r.text
+    # elif isinstance(r, requests.Response):
+    #     return r.text
 
 
 def safe_dds_and_data(r, user_charset):
-    if r.content_encoding == "gzip":
-        raw = gzip.GzipFile(fileobj=BytesIO(r.body)).read()
-    else:
-        raw = r.body
-    dds, data = raw.split(b"\nData:\n", 1)
-    return dds.decode(get_charset(r, user_charset)), data
-
+    """
+    Takes the raw response of a dap2 request and splits it into the dds and data.
+    If the response is gzipped, it is decompressed first.
+    """
+    dds,data = None, None # initialize
+    if isinstance(r, Response):
+        if r.content_encoding == "gzip":
+            raw = gzip.GzipFile(fileobj=BytesIO(r.body)).read()
+        else:
+            raw = r.body
+        _dds, data = raw.split(b"\nData:\n", 1)
+        dds = _dds.decode(get_charset(r, user_charset))
+    elif isinstance(r, requests.Response):
+        raw = r.content
+        _dds, data = raw.split(b"\nData:\n", 1)
+        dds = _dds.decode(user_charset)
+    return dds, data
 
 class BaseProxyDap2(object):
     """A proxy for remote base types.
@@ -884,6 +898,10 @@ class UNPACKDAP4DATA(object):
             # r comes from reading a local file
             self.r = Response()  # make empty response
             self.raw = BytesReader(r.read())
+        elif isinstance(r, requests.Response):
+            # r comes from reading a remote dataset
+            self.r = r
+            self.raw = BytesReader(r.content)
         else:
             raise TypeError(
                 """
@@ -909,7 +927,10 @@ class UNPACKDAP4DATA(object):
         chunk_header = numpy.frombuffer(self.raw.read(4), dtype=">u4")[0]
         dmr_length = chunk_header & 0x00FFFFFF
         chunk_type = (chunk_header >> 24) & 0xFF
-        dmr = self.raw.read(dmr_length).decode(get_charset(self.r, self.user_charset))
+        if isinstance(self.r, Response):
+            dmr = self.raw.read(dmr_length).decode(get_charset(self.r, self.user_charset))
+        else:
+            dmr = self.raw.read(dmr_length).decode(self.user_charset)
         data = self.raw.data
         # get endianness from first chunk
         _, _, endianness = decode_chunktype(chunk_type)

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -596,10 +596,13 @@ class SequenceProxy(object):
         )
         raise_for_status(r)
 
-        i = r.app_iter
-        if not hasattr(i, "__next__"):
-            i = iter(i)
-
+        if isinstance(r, Response):
+            i = r.app_iter
+            if not hasattr(i, "__next__"):
+                i = iter(i)
+        elif isinstance(r, requests.Response):
+            i = r.iter_content()
+ 
         # Fast forward past the DDS header
         # the pattern could span chunk boundaries though so make sure to check
         pattern = b"Data:\n"

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -25,7 +25,9 @@ from itertools import chain
 import numpy
 import requests
 from requests.utils import urlparse, urlunparse
+from requests.exceptions import HTTPError
 from webob.response import Response
+
 
 from pydap.handlers.lib import BaseHandler, ConstraintExpression, IterData
 from pydap.lib import (
@@ -42,7 +44,7 @@ from pydap.lib import (
     walk,
 )
 from pydap.model import BaseType, GridType, SequenceType, StructureType
-from pydap.net import GET, raise_for_status
+from pydap.net import GET
 from pydap.parsers import parse_ce
 from pydap.parsers.das import add_attributes, parse_das
 from pydap.parsers.dds import dds_to_dataset
@@ -156,7 +158,6 @@ class DAPHandler(BaseHandler):
             timeout=self.timeout,
             verify=self.verify,
         )
-        raise_for_status(r)
         dmr = safe_charset_text(r, self.user_charset)
         self.dataset = dmr_to_dataset(dmr)
 
@@ -179,7 +180,7 @@ class DAPHandler(BaseHandler):
             timeout=self.timeout,
             verify=self.verify,
         )
-        raise_for_status(r)
+
         dds = safe_charset_text(r, self.user_charset)
         self.dataset = dds_to_dataset(dds)
 
@@ -202,7 +203,6 @@ class DAPHandler(BaseHandler):
             timeout=self.timeout,
             verify=self.verify,
         )
-        raise_for_status(r)
         das = safe_charset_text(r, self.user_charset)
         add_attributes(self.dataset, parse_das(das))
 
@@ -388,8 +388,7 @@ class BaseProxyDap2(object):
             timeout=self.timeout,
             verify=self.verify,
         )
-
-        raise_for_status(r)
+    
         dds, data = safe_dds_and_data(r, self.user_charset)
 
         # Parse received dataset:
@@ -472,7 +471,8 @@ class BaseProxyDap4(BaseProxyDap2):
             verify=self.verify,
         )
 
-        raise_for_status(r)
+
+        
         dataset = UNPACKDAP4DATA(r, self.user_charset).dataset
         self.checksum = dataset[self.id].attributes["checksum"]
         self.data = dataset[self.id].data
@@ -593,7 +593,6 @@ class SequenceProxy(object):
             timeout=self.timeout,
             verify=self.verify,
         )
-        raise_for_status(r)
 
         if isinstance(r, Response):
             i = r.app_iter

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -1,11 +1,12 @@
 import ssl
 
 import requests
-from requests.exceptions import Timeout, HTTPError
-from requests.utils import urlparse, urlunparse
-from webob.request import Request
 from requests.adapters import HTTPAdapter
+from requests.exceptions import HTTPError, Timeout
+from requests.utils import urlparse, urlunparse
 from urllib3 import Retry
+from webob.request import Request
+
 from .lib import DEFAULT_TIMEOUT, _quote
 
 
@@ -24,7 +25,7 @@ def GET(url, application=None, session=None, timeout=DEFAULT_TIMEOUT, verify=Tru
 
     if session is None:
         session = requests.Session()
-    
+
     req = create_request(
         url, application=application, session=session, timeout=timeout, verify=verify
     )
@@ -32,6 +33,7 @@ def GET(url, application=None, session=None, timeout=DEFAULT_TIMEOUT, verify=Tru
     # # Decode request response (i.e. gzip)
     # response.decode_content()
     return response
+
 
 def get_response(req, application=None, verify=True):
     """
@@ -74,7 +76,11 @@ def get_response(req, application=None, verify=True):
 
 
 def create_request(
-    url, application=None, session=None, timeout=DEFAULT_TIMEOUT, verify=True, retries=2, delay=1,
+    url,
+    application=None,
+    session=None,
+    timeout=DEFAULT_TIMEOUT,
+    verify=True,
 ):
     """
     Creates a requests.get request object for a local or remote url.
@@ -86,9 +92,9 @@ def create_request(
     If session is set and cookies were loaded using pydap.cas.get_cookies
     using the check_url option, then we can legitimately expect that
     the connection will go through seamlessly. The request library handles
-    redirects automatically and adjust the cookies as needed. We can then use the final url and
-    the final cookies to set up a requests's Request object that will
-    be guaranteed to have all the needed credentials:
+    redirects automatically and adjust the cookies as needed. We can then use
+    the final url and the final cookies to set up a requests's Request object
+    that will be guaranteed to have all the needed credentials:
     """
     try:
         if application:
@@ -97,15 +103,17 @@ def create_request(
             req.environ["webob.client.timeout"] = timeout
         else:
             # we pass any cookies, headers, if session has these attrs
-            keys = ['cookies', 'headers']
+            keys = ["cookies", "headers"]
             kwargs = {k: getattr(session, k) for k in keys if hasattr(session, k)}
-            args = {**kwargs, 'timeout': timeout, 'verify': verify}
+            args = {**kwargs, "timeout": timeout, "verify": verify}
             session = requests.Session()
 
-            retries = Retry(total=5, backoff_factor=0.1, status_forcelist=[500, 502, 503, 504])
+            retries = Retry(
+                total=5, backoff_factor=0.1, status_forcelist=[500, 502, 503, 504]
+            )
             adapter = HTTPAdapter(max_retries=retries)
-            session.mount('http://', adapter)
-            session.mount('https://', adapter)
+            session.mount("http://", adapter)
+            session.mount("https://", adapter)
             req = session.get(url, **args)
             try:
                 req.raise_for_status()

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -7,7 +7,7 @@ from requests.utils import urlparse, urlunparse
 from urllib3 import Retry
 from webob.request import Request as webob_Request
 
-from .lib import DEFAULT_TIMEOUT, __version__, _quote
+from .lib import DEFAULT_TIMEOUT, _quote
 
 
 def GET(

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -6,7 +6,6 @@ from requests.exceptions import HTTPError
 from requests.utils import urlparse, urlunparse
 from urllib3 import Retry
 from webob.request import Request as webob_Request
-from webob.response import Response as webob_Response
 
 from .lib import DEFAULT_TIMEOUT, _quote
 
@@ -52,7 +51,7 @@ def GET(
         verify=verify,
         **retry_args,
     )
-    if isinstance(res,  webob_Request):
+    if isinstance(res, webob_Request):
         res = get_response(res, application, verify=verify)
         # requests library automatically decodes the response
         res.decode_content()

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -148,5 +148,7 @@ def create_request(
         try:
             req.raise_for_status()
             return req
-        except HTTPError as ex:
-            raise ex
+        except HTTPError as http_err:
+            raise HTTPError(
+                f"HTTP Error occurred {http_err} - Failed to fetch data from `{url}`"
+            ) from http_err

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -7,7 +7,7 @@ from requests.utils import urlparse, urlunparse
 from urllib3 import Retry
 from webob.request import Request as webob_Request
 
-from .lib import DEFAULT_TIMEOUT, _quote, __version__
+from .lib import DEFAULT_TIMEOUT, __version__, _quote
 
 
 def GET(
@@ -130,7 +130,9 @@ def create_request(
         req.environ["webob.client.timeout"] = timeout
         return req
     else:
-        session_kwargs = kwargs.pop("session_kwargs", {})  # Extract session-specific kwargs
+        session_kwargs = kwargs.pop(
+            "session_kwargs", {}
+        )  # Extract session-specific kwargs
         if session is None:
             # Create a new session with user-specified kwargs
             session = requests.Session()
@@ -150,7 +152,9 @@ def create_request(
             # Mount the adapter to the session
             session.mount("http://", adapter)
             session.mount("https://", adapter)
-        req = session.get(url, timeout=timeout, verify=verify, allow_redirects=True, **kwargs)
+        req = session.get(
+            url, timeout=timeout, verify=verify, allow_redirects=True, **kwargs
+        )
         try:
             req.raise_for_status()
             return req

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -1,8 +1,7 @@
 import ssl
-from contextlib import closing
 
 import requests
-from requests.exceptions import InvalidSchema, MissingSchema, Timeout
+from requests.exceptions import Timeout
 from requests.utils import urlparse, urlunparse
 from webob.exc import HTTPError
 from webob.request import Request
@@ -75,7 +74,9 @@ def follow_redirect(
     headers as the passed session.
     """
 
-    req = create_request(url,application=application, session=session, timeout=timeout, verify=verify)
+    req = create_request(
+        url, application=application, session=session, timeout=timeout, verify=verify
+    )
     return get_response(req, application, verify=verify)
 
 
@@ -110,7 +111,7 @@ def get_response(req, application=None, verify=True):
                 resp = req.get_response(application)
             else:
                 # this is a remote request
-                return req                
+                return req
         finally:
             if _create_default_https_ctx is not None:
                 # Restore verified context
@@ -118,7 +119,9 @@ def get_response(req, application=None, verify=True):
     return resp
 
 
-def create_request(url, application=None, session=None, timeout=DEFAULT_TIMEOUT, verify=True):
+def create_request(
+    url, application=None, session=None, timeout=DEFAULT_TIMEOUT, verify=True
+):
     """
     If session is set and cookies were loaded using pydap.cas.get_cookies
     using the check_url option, then we can legitimately expect that
@@ -136,17 +139,27 @@ def create_request(url, application=None, session=None, timeout=DEFAULT_TIMEOUT,
         # requests.Session() object. The requests library allows the
         # handling of redirects that are not naturally handled by Webob.
         session = requests.Session()
-    return create_request_from_session(url, session, timeout=timeout, application=application, verify=verify)
+    return create_request_from_session(
+        url, session, timeout=timeout, application=application, verify=verify
+    )
 
 
-def create_request_from_session(url, session, timeout=DEFAULT_TIMEOUT, application=None, verify=True):
+def create_request_from_session(
+    url, session, timeout=DEFAULT_TIMEOUT, application=None, verify=True
+):
     try:
         if application:
             # local datset, webob request.
             req = Request.blank(url)
             req.environ["webob.client.timeout"] = timeout
         else:
-            req = requests.get(url, cookies=session.cookies, headers=session.headers, timeout=timeout, verify=verify)
-        return req          
+            req = requests.get(
+                url,
+                cookies=session.cookies,
+                headers=session.headers,
+                timeout=timeout,
+                verify=verify,
+            )
+        return req
     except Timeout:
         raise HTTPError("Timeout")

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -2,10 +2,9 @@ import ssl
 
 import requests
 from requests.adapters import HTTPAdapter
-from requests.exceptions import ConnectTimeout, HTTPError, ReadTimeout
+from requests.exceptions import HTTPError
 from requests.utils import urlparse, urlunparse
 from urllib3 import Retry
-from urllib3.exceptions import ConnectionError, MaxRetryError, TimeoutError
 from webob.request import Request
 
 from .lib import DEFAULT_TIMEOUT, _quote
@@ -103,7 +102,7 @@ def create_request(
         return req
     else:
         # we pass any cookies, headers, if session has these attrs
-        args= {"timeout": timeout, "verify": verify}
+        args = {"timeout": timeout, "verify": verify}
         if session:
             # get any cookies and headers from previous session
             keys = ["cookies", "headers"]
@@ -137,5 +136,3 @@ def create_request(
             return req
         except HTTPError as ex:
             raise ex
-
-

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -19,13 +19,26 @@ def GET(
     verify=True,
     **retry_args,
 ):
-    """Open a remote URL returning a webob.response.Response object
+    """Open a remote URL returning a requests.GET object
 
-    Optional parameters:
-    session: a requests.Session() object (potentially) containing
-             authentication cookies.
+    Parameters:
+    -----------
+        url: str
+            open a remote URL
+        application: a WSGI application object | None
+            When set, we are dealing with a local application, and a webob.response is
+            returned. When None, a requests.Response object is returned.
+        session: requests.Session() | None
+            object (potentially) containing authentication cookies.
+        timeout: int | None (default: 512)
+            timeout in seconds.
+        verify: bool (default: True)
+            verify SSL certificates
+        retry_args: dict
+            retry arguments passed to HTTPAdapter
 
-    Optionally open a URL to a local WSGI application
+    Returns:
+        response: requests.Response object | webob.Response object
     """
     if application:
         _, _, path, _, query, fragment = urlparse(url)

--- a/src/pydap/server/devel.py
+++ b/src/pydap/server/devel.py
@@ -7,7 +7,7 @@ import time
 from wsgiref.simple_server import make_server
 
 import numpy as np
-from webob.exc import HTTPError
+from requests.exceptions import HTTPError
 from webob.request import Request
 
 from ..handlers.lib import BaseHandler

--- a/src/pydap/server/devel.py
+++ b/src/pydap/server/devel.py
@@ -137,7 +137,7 @@ class LocalTestServer(object):
                 # When checking whether server has started, do
                 # not verify ssl:
                 resp = get_response(
-                    Request.blank(self.url + ".dds"), None, verify=False
+                    Request.blank(self.url + ".dds"), self.application, verify=False
                 )
                 ok = resp.status_code == 200
             except HTTPError:

--- a/src/pydap/server/devel.py
+++ b/src/pydap/server/devel.py
@@ -60,7 +60,7 @@ class LocalTestServer(object):
 
     As an instance:
     >>> with LocalTestServer(application) as server:
-    ...     dataset = open_url("http://localhost:%s" % server.port)
+    ...     dataset = open_url("http://localhost:%s" % server.port, protocol='dap2')
     ...     dataset
     ...     print(dataset['byte'].data[:])
     ...     print(dataset['string'].data[:])
@@ -73,7 +73,7 @@ class LocalTestServer(object):
     Or by managing connection and deconnection:
     >>> server = LocalTestServer(application)
     >>> server.start()
-    >>> dataset = open_url("http://localhost:%s" % server.port)
+    >>> dataset = open_url("http://localhost:%s" % server.port, protocol='dap2')
     >>> dataset
     <DatasetType with children 'byte', 'string', 'short'>
     >>> print(dataset['byte'].data[:])

--- a/src/pydap/server/devel_ssl.py
+++ b/src/pydap/server/devel_ssl.py
@@ -1,9 +1,7 @@
 import multiprocessing
 import sys
 import time
-import warnings
 
-import requests
 from werkzeug.serving import run_simple
 
 from ..handlers.lib import BaseHandler

--- a/src/pydap/server/devel_ssl.py
+++ b/src/pydap/server/devel_ssl.py
@@ -46,6 +46,7 @@ class LocalTestServerSSL(LocalTestServer):
 
     Usage:
     >>> import numpy as np
+    >>> import time
     >>> from pydap.handlers.lib import BaseHandler
     >>> from pydap.model import DatasetType, BaseType
     >>> DefaultDataset = DatasetType("Default")
@@ -59,12 +60,14 @@ class LocalTestServerSSL(LocalTestServer):
     >>> from pydap.client import open_url
     >>> application = BaseHandler(DefaultDataset)
     >>> with LocalTestServerSSL(application) as server:
+    ...     time.sleep(0.1)
     ...     dataset = open_url("http://localhost:%s" % server.port)
 
 
     Or by managing connection and deconnection:
     >>> server = LocalTestServerSSL(application)
     >>> server.start()
+    >>> time.sleep(0.1)
     >>> dataset = open_url("http://localhost:%s" % server.port)
     >>> dataset
     <DatasetType with children 'byte', 'string', 'short'>
@@ -119,13 +122,6 @@ class LocalTestServerSSL(LocalTestServer):
     # https://werkzeug.palletsprojects.com/en/2.2.x/serving/#shutting-down-the-server
     def shutdown(self):
         # Shutdown the server:
-        url = "http://0.0.0.0:%s/shutdown"
-        if self._ssl_context is not None:
-            url = url.replace("http", "https")
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            requests.head(url % self.port, verify=False)
         time.sleep(self._wait)
-        # self._server.join()
         self._server.terminate()
         del self._server

--- a/src/pydap/tests/test_net.py
+++ b/src/pydap/tests/test_net.py
@@ -5,6 +5,9 @@ Test the follow redirects and handling of more complex routing situations
 import requests
 import requests_mock
 
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
 from pydap.net import create_request
 import pytest
 
@@ -61,13 +64,8 @@ def test_redirect():
         assert req.text == "resp2"
 
 
-# def test_httperror():
-#     """test that raise_for_status raises the correct HTTPerror"""
-#     fake_url = 'https://httpstat.us/404' # this url will return a 404
-#     with pytest.raises(requests.exceptions.HTTPError):
-#         create_request(fake_url)
-
-    
-
-
-
+def test_httperror():
+    """test that raise_for_status raises the correct HTTPerror"""
+    fake_url = 'https://httpstat.us/404' # this url will return a 404
+    with pytest.raises(requests.exceptions.HTTPError):
+        create_request(fake_url)

--- a/src/pydap/tests/test_net.py
+++ b/src/pydap/tests/test_net.py
@@ -4,7 +4,6 @@ Test the follow redirects and handling of more complex routing situations
 
 import requests
 import requests_mock
-from webob.request import Request
 
 from pydap.net import create_request
 
@@ -15,40 +14,48 @@ def test_redirect():
     # mock_url is redirected to https:
     redirect_url = "http://www.test2.com/"
     with requests_mock.Mocker() as m:
-        m.register_uri("HEAD", mock_url, text="resp2", status_code=200)
+        m.register_uri("GET", mock_url, status_code=302, 
+        headers={"Location": redirect_url})
+        m.register_uri("GET", redirect_url, text="Final Destination", status_code=200)
         req = create_request(mock_url)
-        assert len(m.request_history) == 1
-        assert isinstance(req, Request)
-        assert req.headers["Host"] == "www.test.com:80"
+        assert req.url == redirect_url
+        assert req.status_code == 200
+        assert req.text == "Final Destination"
+        assert isinstance(req, requests.Response)
 
     # Without session:
     with requests_mock.Mocker() as m:
         m.register_uri(
-            "HEAD",
+            "GET",
             mock_url,
             text="resp1",
             status_code=301,
             headers={"Location": redirect_url},
         )
-        m.register_uri("HEAD", redirect_url, text="resp2", status_code=200)
+        m.register_uri("GET", redirect_url, text="resp2", status_code=200)
         req = create_request(mock_url)
+        assert isinstance(req, requests.Response)
         # Ensure follow redirect:
         assert len(m.request_history) == 2
-        assert isinstance(req, Request)
-        assert req.headers["Host"] == "www.test2.com:80"
+        assert req.url == redirect_url
+        assert req.status_code == 200
+        assert req.text == "resp2"
+
 
     # With session:
     with requests_mock.Mocker() as m:
         m.register_uri(
-            "HEAD",
+            "GET",
             mock_url,
             text="resp1",
             status_code=301,
             headers={"Location": redirect_url},
         )
-        m.register_uri("HEAD", redirect_url, text="resp2", status_code=200)
+        m.register_uri("GET", redirect_url, text="resp2", status_code=200)
         req = create_request(mock_url, session=requests.Session())
         # Ensure follow redirect:
         assert len(m.request_history) == 2
-        assert isinstance(req, Request)
-        assert req.headers["Host"] == "www.test2.com:80"
+        assert isinstance(req, requests.Response)
+        assert req.url == redirect_url
+        assert req.status_code == 200
+        assert req.text == "resp2"

--- a/src/pydap/tests/test_net.py
+++ b/src/pydap/tests/test_net.py
@@ -5,13 +5,13 @@ Test the follow redirects and handling of more complex routing situations
 import pytest
 import requests
 import requests_mock
-
-from pydap.handlers.lib import BaseHandler
-from pydap.tests.datasets import SimpleGroup
-from pydap.net import create_request, GET, get_response
-from requests.exceptions import RequestException
 from webob.request import Request
 from webob.response import Response
+
+from pydap.handlers.lib import BaseHandler
+from pydap.net import GET, create_request, get_response
+from pydap.tests.datasets import SimpleGroup
+
 
 def test_redirect():
     """Test that redirection is handled properly"""
@@ -72,21 +72,23 @@ def test_raise_httperror():
     with pytest.raises(requests.exceptions.HTTPError):
         create_request(fake_url)
 
+
 @pytest.fixture
 def appGroup():
     """Creates an application from the SimpleGroup dataset"""
     return BaseHandler(SimpleGroup)
 
+
 def test_GET_application(appGroup):
     """Test that local url are handled properly"""
     data_url = "http://localhost:8080/"
-    r = GET(data_url+'.dmr', application=appGroup)
+    r = GET(data_url + ".dmr", application=appGroup)
     assert r.status_code == 200
 
 
 def test_create_request_application(appGroup):
     """Test that local url are handled properly"""
-    req = create_request('/.dmr', application=appGroup, verify=True)
+    req = create_request("/.dmr", application=appGroup, verify=True)
     assert isinstance(req, Request)
     resp = get_response(req, application=appGroup, verify=True)
     assert isinstance(resp, Response)

--- a/src/pydap/tests/test_net.py
+++ b/src/pydap/tests/test_net.py
@@ -14,8 +14,9 @@ def test_redirect():
     # mock_url is redirected to https:
     redirect_url = "http://www.test2.com/"
     with requests_mock.Mocker() as m:
-        m.register_uri("GET", mock_url, status_code=302, 
-        headers={"Location": redirect_url})
+        m.register_uri(
+            "GET", mock_url, status_code=302, headers={"Location": redirect_url}
+        )
         m.register_uri("GET", redirect_url, text="Final Destination", status_code=200)
         req = create_request(mock_url)
         assert req.url == redirect_url
@@ -40,7 +41,6 @@ def test_redirect():
         assert req.url == redirect_url
         assert req.status_code == 200
         assert req.text == "resp2"
-
 
     # With session:
     with requests_mock.Mocker() as m:

--- a/src/pydap/tests/test_net.py
+++ b/src/pydap/tests/test_net.py
@@ -6,7 +6,7 @@ import requests
 import requests_mock
 
 from pydap.net import create_request
-
+import pytest
 
 def test_redirect():
     """Test that redirection is handled properly"""
@@ -59,3 +59,15 @@ def test_redirect():
         assert req.url == redirect_url
         assert req.status_code == 200
         assert req.text == "resp2"
+
+
+# def test_httperror():
+#     """test that raise_for_status raises the correct HTTPerror"""
+#     fake_url = 'https://httpstat.us/404' # this url will return a 404
+#     with pytest.raises(requests.exceptions.HTTPError):
+#         create_request(fake_url)
+
+    
+
+
+

--- a/src/pydap/tests/test_net.py
+++ b/src/pydap/tests/test_net.py
@@ -2,14 +2,12 @@
 Test the follow redirects and handling of more complex routing situations
 """
 
+import pytest
 import requests
 import requests_mock
 
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
-
 from pydap.net import create_request
-import pytest
+
 
 def test_redirect():
     """Test that redirection is handled properly"""
@@ -66,6 +64,6 @@ def test_redirect():
 
 def test_httperror():
     """test that raise_for_status raises the correct HTTPerror"""
-    fake_url = 'https://httpstat.us/404' # this url will return a 404
+    fake_url = "https://httpstat.us/404"  # this url will return a 404
     with pytest.raises(requests.exceptions.HTTPError):
         create_request(fake_url)

--- a/src/pydap/tests/test_server_devel_ssl.py
+++ b/src/pydap/tests/test_server_devel_ssl.py
@@ -13,6 +13,7 @@ import sys
 import numpy as np
 import pytest
 import requests
+import time
 
 from pydap.client import open_url
 from pydap.handlers.lib import BaseHandler
@@ -48,7 +49,8 @@ def test_open(sequence_type_data):
     TestDataset = DatasetType("Test")
     TestDataset["sequence"] = sequence_type_data
     with LocalTestServerSSL(BaseHandler(TestDataset)) as server:
-        dataset = open_url(server.url)
+        time.sleep(0.1)
+        dataset = open_url(server.url, protocol="dap2")
         seq = dataset["sequence"]
         retrieved_data = [line for line in seq]
 
@@ -56,7 +58,6 @@ def test_open(sequence_type_data):
         np.array(retrieved_data, dtype=sequence_type_data.data.dtype),
         np.array(sequence_type_data.data[:], dtype=sequence_type_data.data.dtype),
     )
-
 
 @pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")
 @server
@@ -70,7 +71,8 @@ def test_verify_open_url(sequence_type_data):
     application = BaseHandler(TestDataset)
     with LocalTestServerSSL(application, ssl_context="adhoc") as server:
         try:
-            open_url(server.url, verify=False, session=requests.Session())
+            time.sleep(0.1)
+            open_url(server.url, verify=False, session=requests.Session(), protocol="dap2")
         except (ssl.SSLError, requests.exceptions.SSLError):
             pytest.fail("SSLError should not be raised.")
 

--- a/src/pydap/tests/test_server_devel_ssl.py
+++ b/src/pydap/tests/test_server_devel_ssl.py
@@ -72,7 +72,7 @@ def test_verify_open_url(sequence_type_data):
     application = BaseHandler(TestDataset)
     with LocalTestServerSSL(application, ssl_context="adhoc") as server:
         try:
-            time.sleep(0.1)
+            time.sleep(0.2)
             open_url(
                 server.url, verify=False, session=requests.Session(), protocol="dap2"
             )

--- a/src/pydap/tests/test_server_devel_ssl.py
+++ b/src/pydap/tests/test_server_devel_ssl.py
@@ -9,11 +9,11 @@ it could work with more data formats.
 
 import ssl
 import sys
+import time
 
 import numpy as np
 import pytest
 import requests
-import time
 
 from pydap.client import open_url
 from pydap.handlers.lib import BaseHandler
@@ -59,6 +59,7 @@ def test_open(sequence_type_data):
         np.array(sequence_type_data.data[:], dtype=sequence_type_data.data.dtype),
     )
 
+
 @pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")
 @server
 def test_verify_open_url(sequence_type_data):
@@ -72,7 +73,9 @@ def test_verify_open_url(sequence_type_data):
     with LocalTestServerSSL(application, ssl_context="adhoc") as server:
         try:
             time.sleep(0.1)
-            open_url(server.url, verify=False, session=requests.Session(), protocol="dap2")
+            open_url(
+                server.url, verify=False, session=requests.Session(), protocol="dap2"
+            )
         except (ssl.SSLError, requests.exceptions.SSLError):
             pytest.fail("SSLError should not be raised.")
 


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:
- [x] Replaces with use of Webob on pydap.net.GET in a general scenario where URL points to a remote (or local) dataset. Se below. Thus, this should close #429 and #432
- [x] Enable retries when requesting a GET via requests library on HTTP 500s. By default retries=5, but arguments can be passed directly to pydap.get_request()
- [x] Added more tests.
- [x] refactors `pydap.net` module. I remove several functions, in particular `pydap.net.raise_with_status` is no longer there. `pydap.net.follow_redirect` and `pydap.create_request` and `pydap.create_request_with_session` are combined together


In essence, this PR makes it so that 
- `pydap.net.GET` uses `requests.get(URL)` when the `application is None`, meaning that the URL points to a remote dataset. 
- `pydap.net` uses `Webob.Request.get_response` When application is not None, but intead is a wsgi applicatoin wrapping a pydap dataset. This case is mostly use for testing/development purposes.









