### PR TITLE
enables caching of multiple dap4 urls and custom cache key for dimensions dap responses

### DIFF
--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -57,15 +57,14 @@ from urllib.parse import parse_qs, unquote, urlencode
 from requests.utils import urlparse, urlunparse
 from requests_cache import CachedSession
 
+from .handlers.dap import UNPACKDAP4DATA, DAPHandler, StreamReader, unpack_dap2_data
+from .lib import DEFAULT_TIMEOUT as DEFAULT_TIMEOUT
+from .lib import encode
 from .model import DapType
-from .net import GET
-from .parsers.das import parse_das, add_attributes
+from .net import GET, create_session
+from .parsers.das import add_attributes, parse_das
 from .parsers.dds import dds_to_dataset
-from .handlers.dap import UNPACKDAP4DATA, DAPHandler, unpack_dap2_data, StreamReader
-from .lib import DEFAULT_TIMEOUT as DEFAULT_TIMEOUT, encode
 from .parsers.dmr import DMRParser, dmr_to_dataset
-
-from .net import create_session
 
 
 def open_url(

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -211,7 +211,7 @@ def datacube_urls(urls, session=None):
     dims = set([item for sublist in nested for item in sublist])
     if not dims:
         warnings.warn("No dimensions found in the dataset.")
-        return session
+        return None
 
     # make sure count of dimensions is the same as the number of urls
 
@@ -240,7 +240,7 @@ def datacube_urls(urls, session=None):
         with session as Session:  # Authenticate once
             with ThreadPoolExecutor(max_workers=ncores) as executor:
                 results = list(executor.map(lambda url: Session.get(url), new_urls))
-    return session
+    return None
 
 
 def open_file(file_path, das_path=None):

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -166,7 +166,7 @@ def datacube_urls(urls, session=None):
     if not session:
         session = create_session()
     if not isinstance(urls, list) or len(urls) == 1:
-        raise TypeError("urls must be a list of `len` > 2. Try again!")
+        raise TypeError("urls must be a list of `len` >= 2. Try again!")
 
     # check elements in urls are strings
     if not all(isinstance(url, str) for url in urls):

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -214,8 +214,10 @@ def datacube_urls(urls, session=None):
     ]
     dims = set([item for sublist in nested for item in sublist])
     if not dims:
-        print("Error: No share dimensions found. Make sure the urls are correct.")
-        return None
+        warnings.warn(
+            "No dimensions found in the dataset. Please check the URLs."
+        )
+        return session
 
     # make sure count of dimensions is the same as the number of urls
 

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -459,7 +459,7 @@ class ServerFunctionResult(object):
 def fetch_url(url, session):
     """Fetch a URL and return its status code."""
     try:
-        response = session.get(url, stream=True)
+        response = session.get(url)
         return url, response.status_code
     except requests.RequestException as e:
         return url, f"Error: {e}"
@@ -477,7 +477,7 @@ def compute_base_url_prefix(url_list):
     if not all(url.startswith("http") for url in url_list):
         raise ValueError("url_list must contain valid HTTP URLs.")
     parsed_paths = [urlparse(url).path.split("?")[0] for url in url_list]
