### PR TITLE
Enable unpacking responses from httpx

### DIFF
--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -49,6 +49,11 @@ from pydap.parsers.dds import dds_to_dataset
 from pydap.parsers.dmr import dmr_to_dataset
 from pydap.responses.dods import DAP2_response_dtypemap
 
+try:
+    import httpx
+except ImportError:
+    httpx = None
+
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
@@ -946,14 +951,15 @@ class UNPACKDAP4DATA(object):
     def __init__(self, r, checksum=False, user_charset="ascii"):
         self.user_charset = user_charset
         self.checksum = checksum
-        if isinstance(r, requests.Response):
+        self.r = r
+        try:
+            iterator = self.iter_body()
+            CHUNK_SIZE = 1048576
             # remote dataset
-            self.r = r
-            CHUNK_SIZE = 1048576  # 1 MB
             with tempfile.TemporaryFile() as tmp:
                 # write the response to a temporary file
                 # so that we can read it in chunks
-                for chunk in r.iter_content(chunk_size=CHUNK_SIZE):
+                for chunk in iterator(chunk_size=CHUNK_SIZE):
                     if chunk:  # filter out keep-alive chunks
                         tmp.write(chunk)
                 tmp.seek(0)
@@ -961,7 +967,7 @@ class UNPACKDAP4DATA(object):
                 self.dmr, self.endianness = self.safe_dmr_and_data()
                 dataset = dmr_to_dataset(self.dmr)
                 self.dataset = self.unpack_dap4_data(dataset)
-        elif isinstance(r, (webob_Response, BufferedReader)):
+        except TypeError:
             if isinstance(r, webob_Response):
                 self.r = r
                 if self.r.content_encoding == "gzip":
@@ -970,22 +976,36 @@ class UNPACKDAP4DATA(object):
                     )
                 else:
                     self.raw = BytesReader(r.body)
-            else:
+            elif isinstance(r, BufferedReader):
                 # r comes from reading a local file
                 self.r = webob_Response()  # make empty response
                 self.raw = BytesReader(r.read())
+            else:
+                raise TypeError(
+                    """
+                    Unrecognized file type object for unpacking dap4 binary data.
+                    Acceptable formats are `webob.response.Response` and
+                    `io.BufferedReader`
+                    """
+                )
             self.dmr, self.endianness = self.safe_dmr_and_data()
             # need to split dmr from data
             dataset = dmr_to_dataset(self.dmr)
             self.dataset = self.unpack_dap4_data(dataset)
+
+    def iter_body(self):
+        """
+        enables iterate over a response, whether the response
+        if a requests.Response, requests_cache.Response, or
+        httpx.Respose
+        """
+
+        if isinstance(self.r, requests.Response):
+            return self.r.iter_content
+        elif httpx is not None and isinstance(self.r, httpx.Response):
+            return self.r.iter_bytes
         else:
-            raise TypeError(
-                """
-                Unrecognized file type object for unpacking dap4 binary data.
-                Acceptable formats are `webob.response.Response` and
-                `io.BufferedReader`
-                """
-            )
+            raise TypeError("Unsupported response type")
 
     def safe_dmr_and_data(self):
         """


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- Enables, if installed, the use of `httpx` to download dap responses. 
 

### Why?

`httpx` is:
- Modern python http client (more than requests)
- Async / http/2 support
- Almost identical syntax to Requests

`httpx` will NOT be listed as a dependency (not even optional) but if installed and if the response is from a `httpx` client, the class `UNPACKDAP4DATA` can decode the `dap response` and return a correct `BaseType` data array




With some few download testing I have done, the first download using the `httpx` client is 1-3x faster than using `requests`. At worst, it the the same speed, but can be significantly faster.

This small change in the code will enable further benchmarking download timings on PR #525 

