### PR TITLE
Add Python3.13 metadata and fix spelling mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ dataset, and pydap will download the accessed data on-the-fly as needed. For exa
 ```python
     (1, 17999, 36000)
 ```
-> ![NOTE] 
+> ![NOTE]
 > In the example above, no data was downloaded, it was all lazily evaluated using OPeNDAP's DMR (DAP4) metadata representation. For more information, please check the documentation on [using pydap as a client](https://pydap.github.io/pydap/client.html).
 
 pydap also comes with a simple server, implemented as a [WSGI]( http://wsgi.org/) application. To use it, you first need to install the server and optionally a data handler:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ Now you simply activate the pydap environment:
 ```bash
     $ conda activate pydap
 ```
-(NOTE: if you have `mamba` install, you can replace `conda` in the commands with `mamba`). You can now use pydap as a client and open any remotely served dataset, and `pydap` will download the accessed data on-the-fly as needed. For example consider [this](http://test.opendap.org:8080/opendap/catalog/ghrsst/20210102090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc.dmr.html) dataset currently hosted on OPeNDAP's Hyrax data server
+
+> [!NOTE]
+> If you have `mamba` installed, you can replace `conda` in the commands with `mamba`.
+
+You can now use pydap as a client and open any remotely served dataset, and `pydap` will download the accessed data on-the-fly as needed. For example consider [this](http://test.opendap.org:8080/opendap/catalog/ghrsst/20210102090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc.dmr.html) dataset currently hosted on OPeNDAP's Hyrax data server
 
 ```python
     from pydap.client import open_url

--- a/README.md
+++ b/README.md
@@ -19,34 +19,26 @@ What is pydap?
 
 Why pydap?
 ----------
-Originally developed in the 2000s, pydap is one of the oldest open-source python projects available and it gets rutinely developed and maintained by the OPeNDAP community at large. In addition, pydap is a long-recognized backend engine (and dependency) for [xarray](https://github.com/pydata/xarray) and chances are you have used pydap in past without knowing.
-
+Originally developed in the 2000s, pydap is one of the oldest open-source python projects available and is routinely developed and maintained by the OPeNDAP community at large. In addition, pydap is a long-recognized backend engine (and dependency) for [xarray](https://github.com/pydata/xarray) and chances are you have used pydap in the past without knowing it.
 
 Quickstart
 ----------
-pydap is a lighweight python package that you can use in either
-of the two modalities: a client and as a server.
-You can install the latest version using
-[pip](http://pypi.python.org/pypi/pip). After [installing
-pip](http://www.pip-installer.org/en/latest/installing.html) you can
-install pydap with this command:
+pydap is a lightweight python package that you can use in either of the two modalities: a client and as a server.
+You can install the latest version using [pip](http://pypi.python.org/pypi/pip). After [installing pip](http://www.pip-installer.org/en/latest/installing.html) you can install pydap with this command:
 
 ```bash
     $ pip install pydap
 ```
-This will install pydap together with all the required
-dependencies.
+This will install pydap together with all the required dependencies.
 
-pydap is also available through [Anaconda](https://www.anaconda.com/).
-Below we install pydap and its required dependencies, along with common
-additional packages in a fresh conda environment named pydap:
+pydap is also available through [Anaconda](https://www.anaconda.com/).  Below we install pydap and its required dependencies, along with common additional packages in a fresh conda environment named pydap:
 
 ```bash
-$ conda create -n pydap -c conda-forge python=3.10 pydap numpy">=2.0" jupyterlab ipython netCDF4 scipy matplotlib
+    $ conda create -n pydap -c conda-forge python=3.10 pydap numpy">=2.0" jupyterlab ipython netCDF4 scipy matplotlib
 ```
 Now you simply activate the pydap environment:
 ```bash
-conda activate pydap
+    $ conda activate pydap
 ```
 (NOTE: if you have `mamba` install, you can replace `conda` in the commands with `mamba`). You can now use pydap as a client and open any remotely served
 dataset, and pydap will download the accessed data on-the-fly as needed. For example consider [this](http://test.opendap.org:8080/opendap/catalog/ghrsst/20210102090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc.dmr.html) dataset currently hosted on OPeNDAP's Hyrax data server
@@ -74,12 +66,10 @@ dataset, and pydap will download the accessed data on-the-fly as needed. For exa
 ```python
     (1, 17999, 36000)
 ```
-**NOTE** In the example above, no data was downloaded, it was all lazily evaluated using OPeNDAP's DMR (DAP4) metadata representation. For more information, please check the documentation on [using pydap
-as a client](https://pydap.github.io/pydap/client.html).
+> ![NOTE] 
+> In the example above, no data was downloaded, it was all lazily evaluated using OPeNDAP's DMR (DAP4) metadata representation. For more information, please check the documentation on [using pydap as a client](https://pydap.github.io/pydap/client.html).
 
-pydap also comes with a simple server, implemented as a [WSGI]( http://wsgi.org/)
-application. To use it, you first need to install the server and
-optionally a data handler:
+pydap also comes with a simple server, implemented as a [WSGI]( http://wsgi.org/) application. To use it, you first need to install the server and optionally a data handler:
 
 ## Running pydap as a Server
 
@@ -93,7 +83,6 @@ for your server data.
 To run the server just issue the command:
 
 ```bash
-
     $ pydap --data ./myserver/data/ --port 8001 --workers 4 --threads 4
 ```
 
@@ -111,5 +100,4 @@ For more information, see [the pydap documentation](https://pydap.github.io/pyda
 
 ## Help and Community
 
-If you need any help with pydap, open an issue in this repository. You can also send an email to
-the [mailing list](http://groups.google.com/group/pydap/). Finally, ff you have a broader OPeNDAP access question, you can reach the OPeNDAP team on the [OPeNDAP Discourse](https://opendap.discourse.group/)!
+If you need any help with pydap, open an issue in this repository. You can also email the [mailing list](http://groups.google.com/group/pydap/). Finally, if you have a broader OPeNDAP access question, you can reach the OPeNDAP team on the [OPeNDAP Discourse](https://opendap.discourse.group/)!

--- a/README.md
+++ b/README.md
@@ -15,23 +15,22 @@ pydap
 
 What is pydap?
 ----------
-[pydap](https://pydap.github.io/pydap/) is an open-source implementation of the OPeNDAP protocol, written from scratch in pure python. You can use pydap to access scientific data available on the many OPeNDAP servers publically available through the internet. Because pydap supports remote and lazy evaluation, you can access the data without having to download it; instead, you work with special array and iterable objects that download data on-the-fly as necessary, saving bandwidth and time. The module also comes with a robust-but-lightweight OPeNDAP server, implemented as a WSGI application.
+[pydap](https://pydap.github.io/pydap/) is an open-source implementation of the OPeNDAP protocol, written from scratch in pure Python. You can use `pydap` to access scientific data available on the many OPeNDAP servers publicly-available through the internet. Because pydap supports remote and lazy evaluation, you can access the data without having to download it; Instead, you work with special array and iterable objects that download data on-the-fly as necessary, saving bandwidth and time. The module also comes with a robust-but-lightweight OPeNDAP server, implemented as a WSGI application.
 
 Why pydap?
 ----------
-Originally developed in the 2000s, pydap is one of the oldest open-source python projects available and is routinely developed and maintained by the OPeNDAP community at large. In addition, pydap is a long-recognized backend engine (and dependency) for [xarray](https://github.com/pydata/xarray) and chances are you have used pydap in the past without knowing it.
+Originally developed in the 2000s, `pydap` is one of the oldest open-source Python projects available and is routinely developed and maintained by the OPeNDAP community at large. In addition, `pydap` is a long-recognized backend engine (and dependency) for [xarray](https://github.com/pydata/xarray) and chances are you have used `pydap` in the past without knowing it.
 
 Quickstart
 ----------
-pydap is a lightweight python package that you can use in either of the two modalities: a client and as a server.
-You can install the latest version using [pip](http://pypi.python.org/pypi/pip). After [installing pip](http://www.pip-installer.org/en/latest/installing.html) you can install pydap with this command:
+`pydap` is a lightweight python package that you can use in either of the two modalities: a client and as a server. You can install the latest version using [pip](http://pypi.python.org/pypi/pip). After [installing pip](http://www.pip-installer.org/en/latest/installing.html) you can install `pydap` with this command:
 
 ```bash
     $ pip install pydap
 ```
 This will install pydap together with all the required dependencies.
 
-pydap is also available through [Anaconda](https://www.anaconda.com/).  Below we install pydap and its required dependencies, along with common additional packages in a fresh conda environment named pydap:
+`pydap` is also available through [Anaconda](https://www.anaconda.com/). Below we install `pydap` and its required dependencies, along with common additional packages in a fresh conda environment named `"pydap"`:
 
 ```bash
     $ conda create -n pydap -c conda-forge python=3.10 pydap numpy">=2.0" jupyterlab ipython netCDF4 scipy matplotlib
@@ -40,8 +39,7 @@ Now you simply activate the pydap environment:
 ```bash
     $ conda activate pydap
 ```
-(NOTE: if you have `mamba` install, you can replace `conda` in the commands with `mamba`). You can now use pydap as a client and open any remotely served
-dataset, and pydap will download the accessed data on-the-fly as needed. For example consider [this](http://test.opendap.org:8080/opendap/catalog/ghrsst/20210102090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc.dmr.html) dataset currently hosted on OPeNDAP's Hyrax data server
+(NOTE: if you have `mamba` install, you can replace `conda` in the commands with `mamba`). You can now use pydap as a client and open any remotely served dataset, and `pydap` will download the accessed data on-the-fly as needed. For example consider [this](http://test.opendap.org:8080/opendap/catalog/ghrsst/20210102090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc.dmr.html) dataset currently hosted on OPeNDAP's Hyrax data server
 
 ```python
     from pydap.client import open_url
@@ -66,10 +64,11 @@ dataset, and pydap will download the accessed data on-the-fly as needed. For exa
 ```python
     (1, 17999, 36000)
 ```
-> ![NOTE]
+
+> [!NOTE]
 > In the example above, no data was downloaded, it was all lazily evaluated using OPeNDAP's DMR (DAP4) metadata representation. For more information, please check the documentation on [using pydap as a client](https://pydap.github.io/pydap/client.html).
 
-pydap also comes with a simple server, implemented as a [WSGI]( http://wsgi.org/) application. To use it, you first need to install the server and optionally a data handler:
+`pydap` also comes with a simple server, implemented as a [WSGI]( http://wsgi.org/) application. To use it, you first need to install the server and optionally a data handler:
 
 ## Running pydap as a Server
 
@@ -77,8 +76,7 @@ pydap also comes with a simple server, implemented as a [WSGI]( http://wsgi.org/
     $ pip install "pydap[server,netcdf]"
 ```
 
-This will install the necessary dependencies for running pydap as a server, along with extra dependencies for handling [netCDF4](https://www.unidata.ucar.edu/software/netcdf/) dataset. Now create a directory
-for your server data.
+This will install the necessary dependencies for running pydap as a server, along with extra dependencies for handling [netCDF4](https://www.unidata.ucar.edu/software/netcdf/) dataset. Now create a directory for your server data.
 
 To run the server just issue the command:
 
@@ -86,13 +84,9 @@ To run the server just issue the command:
     $ pydap --data ./myserver/data/ --port 8001 --workers 4 --threads 4
 ```
 
-This will start a standalone server running on the default http://localhost:8001/,
-serving netCDF files from ``./myserver/data/`` Since the server uses the
-[WSGI](http://wsgi.org/) standard, pydap uses by default 1 worker and 1
-thread, but these can be defined by the user like in the case above (4 workers
-and 4 threads). Pydap can also easily be run behind Apache. The [server
-documentation](https://pydap.github.io/pydap/server.html) has
-more information on how to better deploy pydap.
+This will start a standalone server running on the default http://localhost:8001/, serving netCDF files from ``./myserver/data/`` Since the server uses the [WSGI](http://wsgi.org/) standard, pydap uses by default one (1) worker and one (1)  thread, but these can be defined by the user like in the case above (four (4) workers and four (4) threads). `pydap` can also easily be run behind Apache.
+
+The [server documentation](https://pydap.github.io/pydap/server.html) has more information on how to better deploy `pydap`.
 
 ## Documentation
 
@@ -100,4 +94,4 @@ For more information, see [the pydap documentation](https://pydap.github.io/pyda
 
 ## Help and Community
 
-If you need any help with pydap, open an issue in this repository. You can also email the [mailing list](http://groups.google.com/group/pydap/). Finally, if you have a broader OPeNDAP access question, you can reach the OPeNDAP team on the [OPeNDAP Discourse](https://opendap.discourse.group/)!
+If you need any help with `pydap`, open an issue in this repository. You can also email the [mailing list](http://groups.google.com/group/pydap/). Finally, if you have a broader OPeNDAP access question, you can reach the OPeNDAP team on the [OPeNDAP Discourse](https://opendap.discourse.group/)!

--- a/docs/en/how_to_install.md
+++ b/docs/en/how_to_install.md
@@ -5,14 +5,13 @@ Starting with the latest release `3.5.1`, the installation of `pydap` is now spl
 ## 1. Client-only
 To install `pydap` to use only as a client API, you can do:
 
-
 ```shell
-pip install pydap
+    $ pip install pydap
 ```
-or
+or:
 
 ```shell
-conda install pydap
+    $ conda install pydap
 ```
 
 ```{note}
@@ -21,17 +20,17 @@ If you already have `mamba` installed, you can replace all `conda` in the comman
 This installation of `pydap` will include the minimal dependencies to allow users to subset remote data on OPeNDAP servers.
 
 ## 2. Complete installation
-To recover the full installation of pydap, which includes the packages for using pydap as a client and as a server, run:
+To recover the full installation of `pydap`, which includes the packages for using pydap as a client and as a server, run:
 
 ```shell
-conda install pydap-server
+    $ conda install pydap-server
 ```
 
-This installation of `pydap` will include the dependencies to allow users to a) subset remote data on OPeNDAP servers, and b) use pydap's server to make data available.
+This installation of `pydap` will include the dependencies to allow users to: a) subset remote data on OPeNDAP servers; and b) use `pydap`'s server to make data available.
 
-
+```{note}
 We recommend to use package installation managers like `conda`/`mamba`. This approach requires having an installation of [Miniconda](https://docs.anaconda.com/miniconda/) or [Anaconda](https://docs.anaconda.com/anaconda/install/).
-
+```
 
 ## Dependencies
 ### Minimal Required
@@ -51,8 +50,8 @@ The following are required to run pydap as a client.
 You can easily use conda to install `pydap` or `pydap-server`, along with any optional packages for sharing a reproducible workflow. For example:
 
 ```shell
-conda create -n pydap_env -c conda-forge python=3.10 pydap-server
-conda activate pydap_env
+    $ conda create -n pydap_env -c conda-forge python=3.10 pydap-server
+    $ conda activate pydap_env
 ```
 
 ```{note}
@@ -65,15 +64,12 @@ If you already have `mamba` installed, you can replace all `conda` in the comman
 - `cartopy`
 - `xarray`
 
-
-
-
-To install the latest `pydap` version (client-only), directly from the github repository, run:
+To install the latest `pydap` version (client-only), directly from the GitHub repository, run:
 
 ```shell
-pip install --upgrade git+https://github.com/pydap/pydap.git
+    $ pip install --upgrade git+https://github.com/pydap/pydap.git
 ```
 
 This version is not stable as it is being actively developed and improved upon by contributors and maintainers of the `pydap` package.
 
-If you are interested in installing `pydap` in `developer mode`, to potentially contribute to the package, got o [Contributing to the code](contribute/contr_cod.md).
+If you are interested in installing `pydap` in `developer mode` to potentially contribute to the package, go to [Contributing to the code](contribute/contr_cod.md).

--- a/docs/en/intro.md
+++ b/docs/en/intro.md
@@ -3,15 +3,15 @@
 # <font size="7"><span style='color:#0066cc'> **Welcome to pydap**<font size="3">
 
 
-`pydap` is a Python implementation of the **Data Access Protocol** (**DAP**), also known as [OPeNDAP](http://www.opendap.org/). You can use `pydap` as a client to access thousands of scientific datasets available via OPeNDAP servers in a secure, transparent, and efficient way through the internet, or you can set up `pydap` as a server to make your data available through the internet via an URL.
+`pydap` is a Python implementation of the **Data Access Protocol** (**DAP**), also known as [OPeNDAP](http://www.opendap.org/). You can use `pydap` as a client to access thousands of scientific datasets available via OPeNDAP servers in a secure, transparent, and efficient way through the internet, or you can set up `pydap` as a server to make your data available through the internet via a URL.
 
 ## <font size="5.5"><span style='color:#ff6666'>**Why OPeNDAP?**<font size="3">
 
 Equitable open data access remains essential for advancing effective Open Science frameworks, enabling data-driven discoveries, and empowering inclusive science education and citizen science practices. At the institution level, `OPeNDAP` servers represent a free, open-source solution to enable data access as an alternative to the comercial cloud, as a cost-effective solution when data is stored on the cloud and data file formats that are not cloud-native, or when the collections are too large to re-format.
 
-For researchers, educators, and citizen cientists, `OPeNDAP` allows to share scientific data freely under well-known standard protocols over the web, making data publishable, citeable, and findable. Importantly, data users can access and subset data in a data-proximate way, downloading only the subregion of interest.
+For researchers, educators, and citizen scientists, `OPeNDAP` allows to share scientific data freely under well-known standard protocols over the web, making data publishable, citable, and findable. Importantly, data users can access and subset data in a data-proximate way, downloading only the subregion of interest.
 
-Beginner OPeNDAP users, may rapidly find themselves spending the time to better understand OPeNDAP to enable efficient data access. Some of the OPeNDAP elements that require developing a varying degree of skill by the user to better exploit OPeNDAP are
+Beginner OPeNDAP users may rapidly find themselves spending the time to better understand OPeNDAP to enable efficient data access. Some of the OPeNDAP elements that require developing a varying degree of skill by the user to better exploit OPeNDAP are:
 
 1. Constraint Expressions.
 2. Escaping URL characters for safe internet use.
@@ -30,7 +30,7 @@ Beginner OPeNDAP users, may rapidly find themselves spending the time to better 
 
 1. Builds Contraint Expression for the user. This is done by slicing an array (See [Figure 1](WhyPydap)).
 2. Escapes URL parameters to safely transmit data use over the internet.
-3. Can fetch binary data from DAP2 (`.dods`) and DAP4 (`.dap`) data servers, turning it to a numerical numpy array.
+3. Can fetch binary data from DAP2 (`.dods`) and DAP4 (`.dap`) data servers, turning it to a numerical `numpy` array.
 4. Covers the DAP2 and (*Most*) of the DAP4 data model.
 5. Is being developed and maintained by members of the OPeNDAP team, with open communication with Unidata.
 
@@ -41,9 +41,9 @@ Knowledge of how to construct URLs with Constraint Expressions remains important
 
 ## <font size="5.5"><span style='color:#ff6666'>**What Pydap is not**<font size="3">
 
-`Pydap` is very lightweight, which is great! However, as a result it offers little parallelism, compute or plotting. Most of that is enable by external python libraries. However, `Pydap` remains a `backend engine for xarray`, which fosters a growing community of users and developers, and `xarray` can add parallelism via `Dask` / `Coiled` and plotting via its oww use of matplotlib.
+`Pydap` is very lightweight, which is great! However, as a result it offers little parallelism, compute or plotting. Most of that is enabled by external Python libraries. However, `Pydap` remains a `backend engine for xarray`, which fosters a growing community of users and developers, and `xarray` can add parallelism via `Dask` / `Coiled` and plotting via its own use of `matplotlib`.
 
-That said, we recognize that `pydap` native approaches may provide boost in performance, before using the resulting pydap dataset to create xarray dataaset. And so `Pydap` remains under development! See the [What's New](NEWS) section If you would like to contribute, head to the [issue tracker](https://github.com/pydap/pydap/issues). We welcome contributions! You can pick an existing issue, open a new one. You can contribute to improve our code base, or you can also help improve our documentation with a tutorial example!
+That said, we recognize that `pydap` native approaches may provide boost in performance, before using the resulting pydap dataset to create `xarray` dataset. And so `pydap` remains under development! See the [What's New](NEWS) section If you would like to contribute, head to the [issue tracker](https://github.com/pydap/pydap/issues). We welcome contributions! You can pick an existing issue, open a new one. You can contribute to improve our code base, or you can also help improve our documentation with a tutorial example!
 
 
 Dive into the documentation to learn best practices for accessing remote data on OPeNDAP servers.

--- a/docs/en/responses.rst
+++ b/docs/en/responses.rst
@@ -3,9 +3,9 @@ Responses
 .. warning::
     The information regarding this page may be outdated. If you notice the following examples are not running correctly, consider reporting in the Github issue tracker https://github.com/pydap/pydap/issues.
 
-Like `handlers <handlers.html>`_, responses are special Python modules that convert between the pydap data model and an external representation. For instance, to access a given dataset an Opendap client request two diferent representations of the dataset: a *Dataset Attribute Structure* (DAS) response, describing the attributes of the dataset, and a *Dataset Descriptor Structure* (DDS), describing its structure (shape, type, hierarchy). These responses are returned by appending the extension ``.das`` and ``.dds`` to the dataset URL, respectively.
+Like `handlers <handlers.html>`_, responses are special Python modules that convert between the pydap data model and an external representation. For instance, to access a given dataset an OPeNDAP client request two different representations of the dataset: a *Dataset Attribute Structure* (DAS) response, describing the attributes of the dataset, and a *Dataset Descriptor Structure* (DDS), describing its structure (shape, type, hierarchy). These responses are returned by appending the extension ``.das`` and ``.dds`` to the dataset URL, respectively.
 
-Other common responses include the ASCII (``.asc`` or ``.ascii``) response, which returns an ASCII representation of the data; and an HTML form for data request using the browser, at the ``.html`` extension. And perhaps the most important response is the ``.dods`` response, which actually carries the data in binary format, and is used when clients request data from the server. All these responses are standard and come with pydap.
+Other common responses include the ASCII (``.asc`` or ``.ascii``) response, which returns an ASCII representation of the data; and an HTML form for data request using the browser, at the ``.html`` extension. And perhaps the most important response is the ``.dods`` response, which actually carries the data in binary format, and is used when clients request data from the server. All these responses are standard and come with `pydap`.
 
 There are other extension responses available for pydap; these are not defined in the DAP specification, but improve the user experience by allowing data to be accessed in different formats.
 
@@ -15,13 +15,13 @@ Installing additional responses
 Web Map Service
 ~~~~~~~~~~~~~~~
 
-This response enables pydap to act like a `Web Map Service <http://en.wikipedia.org/wiki/Web_Map_Service>`_ 1.1.1 server, returning images (maps) of the available data. These maps can be visualized in any WMS client like Openlayers or Google Earth.
+This response enables pydap to act like a `Web Map Service <http://en.wikipedia.org/wiki/Web_Map_Service>`_ 1.1.1 server, returning images (maps) of the available data. These maps can be visualized in any WMS client like `OpenLayers` or `Google Earth`.
 
 You can install the WMS response using `pip <http://pypi.python.org/pypi/pip>`_:
 
 .. code-block:: bash
 
-    pip install "pydap[responses.wms]"
+    $ pip install "pydap[responses.wms]"
 
 This will take care of the necessary dependencies, which include `Matplotlib <https://matplotlib.org/>`_ and pydap itself. Once the response is installed you can introspect the available layers at the URL::
 
@@ -50,13 +50,13 @@ This response converts a pydap dataset to a `KML <http://code.google.com/apis/km
 
 .. code-block:: bash
 
-    pip install "pydap[responses.kml]"
+    $ pip install "pydap[responses.kml]"
 
 And open a URL by appending the ``.kml`` extension to the dataset, say::
 
     http://server.example.com/dataset.kml
 
-For now, the KML response will only return datasets that have a valid WMS representation. These datasets can be overlayed as layers on top of Google Earth, and are presented with a nice colorbar.
+For now, the KML response will only return datasets that have a valid WMS representation. These datasets can be overlaid as layers on top of Google Earth, and are presented with a nice colorbar.
 
 NetCDF
 ~~~~~~
@@ -65,7 +65,7 @@ This response allows data to be downloaded as a NetCDF file; it works better wit
 
 .. code-block:: bash
 
-    pip install "pydap[responses.netcdf]"
+    $ pip install "pydap[responses.netcdf]"
 
 And try to append the extension ``.nc`` to a request. The data will be converted on-the-fly to a NetCDF file.
 
@@ -76,7 +76,7 @@ The Matlab response returns data in a Matlab v5 file. It is returned when the fi
 
 .. code-block:: bash
 
-    pip install "pydap[responses.matlab]"
+    $ pip install "pydap[responses.matlab]"
 
 Excel spreadsheet
 ~~~~~~~~~~~~~~~~~
@@ -85,4 +85,4 @@ This response returns sequential data as an Excel spreadsheet when ``.xls`` is a
 
 .. code-block:: bash
 
-    pip install "pydap[responses.xls]"
+    $ pip install "pydap[responses.xls]"

--- a/docs/en/server.rst
+++ b/docs/en/server.rst
@@ -1,13 +1,13 @@
 Running a server
 ================
 .. warning::
-    The information regarding this page may be outdated. If you notice the following examples are not running correctly, consider reporting in the Github issue tracker https://github.com/pydap/pydap/issues. If you have an example in which you configured pydap as a server, consider adding to this documentation. We always want to hear how PyDAP is being used.
+    The information regarding this page may be outdated. If you notice the following examples are not running correctly, consider reporting in the GitHub issue tracker https://github.com/pydap/pydap/issues. If you have an example in which you configured `pydap` as a server, consider adding to this documentation. We always want to hear how PyDAP is being used.
 
-pydap comes with a lightweight and scalable OPeNDAP server, implemented as a `WSGI <http://wsgi.org/>`_ application. Being a WSGI `application <http://wsgi.org/wsgi/Applications>`_, pydap can run on a variety of `servers <http://wsgi.org/wsgi/Servers>`_, and frameworks including Apache, `Nginx <https://www.nginx.com/>`_, IIS, `uWSGI <https://uwsgi-docs.readthedocs.io/en/latest/>`_, `Flask <http://flask.pocoo.org/>`_ or as a standalone Python process. It can also be seamless combined with different `middleware <http://wsgi.org/wsgi/Middleware_and_Utilities>`_ for authentication/authorization, GZip compression, and much more.
+`pydap` comes with a lightweight and scalable OPeNDAP server, implemented as a `WSGI <http://wsgi.org/>`_ application. Being a WSGI `application <http://wsgi.org/wsgi/Applications>`_, pydap can run on a variety of `servers <http://wsgi.org/wsgi/Servers>`_, and frameworks including Apache, `Nginx <https://www.nginx.com/>`_, IIS, `uWSGI <https://uwsgi-docs.readthedocs.io/en/latest/>`_, `Flask <http://flask.pocoo.org/>`_ or as a standalone Python process. It can also be seamless combined with different `middleware <http://wsgi.org/wsgi/Middleware_and_Utilities>`_ for authentication/authorization, GZip compression, and much more.
 
 There is no one right way to run pydap server; your application requirements and software stack will inform your deployment decisions. In this chapter we provide a few examples to try and get you on the right track.
 
-In order to distribute your data first you need to install a proper `handler <handlers.html>`_, that will convert the data format to the pydap data model.
+In order to distribute your data first you need to install a proper `handler <handlers.html>`_, that will convert the data format to the `pydap` data model.
 
 Running standalone
 ------------------
@@ -16,19 +16,19 @@ If you just want to quickly test the pydap server, you can run it as a standalon
 
 .. code-block:: bash
 
-    pip install "pydap[server]"
+    $ pip install "pydap[server]"
 
 and then just run the ``pydap`` script that pip installs into your bin directory:
 
 .. code-block:: bash
 
-    pydap --data /path/to/my/data/files --port 8080
+    $ pydap --data /path/to/my/data/files --port 8080
 
 To change the default directory listing, the help page and the HTML form, you can point a switch to your template directory
 
 .. code-block:: bash
 
-    pydap --data /path/to/my/data/files --templates /path/to/my/templates.
+    $ pydap --data /path/to/my/data/files --templates /path/to/my/templates.
 
 The HTML form template is fairly complex, since it contain some application logic and some Javascript code, so be careful to not break anything.
 
@@ -43,7 +43,6 @@ pydap follows the `WSGI specification <https://www.fullstackpython.com/wsgi-serv
 
     from pydap.wsgi.app import DapServer
     application = DapServer('/path/to/my/data/files')
-
 
 Flask
 -----
@@ -67,16 +66,16 @@ For a robust deployment you can run pydap with Apache, using `mod_wsgi <http://m
 
 .. code-block:: bash
 
-    mkdir /var/www/pydap
-    python3 -m venv /var/www/pydap/env
+    $ mkdir /var/www/pydap
+    $ python3 -m venv /var/www/pydap/env
 
-If you want the sandbox to use your system installed packages (like Numpy, e.g.) you can use the ``--system-site-packages`` flag:
+If you want the sandbox to use your system installed packages (like `numpy`, e.g.) you can use the ``--system-site-packages`` flag:
 
 .. code-block:: bash
 
     $ python3 -m venv --system-site-packages /var/www/pydap/env
 
-Now let's activate the sandbox and install pydap -- this way the module and its dependencies can be isolated from the system libraries:
+Now let's activate the sandbox and install `pydap` -- this way the module and its dependencies can be isolated from the system libraries:
 
 .. code-block:: bash
 
@@ -139,7 +138,6 @@ This is the file I use for the `test.pydap.org <http://test.pydap.org/>`_ virtua
 
 You can find more information on the `mod_wsgi configuration guide <http://code.google.com/p/modwsgi/wiki/QuickConfigurationGuide>`_. Just remember that pydap is a WSGI application like any other else, so any information on WSGI applications applies to it as well.
 
-
 uWSGI
 -----
 
@@ -177,7 +175,6 @@ In order to make it run automatically during boot on Linux you can type:
 .. code-block:: bash
 
     $ sudo initctl reload-configuration
-
 
 Docker
 ------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,11 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Operating System :: MacOS",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: POSIX",
-  "Operating System :: POSIX :: Linux",
+  "Topic :: Internet :: WWW/HTTP :: WSGI",
   "Topic :: Scientific/Engineering",
   "License :: OSI Approved :: MIT License"
 ]


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

Hi there,

I use `pydap` on Anaconda, and I noticed that Python3.13 has recently received support here. I just wanted to be certain that the metadata reflects that change.

There also were a handful of small formatting, consistency, and spelling issues that I figured could be fixed at the same time.

Cheers,