### PR TITLE
patch to enable auth with tds + dap4 + authentication

### DIFF
--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -9,7 +9,7 @@ from requests_cache import CachedSession
 from urllib3 import Retry
 from webob.request import Request as webob_Request
 
-from .lib import DEFAULT_TIMEOUT, _quote
+from .lib import DEFAULT_TIMEOUT, _quote, __version__
 
 
 def GET(
@@ -240,6 +240,7 @@ def create_session(
     session_kwargs = session_kwargs or {}
     token = session_kwargs.pop("token", None)
     cache_kwargs = cache_kwargs or {}
+    headers = [("User-agent", "pydap/{}".format(__version__))]
     if use_cache:
         expire_after = cache_kwargs.pop("expire_after", None)
         if not expire_after:
@@ -257,7 +258,7 @@ def create_session(
                 "expire_after": expire_after,
             }
             # Create a new session with cache
-        session = CachedSession(**{**session_kwargs, **cache_kwargs})
+        session = CachedSession(**{**session_kwargs, **cache_kwargs}) 
     else:
         if len(cache_kwargs) > 0:
             warnings.warn(
@@ -272,6 +273,7 @@ def create_session(
         session = requests.Session()
         for key, value in session_kwargs.items():
             setattr(session, key, value)
+    session.headers.update(headers)
     # Handle retry arguments separately
     retry_args = session_kwargs.pop("retry_args", {})
     if "total" not in retry_args:

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -200,7 +200,8 @@ def create_request(
                 else:
                     raise HTTPError(
                         "HTTP Error - Failed to correctly authenticate on this "
-                        "Thredds Data server under the DAP4 protocol"
+                        "Thredds Data server under the DAP4 protocol. See GH issue"
+                        "https://github.com/pydap/pydap/issues/442"
                     )
             raise HTTPError(
                 f"HTTP Error occurred {http_err} - Failed to fetch data from `{url}`"

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -9,7 +9,7 @@ from requests_cache import CachedSession
 from urllib3 import Retry
 from webob.request import Request as webob_Request
 
-from .lib import DEFAULT_TIMEOUT, _quote, __version__
+from .lib import DEFAULT_TIMEOUT, __version__, _quote
 
 
 def GET(
@@ -258,7 +258,7 @@ def create_session(
                 "expire_after": expire_after,
             }
             # Create a new session with cache
-        session = CachedSession(**{**session_kwargs, **cache_kwargs}) 
+        session = CachedSession(**{**session_kwargs, **cache_kwargs})
     else:
         if len(cache_kwargs) > 0:
             warnings.warn(


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] A temporary, not very elegant patch to fix authentication issues with tds data server + DAP4 data. See #442 for context. Also #411  

### What is new with this PR

pydap can now access DAP4 data from a Thredds data server, when needing to authenticate. Authentication is handled by requests.Session object (via ~/.netrc), and pydap manually handles the cookies and redirect urls

The following now works, with authentication credentials on a local `~/.netrc` file.
```python
from pydap.client import open_url
url = "https://thredds-test.unidata.ucar.edu/thredds/dap4/dev/d4icomp/restricted/SimpleGroup.nc4"
ds = open_url(url, protocol='dap4')
ds.tree()

.SimpleGroup.nc4
├──SimpleGroup
│  ├──Temperature
│  ├──Salinity
│  ├──Y
│  └──X
├──Pressure
├──time_bnds
├──time
└──Z


```

### NOTE
This is a temporary fix, while the bug is corrected on the server side.

