### PR TITLE
Enables batching multiple variable requests into a single dap url

### DIFF
--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -61,14 +61,19 @@ from requests.exceptions import (
 from requests.utils import urlparse, urlunparse
 from requests_cache import CachedSession
 
-from .handlers.dap import UNPACKDAP4DATA, DAPHandler, StreamReader, unpack_dap2_data
-from .lib import DEFAULT_TIMEOUT as DEFAULT_TIMEOUT
-from .lib import encode
-from .model import DapType
-from .net import GET, create_session
-from .parsers.das import add_attributes, parse_das
-from .parsers.dds import dds_to_dataset
-from .parsers.dmr import DMRParser, dmr_to_dataset
+from pydap.handlers.dap import (
+    UNPACKDAP4DATA,
+    DAPHandler,
+    StreamReader,
+    unpack_dap2_data,
+)
+from pydap.lib import DEFAULT_TIMEOUT as DEFAULT_TIMEOUT
+from pydap.lib import encode
+from pydap.model import DapType
+from pydap.net import GET, create_session
+from pydap.parsers.das import add_attributes, parse_das
+from pydap.parsers.dds import dds_to_dataset
+from pydap.parsers.dmr import DMRParser, dmr_to_dataset
 
 
 def open_url(

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -252,6 +252,8 @@ class DAPHandler(BaseHandler):
                 get_kwargs={**self.get_kwargs, "stream": True},
             )
 
+        self.dataset.assign_dataset_recursive(self.dataset)
+
         # apply projections to BaseType only
         # CE for sequences and structs
         # are not ready (see https://github.com/pydap/pydap/issues/314)
@@ -484,12 +486,19 @@ class BaseProxyDap4(BaseProxyDap2):
             map(repr, [self.baseurl, self.id, self.dtype, self.shape, self.slice])
         )
 
-    def __getitem__(self, index):
+    def __getitem__(self, index, build_only=False):
         # build download url
         index = combine_slices(self.slice, fix_slice(index, self.shape))
+
         scheme, netloc, path, _, query, fragment = urlparse(self.baseurl)
-        ce = "dap4.ce=" + self.id + hyperslab(index)
-        url = urlunparse((scheme, netloc, path + ".dap", "", ce, fragment)).rstrip("&")
+        self.ce = "dap4.ce=" + self.id + hyperslab(index)
+
+        if build_only:
+            # In batch mode: just store CE, don't fetch
+            return self
+        url = urlunparse((scheme, netloc, path + ".dap", "", self.ce, fragment)).rstrip(
+            "&"
+        )
         if self.checksum:
             url += "&dap4.checksum=true"
         else:
@@ -507,11 +516,11 @@ class BaseProxyDap4(BaseProxyDap2):
         )
 
         dataset = UNPACKDAP4DATA(r, self.checksum, self.user_charset).dataset
-        self.data = dataset[self.id].data
+        self._data = dataset[self.id]._data
         if self.checksum:
             self.checksum = dataset[self.id].attributes["_DAP4_Checksum_CRC32"]
 
-        return self.data
+        return self._data
 
 
 class SequenceProxy(object):
@@ -948,6 +957,7 @@ class UNPACKDAP4DATA(object):
         self.checksum = checksum
         if isinstance(r, requests.Response):
             # remote dataset
+
             self.r = r
             CHUNK_SIZE = 1048576  # 1 MB
             with tempfile.TemporaryFile() as tmp:

--- a/src/pydap/parsers/dmr.py
+++ b/src/pydap/parsers/dmr.py
@@ -268,7 +268,6 @@ def dmr_to_dataset(dmr):
                 variable["shape"] += (variables[dim]["size"],)
             else:
                 variable["shape"] += (named_dimensions[dim],)
-
     for name, variable in variables.items():
         var_name = variable["name"]
         path = None
@@ -327,6 +326,8 @@ def dmr_to_dataset(dmr):
                 dataset.createStructure(("/").join(parts), path=path)
         else:
             dataset.createVariable(**var_kwargs)
+        # assign root to each variable
+        dataset.assign_dataset_recursive(dataset)
 
     return dataset
 
@@ -391,7 +392,6 @@ class DMRParser(object):
                 Maps=Maps,
                 attributes=attributes,
             )
-
         return dataset
 
 

