### PR TITLE
include a session object as attribute to pydap.dataset so that it can be retrieved/recovered by user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 # C extensions
 *.so
 
+# no chached sessions
+*.sqlite
 # Packages
 *.egg
 *.egg-info

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -135,6 +135,7 @@ def open_url(
         get_kwargs=get_kwargs,
     )
     dataset = handler.dataset
+    dataset._session = session
 
     # attach server-side functions
     dataset.functions = Functions(url, application, session, timeout=timeout)

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -174,11 +174,11 @@ import warnings
 from collections import OrderedDict
 from collections.abc import Mapping
 from functools import reduce
-from typing import Union, Optional
-import requests
-import requests_cache
+from typing import Optional, Union
 
 import numpy as np
+import requests
+import requests_cache
 
 from .lib import _quote, decode_np_strings, tree, walk
 
@@ -568,12 +568,44 @@ class DatasetType(StructureType):
         'B'
     """
 
-    def __init__(self, name="nameless", attributes=None, session: Optional[Union[requests.Session, requests_cache.CachedSession]] = None, **kwargs):
+    def __init__(
+        self,
+        name="nameless",
+        attributes=None,
+        session: Optional[Union[requests.Session, requests_cache.CachedSession]] = None,
+        **kwargs,
+    ):
         super().__init__(name, attributes, **kwargs)
         # Explicit type checking to enforce the allowed types
-        if session is not None and not isinstance(session, (requests.Session, requests_cache.CachedSession)):
-            raise TypeError("`session` must be a `requests.Session` or `requests_cache.CachedSession` instance")
-        self.session = session 
+        if session is not None and not isinstance(
+            session, (requests.Session, requests_cache.CachedSession)
+        ):
+            raise TypeError(
+                "`session` must be a `requests.Session` or "
+                "`requests_cache.CachedSession` instance"
+            )
+        self._session = session
+
+    @property
+    def session(self):
+        """Read-only property for session."""
+        return self._session
+
+    @session.setter
+    def session(self, value):
+        """Prevent re-assignment of session."""
+        if self.session:
+            raise AttributeError("Cannot modify `session` after it has been set.")
+        else:
+            if value is not None and not isinstance(
+                value, (requests.Session, requests_cache.CachedSession)
+            ):
+                raise TypeError(
+                    "`session` must be a `requests.Session` or "
+                    "`requests_cache.CachedSession` instance"
+                )
+            else:
+                self._session = value
 
     def __setitem__(self, key, item):
         # key a path-like only in DAP4

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -174,6 +174,9 @@ import warnings
 from collections import OrderedDict
 from collections.abc import Mapping
 from functools import reduce
+from typing import Union, Optional
+import requests
+import requests_cache
 
 import numpy as np
 
@@ -564,6 +567,13 @@ class DatasetType(StructureType):
         >>> dataset["B"].id
         'B'
     """
+
+    def __init__(self, name="nameless", attributes=None, session: Optional[Union[requests.Session, requests_cache.CachedSession]] = None, **kwargs):
+        super().__init__(name, attributes, **kwargs)
+        # Explicit type checking to enforce the allowed types
+        if session is not None and not isinstance(session, (requests.Session, requests_cache.CachedSession)):
+            raise TypeError("`session` must be a `requests.Session` or `requests_cache.CachedSession` instance")
+        self.session = session 
 
     def __setitem__(self, key, item):
         # key a path-like only in DAP4

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -603,15 +603,13 @@ class DatasetType(StructureType):
         if self.session:
             raise AttributeError("Cannot modify `session` after it has been set.")
         else:
-            if value is not None and not isinstance(
-                value, (requests.Session, requests_cache.CachedSession)
-            ):
+            if isinstance(value, (requests.Session, requests_cache.CachedSession)):
+                self._session = value
+            else:
                 raise TypeError(
                     "`session` must be a `requests.Session` or "
                     "`requests_cache.CachedSession` instance"
                 )
-            else:
-                self._session = value
 
     def __setitem__(self, key, item):
         # key a path-like only in DAP4

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -30,6 +30,7 @@ def test_open_url(sequence_app):
     """Open an URL and check dataset keys."""
     dataset = open_url("http://localhost:8001/", sequence_app)
     assert list(dataset.keys()) == ["cast"]
+    assert isinstance(dataset.session, requests.Session)
 
 
 @pytest.fixture

--- a/src/pydap/tests/test_model.py
+++ b/src/pydap/tests/test_model.py
@@ -6,6 +6,8 @@ from collections.abc import Mapping
 
 import numpy as np
 import pytest
+import requests
+import requests_cache
 
 from pydap.model import (
     BaseType,
@@ -654,3 +656,31 @@ def test_GridType_maps(gridtype_example):
 def test_GridType_dimensions(gridtype_example):
     """Test ``dimensions`` property."""
     assert gridtype_example.dimensions == ("x", "y")
+
+
+@pytest.mark.parametrize(
+    "session",
+    [None, requests.Session(), requests_cache.CachedSession(), "session"],
+)
+def test_error_session(session):
+    """test that trying to set a session with other than a `None`,
+    a `requests.Session` or a `requests_cached.CachedSession()` object
+    returns a TypeError
+    """
+    if not session:
+        # is session is None (default) then session can be changed later
+        pyds = DatasetType("name")
+        assert pyds.session == session  # asserts default
+        pyds.session = (
+            requests_cache.CachedSession()
+        )  # sets the session to a new cached session
+        assert isinstance(pyds.session, requests_cache.CachedSession)
+    elif isinstance(session, (requests.Session, requests_cache.CachedSession)):
+        pyds = DatasetType("name", session=session)
+        assert pyds.session == session
+        with pytest.raises(AttributeError):
+            pyds.session = None  # session cannot be modify once set
+    else:
+        # test attemps to set the session object with a string type - not allowed
+        with pytest.raises(TypeError):
+            DatasetType("name", session=session)


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Can potentially close #444, which describes how caching a requests can lead to unexpected behaviors when the session is never returned to the user.
- [x] Tests are added to demonstrate the new or fixed behavior, and all tests pass
on a local environment.

### example of new behavior/feature

```python
url = "http://<data_url>"
# the following create a `session` object in the background which handles the requests
pyds = pydap.client.open_url(url, use_cache=True)

## this is new
session=pyds.session

```

And so the session can be reused to talk to a different server, and cache that response. It will not prevent the unexpected behavior described in #444 , but it will make it easier to avoid it or to correct it with:

```python
session.cache.clear()
```