-    parsed_paths = [("/").join(path.split("/")[:-1]) for path in parsed_paths]
+    # parsed_paths = [("/").join(path.split("/")) for path in parsed_paths]
     common_path = os.path.dirname(commonprefix(parsed_paths))
     if not all(
         [

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -470,8 +470,23 @@ def compute_base_url_prefix(url_list):
     Compute the longest common base path across a list of URLs.
     Returns the common prefix as a normalized base URL.
     """
-    parsed_paths = [urlparse(url).path for url in url_list]
+    if not isinstance(url_list, list) or len(url_list) < 2:
+        raise ValueError("url_list must be a list of at least two URLs.")
+    if not all(isinstance(url, str) for url in url_list):
+        raise ValueError("url_list must contain only strings.")
+    if not all(url.startswith("http") for url in url_list):
+        raise ValueError("url_list must contain valid HTTP URLs.")
+    parsed_paths = [urlparse(url).path.split("?")[0] for url in url_list]
+    parsed_paths = [("/").join(path.split("/")[:-1]) for path in parsed_paths]
     common_path = os.path.dirname(commonprefix(parsed_paths))
+    if not all(
+        [
+            len(common_path.split("/")) + 1 == len(path.split("/"))
+            for path in parsed_paths
+        ]
+    ):
+        raise ValueError("No common path found in the provided URLs.")
+    # Normalize the common path
     parsed_example = urlparse(url_list[0])
     return f"{parsed_example.scheme}://{parsed_example.netloc}{common_path}"
 

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -214,9 +214,7 @@ def datacube_urls(urls, session=None):
     ]
     dims = set([item for sublist in nested for item in sublist])
     if not dims:
-        warnings.warn(
-            "No dimensions found in the dataset. Please check the URLs."
-        )
+        warnings.warn("No dimensions found in the dataset.")
         return session
 
     # make sure count of dimensions is the same as the number of urls

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -45,8 +45,6 @@ lazy mechanism for function call, supporting any function. Eg, to call the
 """
 
 import os
-
-# import logging
 import re
 import warnings
 from concurrent.futures import ThreadPoolExecutor

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -17,7 +17,6 @@ import pprint
 import re
 import sys
 import warnings
-import warnings as _warnings
 from concurrent.futures import ThreadPoolExecutor
 from io import BufferedReader, BytesIO
 from itertools import chain
@@ -132,7 +131,7 @@ class DAPHandler(BaseHandler):
         if self.query[:4] == "dap4":
             return "dap4"
         else:
-            _warnings.warn(
+            warnings.warn(
                 "PyDAP was unable to determine the DAP protocol defaulting "
                 "to DAP2. DAP2 is consider legacy and may result in slower "
                 "responses. \nConsider replacing `http` in your `url` with "

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -152,11 +152,15 @@ class DAPHandler(BaseHandler):
             self.attach_das()
 
     def dataset_from_dap4(self):
+        if not self.path.endswith(".dmr"):
+            path = self.path + ".dmr"
+        else:
+            path = self.path
         dmr_url = urlunparse(
             (
                 self.scheme,
                 self.netloc,
-                self.path + ".dmr",
+                path,
                 "",
                 _quote(self.query),
                 self.fragment,

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -410,7 +410,7 @@ def test_warning_datacube_urls(urls):
     assert returns is None
 
 
-ce = "?dap4.ce=/i[0:1:1];/j[0:1:2];/bears[0:1:1][0:1:2];/l[0:1:2]"
+ce1 = "?dap4.ce=/i[0:1:1];/j[0:1:2];/bears[0:1:1][0:1:2];/l[0:1:2]"
 
 
 @pytest.mark.parametrize(
@@ -418,7 +418,7 @@ ce = "?dap4.ce=/i[0:1:1];/j[0:1:2];/bears[0:1:1][0:1:2];/l[0:1:2]"
     [
         [
             "dap4://test.opendap.org/opendap/data/nc/123bears.nc",
-            "dap4://test.opendap.org/opendap/data/nc/123bears.nc" + ce,
+            "dap4://test.opendap.org/opendap/data/nc/123bears.nc" + ce1,
         ],
     ],
 )
@@ -436,3 +436,11 @@ def test_cached_datacube_urls(urls):
     # check that the cached session has all the dmr urls and
     # caches the dap response of the dimensions only once
     assert len(cached_session.cache.urls()) == len(urls) + len(dims)
+    # THE FOLLOWING IS AN IMPORTANT CHECK. THE EXTRA CACHED URLS
+    # ARE THE DAP RESPONSES OF EACH DIMENSION. AND THESE ARE THE LAST
+    # TO CACHE. MEANING THE FIRST ELEMENTS OF THE LIST OF CACHED URLS.
+    dap_urls = [url.replace("dap4", "http") for url in urls]
+    dim_dap_urls = [dap_urls[0] + ".dap?dap4.ce=" + dim for dim in dims]
+    N = len(dims)  # should be 3 for this dataset.
+    for n in range(N):
+        assert cached_session.cache.urls()[n].split("%")[0] == dim_dap_urls[n]

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -7,7 +7,14 @@ import pytest
 import requests
 from requests_cache import CachedSession
 
-from ..client import datacube_urls, open_dmr, open_dods_url, open_file, open_url
+from ..client import (
+    compute_base_url_prefix,
+    datacube_urls,
+    open_dmr,
+    open_dods_url,
+    open_file,
+    open_url,
+)
 from ..handlers.lib import BaseHandler
 from ..model import BaseType, DatasetType, GridType
 from ..net import create_session
@@ -460,3 +467,29 @@ def tests_no_dims_cache(remote_url):
         # so the dap urls are not cached
         session = datacube_urls(dap_urls)
         assert isinstance(session, requests.Session)
+
+
+@pytest.mark.parametrize(
+    "urls",
+    [
+        ["http://localhost:8001/", 1, "http://localhost:8003/"],
+        [
+            "dap2://localhost:8001/",
+            "dap2://localhost:8002/",
+            "dap2://localhost:8003/",
+        ],
+        ["http://localhost:8001/"],
+        [
+            "http://localhost:8001/common/path/data.nc",
+            "http://localhost:8002/common/path/data.nc",
+            "http://localhost:8003/NO/COMMON/PATH/HERE/data.nc",
+        ],
+    ],
+)
+def test_ValueErrors_compute_base_url_prefix(urls):
+    """Tests that ValueError is raised wuen urls
+    is not a `uniform` list of https urls belonging to the same
+    data cube. That is, URLS MUST be valid, and have a common path
+    """
+    with pytest.raises(ValueError):
+        compute_base_url_prefix(urls)

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -411,6 +411,8 @@ def test_warning_datacube_urls(urls):
 
 
 ce1 = "?dap4.ce=/i[0:1:1];/j[0:1:2];/bears[0:1:1][0:1:2];/l[0:1:2]"
+
+
 @pytest.mark.parametrize(
     "urls",
     [
@@ -425,7 +427,7 @@ def test_cached_datacube_urls(urls):
     with the dap4 urls of the dimensions
     """
     pyds = open_dmr(urls[0].replace("dap4", "http") + ".dmr")
-    dims = list(pyds.dimensions) # dimensions of full dataset
+    dims = list(pyds.dimensions)  # dimensions of full dataset
 
     cached_session = create_session(use_cache=True)
     cached_session.cache.clear()  # clears any existing cache

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -5,7 +5,6 @@ import os
 import numpy as np
 import pytest
 import requests
-from requests_cache import CachedSession
 
 from ..client import (
     compute_base_url_prefix,

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -493,3 +493,30 @@ def test_ValueErrors_compute_base_url_prefix(urls):
     """
     with pytest.raises(ValueError):
         compute_base_url_prefix(urls)
+
+
+cloud_common = "/providers/POCLOUD/collections/granules"
+cloud_urls = "https://opendap.earthdata.nasa.gov"
+posix_urls= "http://localhost:8001"
+posix_common = "/common/path"
+@pytest.mark.parametrize(
+    "urls, common_path",
+    [
+        ([
+            posix_urls+posix_common+"/data.nc",
+            posix_urls+posix_common+"/data.nc",
+            posix_urls+posix_common+"/data.nc",
+        ], posix_urls+posix_common),
+        ([
+            cloud_urls+cloud_common+"/fileA.nc",
+            cloud_urls+cloud_common+"/fileC.nc",
+            cloud_urls+cloud_common+"/fileB.nc",
+        ], cloud_urls+cloud_common)
+    ],
+)
+def test_compute_base_url_prefix(urls, common_path):
+    """Tests that compute_base_url_prefix returns the correct common path
+    for a list of urls. The urls must be valid and have a common path.
+    """
+    base_url = compute_base_url_prefix(urls)
+    assert base_url == common_path

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -22,6 +22,7 @@ from .datasets import SimpleGrid, SimpleSequence, SimpleStructure
 
 DODS = os.path.join(os.path.dirname(__file__), "data/test.01.dods")
 DAS = os.path.join(os.path.dirname(__file__), "data/test.01.das")
+SimpleGroupdmr = os.path.join(os.path.dirname(__file__), "data/dmrs/SimpleGroup.dmr")
 
 
 @pytest.fixture
@@ -499,8 +500,6 @@ cloud_common = "/providers/POCLOUD/collections/granules"
 cloud_urls = "https://opendap.earthdata.nasa.gov"
 posix_urls = "http://localhost:8001"
 posix_common = "/common/path"
-
-
 @pytest.mark.parametrize(
     "urls, common_path",
     [
@@ -528,3 +527,26 @@ def test_compute_base_url_prefix(urls, common_path):
     """
     base_url = compute_base_url_prefix(urls)
     assert base_url == common_path
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [[None, None],
+     ["FileNotFound", None],
+        [
+            "http://test.opendap.org/opendap/data/nc/coads_climatology.nc.dmr",
+            DatasetType,
+        ],
+        [
+            SimpleGroupdmr,
+            DatasetType,
+        ],  
+    ]
+)
+def test_open_dmr(url, expected):
+    """Test `open_dmr` for various urls"""
+    pyds = open_dmr(url)
+    if expected:
+        assert isinstance(pyds,expected)
+    else:
+        assert pyds == expected 

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -481,8 +481,8 @@ def tests_no_dims_cache(remote_url):
         ["http://localhost:8001/"],
         [
             "http://localhost:8001/common/path/data.nc",
-            "http://localhost:8002/common/path/data.nc",
-            "http://localhost:8003/NO/COMMON/PATH/HERE/data.nc",
+            "http://localhost:8001/common/path/data.nc",
+            "http://localhost:8001/NO/COMMON/PATH/HERE/data.nc",
         ],
     ],
 )

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -500,6 +500,8 @@ cloud_common = "/providers/POCLOUD/collections/granules"
 cloud_urls = "https://opendap.earthdata.nasa.gov"
 posix_urls = "http://localhost:8001"
 posix_common = "/common/path"
+
+
 @pytest.mark.parametrize(
     "urls, common_path",
     [
@@ -531,8 +533,9 @@ def test_compute_base_url_prefix(urls, common_path):
 
 @pytest.mark.parametrize(
     "url, expected",
-    [[None, None],
-     ["FileNotFound", None],
+    [
+        [None, None],
+        ["FileNotFound", None],
         [
             "http://test.opendap.org/opendap/data/nc/coads_climatology.nc.dmr",
             DatasetType,
@@ -540,13 +543,13 @@ def test_compute_base_url_prefix(urls, common_path):
         [
             SimpleGroupdmr,
             DatasetType,
-        ],  
-    ]
+        ],
+    ],
 )
 def test_open_dmr(url, expected):
     """Test `open_dmr` for various urls"""
     pyds = open_dmr(url)
     if expected:
-        assert isinstance(pyds,expected)
+        assert isinstance(pyds, expected)
     else:
-        assert pyds == expected 
+        assert pyds == expected

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -497,21 +497,29 @@ def test_ValueErrors_compute_base_url_prefix(urls):
 
 cloud_common = "/providers/POCLOUD/collections/granules"
 cloud_urls = "https://opendap.earthdata.nasa.gov"
-posix_urls= "http://localhost:8001"
+posix_urls = "http://localhost:8001"
 posix_common = "/common/path"
+
+
 @pytest.mark.parametrize(
     "urls, common_path",
     [
-        ([
-            posix_urls+posix_common+"/data.nc",
-            posix_urls+posix_common+"/data.nc",
-            posix_urls+posix_common+"/data.nc",
-        ], posix_urls+posix_common),
-        ([
-            cloud_urls+cloud_common+"/fileA.nc",
-            cloud_urls+cloud_common+"/fileC.nc",
-            cloud_urls+cloud_common+"/fileB.nc",
-        ], cloud_urls+cloud_common)
+        (
+            [
+                posix_urls + posix_common + "/data.nc",
+                posix_urls + posix_common + "/data.nc",
+                posix_urls + posix_common + "/data.nc",
+            ],
+            posix_urls + posix_common,
+        ),
+        (
+            [
+                cloud_urls + cloud_common + "/fileA.nc",
+                cloud_urls + cloud_common + "/fileC.nc",
+                cloud_urls + cloud_common + "/fileB.nc",
+            ],
+            cloud_urls + cloud_common,
+        ),
     ],
 )
 def test_compute_base_url_prefix(urls, common_path):

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -439,8 +439,7 @@ def test_cached_datacube_urls(urls):
 
     cached_session = create_session(use_cache=True)
     cached_session.cache.clear()  # clears any existing cache
-    cached_session = datacube_urls(urls, cached_session)
-    assert isinstance(cached_session, CachedSession)
+    datacube_urls(urls, cached_session)
     # check that the cached session has all the dmr urls and
     # caches the dap response of the dimensions only once
     assert len(cached_session.cache.urls()) == len(urls) + len(dims)
@@ -466,8 +465,7 @@ def tests_no_dims_cache(remote_url):
     with pytest.warns(Warning):
         # no dimensions in the urls
         # so the dap urls are not cached
-        session = datacube_urls(dap_urls)
-        assert isinstance(session, requests.Session)
+        datacube_urls(dap_urls)
 
 
 @pytest.mark.parametrize(

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -411,8 +411,6 @@ def test_warning_datacube_urls(urls):
 
 
 ce1 = "?dap4.ce=/i[0:1:1];/j[0:1:2];/bears[0:1:1][0:1:2];/l[0:1:2]"
-
-
 @pytest.mark.parametrize(
     "urls",
     [
@@ -427,7 +425,7 @@ def test_cached_datacube_urls(urls):
     with the dap4 urls of the dimensions
     """
     pyds = open_dmr(urls[0].replace("dap4", "http") + ".dmr")
-    dims = list(pyds.dimensions)
+    dims = list(pyds.dimensions) # dimensions of full dataset
 
     cached_session = create_session(use_cache=True)
     cached_session.cache.clear()  # clears any existing cache
@@ -444,3 +442,19 @@ def test_cached_datacube_urls(urls):
     N = len(dims)  # should be 3 for this dataset.
     for n in range(N):
         assert cached_session.cache.urls()[n].split("%")[0] == dim_dap_urls[n]
+
+
+def tests_no_dims_cache(remote_url):
+    base_url = remote_url + "nc/123bears.nc"
+    ce1 = "?dap4.ce=/bears[0:1:1][0:1:2]"
+    ce2 = "?dap4.ce=/order[0:1:1][0:1:2]"
+    ce3 = "?dap4.ce=/shot[0:1:1][0:1:2]"
+    CE = [ce1, ce2, ce3]
+    dap_urls = [
+        base_url.replace("http", "dap4") + ce for ce in CE
+    ]  # dap urls with constraints expressions
+    with pytest.warns(Warning):
+        # no dimensions in the urls
+        # so the dap urls are not cached
+        session = datacube_urls(dap_urls)
+        assert isinstance(session, requests.Session)


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->
~DRAFT PR~

This PR will enable

- [x] Caching of dap4 urls (dmrs and dap responses). These urls must be defined as a list object and passed to the new function `datacube_urls`. 
- [x] Caching multiple dap responses of all dimensions within a datacube (say an entire Collection consisting of 100 granules/urls that share same dimensions) by a single key (per dimension). 
For example:
Consider dimensions: 'time', 'lat', 'lon', 'Z' all appear in each of the `N` urls that make up the collection. When requesting the `dap` response of the array `time`, it will no longer be downloaded N times. It will instead it is only downloaded once. Same for each of the other dimensions.
- [x] Test are added and all pass locally.


### New behavior
The following is an example of how it works:
```python
fom pydap.net import create_session
# use requests-cache by setting use_cache=True.
new_session = create_session(use_cache=True)

# Consider a list of dap4 urls
urls[:5]
>>>
['dap4://oceandata.sci.gsfc.nasa.gov/opendap/PACE_OCI/L3SMI/2024/0305/PACE_OCI.20240305.L3m.DAY.CHL.V3_0.chlor_a.4km.nc?dap4.ce=/lat;/lon;/chlor_a',
 'dap4://oceandata.sci.gsfc.nasa.gov/opendap/PACE_OCI/L3SMI/2024/0306/PACE_OCI.20240306.L3m.DAY.CHL.V3_0.chlor_a.4km.nc?dap4.ce=/lat;/lon;/chlor_a',
 'dap4://oceandata.sci.gsfc.nasa.gov/opendap/PACE_OCI/L3SMI/2024/0307/PACE_OCI.20240307.L3m.DAY.CHL.V3_0.chlor_a.4km.nc?dap4.ce=/lat;/lon;/chlor_a',
 'dap4://oceandata.sci.gsfc.nasa.gov/opendap/PACE_OCI/L3SMI/2024/0308/PACE_OCI.20240308.L3m.DAY.CHL.V3_0.chlor_a.4km.nc?dap4.ce=/lat;/lon;/chlor_a',
 'dap4://oceandata.sci.gsfc.nasa.gov/opendap/PACE_OCI/L3SMI/2024/0309/PACE_OCI.20240309.L3m.DAY.CHL.V3_0.chlor_a.4km.nc?dap4.ce=/lat;/lon;/chlor_a']
 
 
# now cache the datacube dmrs and their dimensions
# this line may take O(10) seconds, and only needs to be run once
datacube_urls(urls, cached_session)

# the cached-session now contains reference to O(100) OPeNDAP urls. Internally it uses 
# pydap so the metadata/dmr has been verified to be consistent with creating a pydap dataset
# and therefore an xarray dataset.

## open a virtually aggregated xarray dataset using the cached session
ds = xr.open_mfdataset(urls, engine='pydap', session=cached_session, parallel=True, combine='nested', concat_dim='time')

# That last line may take 1-5 seconds, depending on N-URLS and ncores.
```
Because it uses requests-cache - it can handle two types of authentication: token based and username/password based via netrc file (case above).

