### PR TITLE
Named dim consolidate

### DIFF
--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -882,7 +882,7 @@ def get_cmr_urls(
 
     if time_range and isinstance(time_range, list):
         if len(time_range) != 2:
-            warnings.warns("time_range must be a list of two elements.")
+            warnings.warn("time_range must be a list of two elements.")
             return None
         if all(isinstance(x, dt.datetime) for x in time_range):
             dt_format = "%Y-%m-%dT%H:%M:%SZ"
@@ -897,14 +897,14 @@ def get_cmr_urls(
                 dt.datetime.strptime(time_range[1], "%Y-%m-%dT%H:%M:%SZ")
                 temporal_str = time_range[0] + "," + time_range[1]
             except ValueError:
-                warnings.warns(
+                warnings.warn(
                     "time_range must be a list of two elements each a string in the"
                     " format YYYY-MM-DDTHH:MM:SSZ."
                 )
                 return None
         params["temporal"] = temporal_str
     elif time_range and not isinstance(time_range, list):
-        warnings.warns(
+        warnings.warn(
             "time_range must be a list of two elements or a string in the format"
             " YYYY-MM-DDTHH:MM:SSZ."
         )


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes #506. It adds another parameter that enables to check for maps in the case of named dimensions. 


This addresses a performance issue when accessing via `xarray+pydap` ocean velocity from OSCAR. For that dataset `latitude` and `longitude` are named, whereas `lat` and `lon` respectively have the values (meaning one can request dap responses). In this scenario, xarray requests `lat` and `lon` instead of `latitude` and `longitude`. The requests grow as 2*N, N being the number of URLS. 


This PR then enables caching for `lat`, `lon` or any other similar Map, when the `set_maps` is set to `True` (False by default). 


### Example
```python
urls = ['dap4://opendap.earthdata.nasa.gov/collections/C2098858642-POCLOUD/granules/oscar_currents_final_20190816',
 'dap4://opendap.earthdata.nasa.gov/collections/C2098858642-POCLOUD/granules/oscar_currents_final_20190823', 
...
]
%%time
consolidate_metadata(urls, concat_dim='time', safe_mode=False, set_maps=True, session=my_session)
```

For 100 urls , `consolidate_metadata` takes ~40 secs. With that, the following takes 1 second:

<img width="1055" alt="Screenshot 2025-06-02 at 12 49 23 AM" src="https://github.com/user-attachments/assets/700fb8ed-a1ae-47e3-a161-fbbad94841db" />


#### Notes
1. That the coordinates (e.g. maps) and dimensions do not match spatially. 
2. It is possible to bypass `consolidate_metadata` and create the xarray dataset directly. However, this is ~ 10x slower.
3. There will be some need for more testing, but it works for my purpose