--- a/src/pydap/tests/test_model.py
+++ b/src/pydap/tests/test_model.py
@@ -776,7 +776,7 @@ def test_set_dataset():
 
     ds.assign_dataset_recursive(ds)
 
-    assert ds.dataset.id == "root"
-    assert ds["Group1"].dataset.id == "root"
-    assert ds["Group1/subGroup2"].dataset.id == "root"
-    assert ds["Group1/subGroup2/var"].dataset.id == "root"
+    assert ds.dataset.id == "/"
+    assert ds["Group1"].dataset.id == "/"
+    assert ds["Group1/subGroup2"].dataset.id == "/"
+    assert ds["Group1/subGroup2/var"].dataset.id == "/"


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes #521 .
- [ ] Tests are added to demonstrate the new or fixed behavior, and all tests pass
on a local environment.


### Minimal Example
```python
from pydap.client import open_url
from pydap.net import create_session

url = "http://test.opendap.org/opendap/dap4/SimpleGroup.nc4.h5"
session = create_session(use_cache=True)
session.cache.clear()

pyds = open_url(url, protocol='dap4', session=session)
pyds.tree()
.SimpleGroup.nc4.h5
├──SimpleGroup
│  ├──Y
│  ├──X
│  ├──Temperature
│  └──Salinity
├──time
├──Z
├──Pressure
└──time_bnds


```

Now the new stuff
```python
# Enable batch mode. Set the timeout for 1 second. This is any data request that together take place within 1 second will
# be processed together within a single dap url

pyds.enable_batch_mode(timeout=1)


# trigger download subset of 2 variables at once

temp = pyds['SimpleGroup/Temperature'][0,10:20,10:20].data;
salt = pyds['SimpleGroup/Salinity'][0,10:20,10:20].data;

```

check that there is a single dap url by looking at the cached url

```python
session.cache.urls()
>>> ['http://test.opendap.org/opendap/dap4/SimpleGroup.nc4.h5.dap?dap4.ce=%2FSimpleGroup%2FSalinity%5B0%3A1%3A0%5D%5B10%3A1%3A19%5D%5B10%3A1%3A19%5D%3B%2FSimpleGroup%2FTemperature%5B0%3A1%3A0%5D%5B10%3A1%3A19%5D%5B10%3A1%3A19%5D',
 'http://test.opendap.org/opendap/dap4/SimpleGroup.nc4.h5.dmr']
```

Lastly, check that the data is processed correctly:

```python
temp[:]
>>> array([[[410., 411., 412., 413., 414., 415., 416., 417., 418., 419.],
        [450., 451., 452., 453., 454., 455., 456., 457., 458., 459.],
        [490., 491., 492., 493., 494., 495., 496., 497., 498., 499.],
        [530., 531., 532., 533., 534., 535., 536., 537., 538., 539.],
        [570., 571., 572., 573., 574., 575., 576., 577., 578., 579.],
        [610., 611., 612., 613., 614., 615., 616., 617., 618., 619.],
        [650., 651., 652., 653., 654., 655., 656., 657., 658., 659.],
        [690., 691., 692., 693., 694., 695., 696., 697., 698., 699.],
        [730., 731., 732., 733., 734., 735., 736., 737., 738., 739.],
        [770., 771., 772., 773., 774., 775., 776., 777., 778., 779.]]],
      dtype=float32)
```
that is correct, and
```python
salt[:]
>>> array([[[30., 30., 30., 30., 30., 30., 30., 30., 30., 30.],
        [30., 30., 30., 30., 30., 30., 30., 30., 30., 30.],
        [30., 30., 30., 30., 30., 30., 30., 30., 30., 30.],
        [30., 30., 30., 30., 30., 30., 30., 30., 30., 30.],
        [30., 30., 30., 30., 30., 30., 30., 30., 30., 30.],
        [30., 30., 30., 30., 30., 30., 30., 30., 30., 30.],
        [30., 30., 30., 30., 30., 30., 30., 30., 30., 30.],
        [30., 30., 30., 30., 30., 30., 30., 30., 30., 30.],
        [30., 30., 30., 30., 30., 30., 30., 30., 30., 30.],
        [30., 30., 30., 30., 30., 30., 30., 30., 30., 30.]]],
      dtype=float32)
```

also correct.
