### PR TITLE
Improves support for concat_dims with size larger than 1

### DIFF
--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -263,13 +263,10 @@ def consolidate_metadata(
             + "]"
             for i, url in enumerate(URLs)
         ]
-        if results[0].dimensions[concat_dim]>1:
+        if results[0].dimensions[concat_dim] > 1:
             print("Creating 2 more urls. Size: ", results[0].dimensions[concat_dim])
         concat_dim_urls += [
-            url.split("?")[0]
-            + ".dap?dap4.ce="
-            + concat_dim
-            + "[0:1:0]"
+            url.split("?")[0] + ".dap?dap4.ce=" + concat_dim + "[0:1:0]"
             for i, url in enumerate(URLs)
         ]
         concat_dim_urls += [

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -156,9 +156,7 @@ def open_url(
     return dataset
 
 
-def consolidate_metadata(
-    urls, session, concat_dim=None, safe_mode=False, verbose=False
-):
+def consolidate_metadata(urls, session, concat_dim=None, safe_mode=True, verbose=False):
     """Consolidates the metadata of a collection of OPeNDAP DAP4 URLs belonging to
     data cube, i.e. urls share identical variables and dimensions. This is done
     by caching the DMR response of each URL, and the DAP response of all dimensions
@@ -179,14 +177,17 @@ def consolidate_metadata(
         When `concat_dim` is provided, no cache key is created for that
         dimension, and the dap response associated with that dimension
         is then downloaded for each URL.
-    safe_mode : bool, optional (default=False)
-        If `True`, the DMR response is downloaded for each URL, creating a
-        empty pydap dataset. dimensions are checked for datacube consistency.
-        When `False`, only the first URL DMR response is
+    safe_mode : bool, optional (default=True)
+        If `True`, all DMR responses are downloaded for each URL, creating a
+        empty pydap dataset. dimensions names and sizes are checked for
+        datacube consistency. When `False`, only the first URL DMR response is
         downloaded, and the rest of the DMRs are assigned the same
         cache key as the first URL, to avoid downloading the DMR
-        response for each URL. This is much faster, but does not check
+        response for each URL. This is faster, but does not check
         for consistency across the URLs.
+
+        `NOTE`: If `concat_dim` is provided, and the length of the dimensions
+        is greater than one, `safe_mode` is automatically set to `True` always.
     verbose: bool, optional (default=False)
         For debugging purposes. If `True`, prints various URLs, normalized
         cache-keys, and other information.

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -168,8 +168,6 @@ def consolidate_metadata(urls, session, concat_dim=None, safe_mode=True, verbose
         The URLs of the datasets that define a datacube. Each URL must begin
         with the same base URL, and begin with `dap4://`.
     session : requests-cache.CachedSession
-        A requests-cache session object. Currently, only the sqlite and memory
-        backend are fully tested. The filesystem backend is not yet supported.
     concat_dim : str, optional (default=None)
         A dimensions name (string) to concatenate across the datasets to form
         a datacube. If `None`, each dimension across the datacube
@@ -185,9 +183,8 @@ def consolidate_metadata(urls, session, concat_dim=None, safe_mode=True, verbose
         cache key as the first URL, to avoid downloading the DMR
         response for each URL. This is faster, but does not check
         for consistency across the URLs.
-
-        `NOTE`: If `concat_dim` is provided, and the length of the dimensions
-        is greater than one, `safe_mode` is automatically set to `True` always.
+        `NOTE`: If `concat_dim` is defined, and its dimension has a lenght
+        greater than one, `safe_mode` is automatically set to `True` always.
     verbose: bool, optional (default=False)
         For debugging purposes. If `True`, prints various URLs, normalized
         cache-keys, and other information.
@@ -233,7 +230,7 @@ def consolidate_metadata(urls, session, concat_dim=None, safe_mode=True, verbose
                 UserWarning,
                 stacklevel=3,
             )
-        safe_mode = True
+            safe_mode = True
     if safe_mode:
         with session as Session:  # Authenticate once
             with ThreadPoolExecutor(max_workers=ncores) as executor:
@@ -243,8 +240,8 @@ def consolidate_metadata(urls, session, concat_dim=None, safe_mode=True, verbose
         _dim_check = results[0].dimensions
         if not all(d == _dim_check for d in [ds.dimensions for ds in results]):
             warnings.warn(
-                "The dimensions of the datasets are not identical across all urls. "
-                "Please check the URLs and try again."
+                "The dimensions of the datasets are not identical across all remote "
+                "dataset. Please check the URLs and try again."
             )
             return None
     else:

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -313,7 +313,11 @@ def consolidate_metadata(
     )
     if dims:
         print("datacube has dimensions", dim_ces, f", and concat dim: `{concat_dim}`")
-        dim_ces.update(add_dims)
+        if not safe_mode:
+            # if `safe_mode` is False, only download 2 dap responses, one for the
+            # first element of the concat_dim, and one for the last element of
+            # a single URLs. Create cache keys for rest 2*N urls.
+            dim_ces.update(add_dims)
         patch_session_for_shared_dap_cache(
             session, shared_vars=dim_ces, known_url_list=URLs, verbose=verbose
         )

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -258,30 +258,41 @@ def consolidate_metadata(
             url.split("?")[0]
             + ".dap?dap4.ce="
             + concat_dim
-            + "[0:1:"
+            + "%5B0:1:"
             + str(results[0].dimensions[concat_dim] - 1)
-            + "]"
+            + "%5D"
             for i, url in enumerate(URLs)
         ]
         if results[0].dimensions[concat_dim] > 1:
-            print("Creating 2 more urls. Size: ", results[0].dimensions[concat_dim])
-        concat_dim_urls += [
-            url.split("?")[0] + ".dap?dap4.ce=" + concat_dim + "[0:1:0]"
-            for i, url in enumerate(URLs)
-        ]
-        concat_dim_urls += [
-            url.split("?")[0]
-            + ".dap?dap4.ce="
-            + concat_dim
-            + "["
-            + str(results[0].dimensions[concat_dim] - 1)
-            + ":1:"
-            + str(results[0].dimensions[concat_dim] - 1)
-            + "]"
-            for i, url in enumerate(URLs)
-        ]
+            concat_dim_urls += [
+                url.split("?")[0] + ".dap?dap4.ce=" + concat_dim + "[0:1:0]"
+                for i, url in enumerate(URLs)
+            ]
+            concat_dim_urls += [
+                url.split("?")[0]
+                + ".dap?dap4.ce="
+                + concat_dim
+                + "["
+                + str(results[0].dimensions[concat_dim] - 1)
+                + ":1:"
+                + str(results[0].dimensions[concat_dim] - 1)
+                + "]"
+                for i, url in enumerate(URLs)
+            ]
+            add_dims = set(
+                [
+                    concat_dim + "[0:1:0]",
+                    concat_dim
+                    + "["
+                    + str(results[0].dimensions[concat_dim] - 1)
+                    + ":1:"
+                    + str(results[0].dimensions[concat_dim] - 1)
+                    + "]",
+                ]
+            )
     else:
         concat_dim_urls = []
+        add_dims = set()
 
     new_urls = [
         base_url
@@ -293,6 +304,7 @@ def consolidate_metadata(
         for dim in list(dims)
     ]
     new_urls.extend(concat_dim_urls)
+    # print("new urls", new_urls)
     dim_ces = set(
         [
             dim + "[0:1:" + str(results[0].dimensions[dim] - 1) + "]"
@@ -301,6 +313,7 @@ def consolidate_metadata(
     )
     if dims:
         print("datacube has dimensions", dim_ces, f", and concat dim: `{concat_dim}`")
+        dim_ces.update(add_dims)
         patch_session_for_shared_dap_cache(
             session, shared_vars=dim_ces, known_url_list=URLs, verbose=verbose
         )
@@ -599,7 +612,7 @@ def try_generate_custom_key(request, config, verbose=False):
 
     if verbose:
         print("================ request url ========================")
-        print("request.url")
+        print(request.url)
 
     shared_ext = ext
 

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -263,6 +263,26 @@ def consolidate_metadata(
             + "]"
             for i, url in enumerate(URLs)
         ]
+        if results[0].dimensions[concat_dim]>1:
+            print("Creating 2 more urls. Size: ", results[0].dimensions[concat_dim])
+        concat_dim_urls += [
+            url.split("?")[0]
+            + ".dap?dap4.ce="
+            + concat_dim
+            + "[0:1:0]"
+            for i, url in enumerate(URLs)
+        ]
+        concat_dim_urls += [
+            url.split("?")[0]
+            + ".dap?dap4.ce="
+            + concat_dim
+            + "["
+            + str(results[0].dimensions[concat_dim] - 1)
+            + ":1:"
+            + str(results[0].dimensions[concat_dim] - 1)
+            + "]"
+            for i, url in enumerate(URLs)
+        ]
     else:
         concat_dim_urls = []
 

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -239,9 +239,8 @@ def consolidate_metadata(
                 results = list(
                     executor.map(lambda url: open_dmr(url, session=Session), dmr_urls)
                 )
-        if [ds.dimensions for ds in results].count(results[0].dimensions) != len(
-            results
-        ):
+        _dim_check = results[0].dimensions
+        if not all(d == _dim_check for d in [ds.dimensions for ds in results]):
             warnings.warn(
                 "The dimensions of the datasets are not identical across all urls. "
                 "Please check the URLs and try again."

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -547,11 +547,12 @@ def test_consolidate_metadata_concat_dim(urls, concat_dim):
     downloaded and cached. So there should be N dap responses for N urls associated with
     a dimension.
     """
+    safe_mode = True
     cached_session = create_session(use_cache=True, cache_kwargs={"backend": "memory"})
     cached_session.cache.clear()
     # download all dmr for testing - not most performant
     consolidate_metadata(
-        urls, session=cached_session, safe_mode=True, concat_dim=concat_dim
+        urls, session=cached_session, safe_mode=safe_mode, concat_dim=concat_dim
     )
     pyds = open_dmr(urls[0].replace("dap4", "http") + ".dmr")
     dims = list(pyds.dimensions)
@@ -559,10 +560,10 @@ def test_consolidate_metadata_concat_dim(urls, concat_dim):
         assert len(cached_session.cache.urls()) == len(urls) + len(dims)
     else:
         N_concat_dims = len(urls)
-        if pyds.dimensions[concat_dim] > 1:
-            N_concat_dims += (
-                2  # 2 extra dap responses downloaded (1st and last element)
-            )
+        if pyds.dimensions[concat_dim] > 1 and safe_mode:
+            # there are 2 extra dap responses per url
+            # one for 1st element, and another for last element
+            N_concat_dims += 2 * N_concat_dims  #
         N_non_concat_dims = len(dims) - 1  # only one dimension is concatenated
         assert (
             len(cached_session.cache.urls())

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -549,16 +549,20 @@ def test_consolidate_metadata_concat_dim(urls, concat_dim):
     """
     cached_session = create_session(use_cache=True, cache_kwargs={"backend": "memory"})
     cached_session.cache.clear()
-    pyds = open_dmr(urls[0].replace("dap4", "http") + ".dmr")
-    dims = list(pyds.dimensions)
-    # download all dmr for testing - not recommmended in production.
+    # download all dmr for testing - not most performant
     consolidate_metadata(
         urls, session=cached_session, safe_mode=True, concat_dim=concat_dim
     )
+    pyds = open_dmr(urls[0].replace("dap4", "http") + ".dmr")
+    dims = list(pyds.dimensions)
     if not concat_dim:
         assert len(cached_session.cache.urls()) == len(urls) + len(dims)
     else:
         N_concat_dims = len(urls)
+        if pyds.dimensions[concat_dim] > 1:
+            N_concat_dims += (
+                2  # 2 extra dap responses downloaded (1st and last element)
+            )
         N_non_concat_dims = len(dims) - 1  # only one dimension is concatenated
         assert (
             len(cached_session.cache.urls())


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes #504 
- [x] Tests are added to demonstrate the new or fixed behavior, and all tests pass
on a local environment.

###
This PR greatly reduces the number of dap responses pydap needs to download in the case multiple (N) urls that aggregate along a dimension `concat_dim` (in most cases, `time`). 
The specific scenario is when the length of the `concat_dim` > 1. In that scenario, `3` dap responses per `concat_dim` per URL are downloaded (Xarray feature when aggregating multiple urls).

This PR makes it so that only `3` dap responses (total!) are downloaded for the `concat_dim` array (e.g. `time`). This is accomplished by forcing the download of all DMR (metadata). This is possible because of the internals of Xarray.

This code assumes that all remote data have the same dimension and identical dim shapes.

### example
Consider a year of MERRA-2 data.
```python
    len(new_urls)
>>> 366
    new_urls[:2] # check the first 2 urls
>>> ['dap4://opendap.earthdata.nasa.gov/collections/C1276812863-GES_DISC/granules/M2T1NXSLV.5.12.4%3AMERRA2_400.tavg1_2d_slv_Nx.20200101.nc4?dap4.ce=/T2M;/U2M;/V2M;/PS;/lon;/time;/lat',
 'dap4://opendap.earthdata.nasa.gov/collections/C1276812863-GES_DISC/granules/M2T1NXSLV.5.12.4%3AMERRA2_400.tavg1_2d_slv_Nx.20200102.nc4?dap4.ce=/T2M;/U2M;/V2M;/PS;/lon;/time;/lat']

## new feature for such collections.
    %% time
    consolidate_metadata(new_urls, concat_dim='time', safe_mode=True, session=cache_session)
>>> datacube has dimensions {'time[0:1:23]', 'lat[0:1:360]', 'lon[0:1:575]'} , and concat dim: `time`
CPU times: user 4.93 s, sys: 1.22 s, total: 6.15 s
Wall time: 1min 2s

### generate xarray dataset
    %%time # jupyter notebook cell magic
    ds = xr.open_mfdataset(new_urls, session=cache_session, engine='pydap', parallel=True, combine='nested', concat_dim='time')
>>> CPU times: user 2.9 s, sys: 498 ms, total: 3.39 s
Wall time: 3.02 s
```
This `O(1) secs` performance is all it will take from now on, when reusing the cache_session.
 
![Screenshot 2025-05-30 at 8 36 10 AM](https://github.com/user-attachments/assets/5a2f4229-4c74-415b-aa12-43317a3ae4c4)



## Old behavior vs New Behavior

With this new behavior the amount of URLs that are downloaded are:
```python
### new feature
    len(cache_session.cache.urls())
>>> 371
```

On the other hand, clearing the `cache_session` and skipping the `consolidate_metadata` step, the timings are:
```python
    %%time
    ds = xr.open_mfdataset(new_urls, session=cache_session, engine='pydap', parallel=True, combine='nested', concat_dim='time')
>>> CPU times: user 21 s, sys: 8.19 s, total: 29.2 s
Wall time: 30min 13s
```
and the total of downloaded URLs are:

```python
    len(cache_session.cache.urls())
>>> 2196 # !!!
```


Overall pydap can now be  10 times faster, because it downloads an order or magnitude fewer downloads



