### PR TITLE
disable caching except when using Consolidate_metadata

### DIFF
--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -166,9 +166,23 @@ def create_request(
         if "Authorization" in session.headers:
             get_kwargs["auth"] = None
         try:
-            req = session.get(
-                url, timeout=timeout, verify=verify, allow_redirects=True, **get_kwargs
-            )
+            if not isinstance(session, CachedSession):
+                req = session.get(
+                    url,
+                    timeout=timeout,
+                    verify=verify,
+                    allow_redirects=True,
+                    **get_kwargs,
+                )
+            else:
+                with session.cache_disabled():
+                    req = session.get(
+                        url,
+                        timeout=timeout,
+                        verify=verify,
+                        allow_redirects=True,
+                        **get_kwargs,
+                    )
         except (ConnectionError, SSLError) as e:
             # some opendap servers do not support https, but they do support http.
             parsed = urlparse(url)


### PR DESCRIPTION
… `consolidate_metadata`

<!-- Thank you very much for your hard work and contribution! -->
This PR disables caching even when reusing a requests-cache session. The purpose of this is to avoid caching large dap responses, for example that result from aggregating large datasets across many OPeNDAP urls. Caching is then only safely applied when running Consolidate_metadata. This caches the dmr and dap responses of all dimensions across all URLs in a very effective way.

The following Pull Request:

- [x] This addresses a potential problem when caching dap responses of variables onther than dimensions and maps. See #512 . 
- [ ] Tests are added to demonstrate the new or fixed behavior, and all tests pass
on a local environment.
