### PR TITLE
Remove slashes from dimension names when creating dds responses (pydap server)

### DIFF
--- a/src/pydap/responses/dds.py
+++ b/src/pydap/responses/dds.py
@@ -93,7 +93,8 @@ def _basetype(var, level=0, sequence=0):
     shape = var.shape[sequence:]
 
     if var.dims:
-        shape = "".join(map("[{0[0]} = {0[1]}]".format, zip(var.dims, shape)))
+        dims = [dim.split("/")[-1] for dim in var.dims]
+        shape = "".join(map("[{0[0]} = {0[1]}]".format, zip(dims, shape)))
     elif len(shape) == 1:
         shape = "[{0} = {1}]".format(var.name, shape[0])
     else:


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes #496 

This does not show up during testing, because it represents the case when reading data from an nc- file (as opposed to pydap dataset created for testing purposes)

Now the dds looks like:

```python
Dataset {
    Float64 lon_bnds[lon = 180][bnds = 2];
    Float64 lat_bnds[lat = 170][bnds = 2];
    Float64 time_bnds[time = 24][bnds = 2];
    Float32 tos[time = 24][lat = 170][lon = 180];
    Float64 lon[lon = 180];
    Float64 lat[lat = 170];
    Float64 time[time = 24];
} tos_O1_2001-2002%2Enc%2Enc4;

```

and accessing using pydap now looks like:

```python

open_url("http://127.0.0.1:8001/tos_O1_2001-2002.nc.nc4").tree()
.tos_O1_2001-2002.nc.nc4
├──lon_bnds
├──lat_bnds
├──time_bnds
├──tos
├──lon
├──lat
└──time
```

