### PR TITLE
Improve handling of Maps when consolidating metadata

### DIFF
--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -353,7 +353,6 @@ def consolidate_metadata(
             map_urls = [
                 base_url + ".dap?dap4.ce=" + ";".join(map_urls) + "&dap4.checksum=true"
             ]
-            session.headers["Maps"] = map_urls[0]  # only a single url
             maps_ces = set(
                 [
                     coord + "[0:1:" + str(len(pyds[coord]) - 1) + "]"
@@ -370,14 +369,6 @@ def consolidate_metadata(
         dim_ces.update(add_dims)
         if maps_ces:
             dim_ces.update(maps_ces)
-        # if dim_ces:
-        #     patch_session_for_shared_dap_cache(
-        #         session,
-        #         shared_vars=dim_ces,
-        #         concat_dim=concat_dim,
-        #         known_url_list=URLs,
-        #         verbose=verbose,
-        #     )
         with session as Session:
             _ = download_all_urls(Session, new_urls, ncores=ncores)
     return None

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -241,7 +241,7 @@ def consolidate_metadata(
     dmr_urls = [
         url + ".dmr" if "?" not in url else url.replace("?", ".dmr?") for url in URLs
     ]
-
+    session.headers["consolidated"] = "True"
     if safe_mode:
         with session as Session:  # Authenticate once
             with ThreadPoolExecutor(max_workers=ncores) as executor:
@@ -370,14 +370,14 @@ def consolidate_metadata(
         dim_ces.update(add_dims)
         if maps_ces:
             dim_ces.update(maps_ces)
-        if dim_ces:
-            patch_session_for_shared_dap_cache(
-                session,
-                shared_vars=dim_ces,
-                concat_dim=concat_dim,
-                known_url_list=URLs,
-                verbose=verbose,
-            )
+        # if dim_ces:
+        #     patch_session_for_shared_dap_cache(
+        #         session,
+        #         shared_vars=dim_ces,
+        #         concat_dim=concat_dim,
+        #         known_url_list=URLs,
+        #         verbose=verbose,
+        #     )
         with session as Session:
             _ = download_all_urls(Session, new_urls, ncores=ncores)
     return None

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -86,7 +86,6 @@ def open_url(
     checksum=False,
     user_charset="ascii",
     protocol=None,
-    consolidated=False,
     batch=False,
     use_cache=False,
     session_kwargs=None,
@@ -122,8 +121,6 @@ def open_url(
         is 'dap4'. If the URL ends with '.dods', the protocol is 'dap2'. Another
         option to specify the protocol is to use replace the url scheme (http, https)
         with 'dap2' or 'dap4'.
-    consolidated:
-        Whether `pydap.client.consolidated_metadata` was ran before or not.
     batch: bool (Default: False)
         Flag that indicates download multiple arrays with single dap response. Only
         compatible with DAP4 protocol.
@@ -274,9 +271,6 @@ def consolidate_metadata(
     dims = set(list(results[0].dimensions))
     add_dims = set()
     if concat_dim is not None and set([concat_dim]).issubset(dims):
-        if not concat_dim.startswith("/"):
-            named_concat_dim = "/" + concat_dim
-            session.headers["concat_dim"] = named_concat_dim
         dims.remove(concat_dim)
         concat_dim_urls = [
             url.split("?")[0]
@@ -310,10 +304,8 @@ def consolidate_metadata(
             + "%3B".join(constrains_dims)
             + "&dap4.checksum=true"
         ]
-        # session.headers["consolidated"] = new_urls[0]
     else:
         new_urls = []
-        # session.headers["consolidated"] = "null"
     new_urls.extend(concat_dim_urls)
     dim_ces = set(
         [
@@ -369,8 +361,6 @@ def consolidate_metadata(
                 ]
             )
             new_urls.extend(map_urls)
-        # else:
-        # session.headers["Maps"] = "null"
     if dims or concat_dim:
         print(
             "datacube has dimensions",

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -512,7 +512,6 @@ def resolve_batch_for_all_variables(parent, Variables, key=None):
         _slice = slice(None) if not key else key
         for name in Variables:
             var = parent[name]
-            print(name)
             if var.name not in parent.dimensions and not var._is_data_loaded():
                 var._pending_batch_slice = _slice
                 var._batch_promise = dataset._current_batch_promise

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -507,10 +507,10 @@ def fetch_consolidated_dimensions(var, cache, concat_dim=None, checksum=True):
         cpyds = pydap.handlers.dap.UNPACKDAP4DATA(r).dataset
         cache[concat_dim] = np.asarray(cpyds[concat_dim].data)
 
-    dims_url = sess.headers["consolidated"]
-    maps_url = sess.headers["Maps"]
+    dims_url = sess.headers.get("consolidated", None)
+    maps_url = sess.headers.get("Maps", None)
     for URL in [dims_url, maps_url]:
-        if URL.startswith("https"):
+        if URL and URL.startswith("https"):
             r = sess.get(URL)
             pyds = pydap.handlers.dap.UNPACKDAP4DATA(r, checksum=checksum).dataset
             for name in pyds.keys():

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -508,22 +508,24 @@ def fetch_consolidated_dimensions(var, cache, concat_dim=None, checksum=True):
         cache[concat_dim] = np.asarray(cpyds[concat_dim].data)
 
     dims_url = sess.headers["consolidated"]
-    if dims_url.startswith("https"):
-        r = sess.get(dims_url)
-        pyds = pydap.handlers.dap.UNPACKDAP4DATA(r, checksum=checksum).dataset
-        for name in pyds.keys():
-            cache[name] = np.asarray(pyds[name].data)
+    maps_url = sess.headers["Maps"]
+    for URL in [dims_url, maps_url]:
+        if URL.startswith("https"):
+            r = sess.get(URL)
+            pyds = pydap.handlers.dap.UNPACKDAP4DATA(r, checksum=checksum).dataset
+            for name in pyds.keys():
+                cache[name] = np.asarray(pyds[name].data)
     return cache
 
 
-def resolve_batch_for_all_variables(dataset, parent, key):
+def resolve_batch_for_all_variables(dataset, parent, key, variables):
     """
     Resolves a batch promise for all non-dimension variables within the
     parent container.
     """
     dataset._current_batch_promise = BatchPromise()
 
-    for name in list(parent.variables()):
+    for name in variables:
         var = parent[name]
         if var.name not in parent.dimensions and not var._is_data_loaded():
             var._pending_batch_slice = key

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -498,20 +498,21 @@ def fetch_consolidated_dimensions(var, cache, concat_dim=None, checksum=True):
             concat_dim = concat_dim[1:]
         all_urls = sess.cache.urls()
         data_url = var.data.baseurl + ".dap"
-        cdim_url = next(
+        cdim_url = [
             url
             for url in all_urls
             if url.split("?")[0] == data_url and concat_dim in url.split("?dap4.ce=")[1]
-        )
+        ][0]
         r = sess.get(cdim_url)
         cpyds = pydap.handlers.dap.UNPACKDAP4DATA(r).dataset
         cache[concat_dim] = np.asarray(cpyds[concat_dim].data)
 
     dims_url = sess.headers["consolidated"]
-    r = sess.get(dims_url)
-    pyds = pydap.handlers.dap.UNPACKDAP4DATA(r, checksum=checksum).dataset
-    for name in pyds.keys():
-        cache[name] = np.asarray(pyds[name].data)
+    if dims_url.startswith("https"):
+        r = sess.get(dims_url)
+        pyds = pydap.handlers.dap.UNPACKDAP4DATA(r, checksum=checksum).dataset
+        for name in pyds.keys():
+            cache[name] = np.asarray(pyds[name].data)
     return cache
 
 

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -1171,8 +1171,6 @@ class DatasetType(StructureType):
         # Clean up
         self._batch_registry.clear()
         self._batch_timer = None
-        # print(f"Delayed batch promise {id(self._current_batch_promise)}\n")
-        # self._current_batch_promise = None
 
         return None
 

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -181,7 +181,6 @@ import requests
 import requests_cache
 
 from pydap.lib import BatchPromise, _quote, decode_np_strings, tree, walk
-from pydap.net import GET
 
 __all__ = [
     "BaseType",
@@ -1111,7 +1110,7 @@ class DatasetType(StructureType):
     def _resolve_batch(self, batch_promise):
         from pydap.handlers.dap import UNPACKDAP4DATA
 
-        print(f"[Batch] Resolving promise: {id(batch_promise)}")
+        # print(f"[Batch] Resolving promise: {id(batch_promise)}")
         variables = [
             var
             for var in self._batch_registry
@@ -1140,8 +1139,16 @@ class DatasetType(StructureType):
         ce_string = "?dap4.ce=" + ";".join(sorted(constraint_expressions))
         _dap_url = base_url + ".dap" + ce_string
         _dap_url += "&dap4.checksum=true"
-        print("dap url:", _dap_url)
-        r = GET(_dap_url, get_kwargs={"stream": True}, session=self._session)
+        # print("dap url:", _dap_url)
+
+        with self._session.cache_disabled():
+            r = self._session.get(
+                _dap_url,
+                timeout=512,
+                verify=True,
+                allow_redirects=True,
+                stream=True,
+            )
 
         parsed_dataset = UNPACKDAP4DATA(r, checksum=True, user_charset="ascii").dataset
 

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -1147,7 +1147,16 @@ class DatasetType(StructureType):
 
         # print("dap url:", _dap_url)
 
-        with self._session.cache_disabled():
+        if isinstance(self._session, requests_cache.CachedSession):
+            with self._session.cache_disabled():
+                r = self._session.get(
+                    _dap_url,
+                    timeout=512,
+                    verify=True,
+                    allow_redirects=True,
+                    stream=True,
+                )
+        else:
             r = self._session.get(
                 _dap_url,
                 timeout=512,

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -1111,7 +1111,7 @@ class DatasetType(StructureType):
     def _resolve_batch(self, batch_promise):
         from pydap.handlers.dap import UNPACKDAP4DATA
 
-        # print(f"[Batch] Resolving promise: {id(batch_promise)}")
+        print(f"[Batch] Resolving promise: {id(batch_promise)}")
         variables = [
             var
             for var in self._batch_registry
@@ -1140,7 +1140,7 @@ class DatasetType(StructureType):
         ce_string = "?dap4.ce=" + ";".join(sorted(constraint_expressions))
         _dap_url = base_url + ".dap" + ce_string
         _dap_url += "&dap4.checksum=true"
-        # print("dap url:", _dap_url)
+        print("dap url:", _dap_url)
         r = GET(_dap_url, get_kwargs={"stream": True}, session=self._session)
 
         parsed_dataset = UNPACKDAP4DATA(r, checksum=True, user_charset="ascii").dataset

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -1128,17 +1128,21 @@ class DatasetType(StructureType):
             if var.build_ce() is not None
         ]
 
-        if not constraint_expressions:
+        base_url = variables[0]._data.baseurl if variables[0]._data else None
+
+        if not constraint_expressions or not base_url:
             self._batch_registry.clear()
             self._batch_timer = None
             return
-
-        base_url = variables[0]._data.baseurl if variables[0]._data else None
 
         # Build the single dap4.ce query parameter
         ce_string = "?dap4.ce=" + ";".join(sorted(constraint_expressions))
         _dap_url = base_url + ".dap" + ce_string
         _dap_url += "&dap4.checksum=true"
+
+        if _dap_url.startswith("https://test.opendap.org"):
+            _dap_url = _dap_url.replace("https", "http")
+
         # print("dap url:", _dap_url)
 
         with self._session.cache_disabled():

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -270,6 +270,8 @@ class DapType(object):
         self.id = path or "/"  # <-- KEY LINE!
 
         if isinstance(self, BaseType):
+            if not self.parent:
+                self.parent = self.dataset
             if type(self._data).__name__ == "BaseProxyDap4" and not hasattr(
                 self, "_original_data_args"
             ):

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -564,29 +564,12 @@ def test_consolidate_metadata_concat_dim(urls, concat_dim):
 
     N_dmr_urls = len(urls)  # Since `safe_mode=False`, only 1 DMR is downloaded
 
-    # # the url to the dap dimensions a
-    # assert cached_session.headers["consolidated"].startswith("https")
-
     if not concat_dim:
-        # assert cached_session.headers.get("concat_dim") is None
-
-        # assert (
-        #     cached_session.headers["consolidated"].split("dap4.ce=")[1].split("&")[0]
-        #     == "COADSX%5B0:1:179%5D;COADSY%5B0:1:89%5D;TIME%5B0:1:11%5D"
-        # )
-
         # Without `concat_dim` set, only one dap response is downloaded per URL.
         assert (
             len(cached_session.cache.urls()) == N_dmr_urls + 1
         )  # all dims are batched together
     else:
-        # cached_session.headers.get("concat_dim") == "/" + concat_dim
-
-        # assert (
-        #     cached_session.headers["consolidated"].split("dap4.ce=")[1]
-        #     == "COADSX%5B0:1:179%5D;COADSY%5B0:1:89%5D&dap4.checksum=true"
-        # )
-
         # concat dim is set. Must download N dap responses for the concat_dim.
         N_concat_dims = len(urls)  # see below !
         N_non_concat_dims = 1  # all dims are downloaded once, together.

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -564,28 +564,28 @@ def test_consolidate_metadata_concat_dim(urls, concat_dim):
 
     N_dmr_urls = len(urls)  # Since `safe_mode=False`, only 1 DMR is downloaded
 
-    # the url to the dap dimensions a
-    assert cached_session.headers["consolidated"].startswith("https")
+    # # the url to the dap dimensions a
+    # assert cached_session.headers["consolidated"].startswith("https")
 
     if not concat_dim:
-        assert cached_session.headers.get("concat_dim") is None
+        # assert cached_session.headers.get("concat_dim") is None
 
-        assert (
-            cached_session.headers["consolidated"].split("dap4.ce=")[1].split("&")[0]
-            == "COADSX%5B0:1:179%5D;COADSY%5B0:1:89%5D;TIME%5B0:1:11%5D"
-        )
+        # assert (
+        #     cached_session.headers["consolidated"].split("dap4.ce=")[1].split("&")[0]
+        #     == "COADSX%5B0:1:179%5D;COADSY%5B0:1:89%5D;TIME%5B0:1:11%5D"
+        # )
 
         # Without `concat_dim` set, only one dap response is downloaded per URL.
         assert (
             len(cached_session.cache.urls()) == N_dmr_urls + 1
         )  # all dims are batched together
     else:
-        cached_session.headers.get("concat_dim") == "/" + concat_dim
+        # cached_session.headers.get("concat_dim") == "/" + concat_dim
 
-        assert (
-            cached_session.headers["consolidated"].split("dap4.ce=")[1]
-            == "COADSX%5B0:1:179%5D;COADSY%5B0:1:89%5D&dap4.checksum=true"
-        )
+        # assert (
+        #     cached_session.headers["consolidated"].split("dap4.ce=")[1]
+        #     == "COADSX%5B0:1:179%5D;COADSY%5B0:1:89%5D&dap4.checksum=true"
+        # )
 
         # concat dim is set. Must download N dap responses for the concat_dim.
         N_concat_dims = len(urls)  # see below !

--- a/src/pydap/tests/test_model.py
+++ b/src/pydap/tests/test_model.py
@@ -753,15 +753,20 @@ def test_DatasetType_set_parent():
     `
     """
     ds = DatasetType("root")
+    ds.createVariable("root_var")
     ds.createGroup("Group1")
     ds.createGroup("Group2")
     ds.createGroup("Group1/subGroup2")
     ds.createVariable("Group1/subGroup2/var")
+    ds.assign_dataset_recursive(ds)
 
-    assert ds["Group1/subGroup2/var"].parent.id == "subGroup2"
-    assert ds["Group1/subGroup2/var"].parent.parent.id == "Group1"
-    assert ds["Group1"].parent.id == "root"
-    assert ds["Group2"].parent.id == "root"
+    assert ds["Group1/subGroup2/var"].parent.id == "/Group1/subGroup2"
+    assert ds["Group1/subGroup2/var"].parent == ds["Group1/subGroup2"]
+    assert ds["Group1/subGroup2/var"].parent.parent.id == ds["/Group1"].id
+    assert ds["Group1"].parent.id == "/"
+    assert ds["Group2"].parent.id == "/"
+    assert ds["root_var"].parent == ds
+    assert ds["Group1/subGroup2/var"].dataset == ds
 
 
 def test_set_dataset():

--- a/src/pydap/tests/test_open_dap4_url.py
+++ b/src/pydap/tests/test_open_dap4_url.py
@@ -35,7 +35,7 @@ def test_batch_mode_downloads():
     session.cache.clear()  # Clear cache before testing
 
     url = "http://test.opendap.org/opendap/dap4/SimpleGroup.nc4.h5"
-    ds = open_url(url, session=session, protocol="dap4", checksum=False)
+    ds = open_url(url, session=session, protocol="dap4", checksum=True)
     ds.enable_batch_mode()
 
     # slash arrays to triger data download.
@@ -54,33 +54,33 @@ def test_batch_mode_downloads():
 
     # check that cached urls are correct
 
-    # Check that there are only 2 URL cached: 1) the DMR and 2) the DAP URL
-    assert len(session.cache.urls()) == 2
+    # Check that there is only 1 URL cached: the DMR. The DAP url us no longer cached
+    assert len(session.cache.urls()) == 1
 
-    # check dap url (assume it is the 0th one of the cached urls)
-    cached_dap_url_query = session.cache.urls()[0].split("?dap4.ce=")[1]
+    # # check dap url (assume it is the 0th one of the cached urls)
+    # cached_dap_url_query = session.cache.urls()[0].split("?dap4.ce=")[1]
 
-    # Checksum query parameter was set to False (default)
-    # but the currently always set to `checksum=true` when batching
-    # this will change later
+    # # Checksum query parameter was set to False (default)
+    # # but the currently always set to `checksum=true` when batching
+    # # this will change later
 
-    data_requests, checksum_query = cached_dap_url_query.split("&")
+    # data_requests, checksum_query = cached_dap_url_query.split("&")
 
-    assert checksum_query == "dap4.checksum=true"
+    # assert checksum_query == "dap4.checksum=true"
 
     # Now take the rest, and check that the two variable data requests are correct
 
-    # expected:
-    expected_CE_temp = (
-        "%2FSimpleGroup%2FTemperature%5B0%3A1%3A0%5D%5B0%3A1%3A39%5D%5B0%3A1%3A39%5D"
-    )
-    expected_CE_salt = (
-        "%2FSimpleGroup%2FSalinity%5B0%3A1%3A0%5D%5B0%3A1%3A39%5D%5B0%3A1%3A39%5D"
-    )
+    # # expected:
+    # expected_CE_temp = (
+    #     "%2FSimpleGroup%2FTemperature%5B0%3A1%3A0%5D%5B0%3A1%3A39%5D%5B0%3A1%3A39%5D"
+    # )
+    # expected_CE_salt = (
+    #     "%2FSimpleGroup%2FSalinity%5B0%3A1%3A0%5D%5B0%3A1%3A39%5D%5B0%3A1%3A39%5D"
+    # )
 
-    observed_CEs = data_requests.split("%3B")  # `;` scaped is %3B
+    # observed_CEs = data_requests.split("%3B")  # `;` scaped is %3B
 
-    assert set(observed_CEs) == set([expected_CE_temp, expected_CE_salt])
+    # assert set(observed_CEs) == set([expected_CE_temp, expected_CE_salt])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

improves how `consolidate_metadata` downloads dap responses: batching several variables within a single dap url (before 1 dap url per variable), since this is how xarray handles / downloads arrays in dap4. Now that I am changing how xarray handles dap downloads (can download multiple variables within same dap url), this will support that change. 

The following Pull Request:

- [ ] Closes an already existing opened issue #xxxx for fixing a bug, requesting
a new feature, etc.
- [ ] Tests are added to demonstrate the new or fixed behavior, and all tests pass
on a local environment.


# Example

Consider the case of OSCAR data (collection). In this case, there are 2 named dimensions (`latitude` and `longitude`), a dimension array (`time`) and two Maps: `lat` and `lon`. `lat` and `lon` are shared across all granules (this is level 3/4 data). To avoid re-download repeated data we need to specify these `lat` and `lon` arrays, so that these are only downloaded once.

```python
urls =  ['dap4://opendap.earthdata.nasa.gov/collections/C2098858642-POCLOUD/granules/oscar_currents_final_20200101', 
         'dap4://opendap.earthdata.nasa.gov/collections/C2098858642-POCLOUD/granules/oscar_currents_final_20200102']

# set_maps=True | False (default=False)
consolidate_metadata(urls, concat_dim='time', session=session, set_maps=True)

```

When `set_maps=True`, the `Maps` are identified within the granule and added to the download dap urls. 
For  given `N` dap4_urls, `consolidate_metadata` downloads 2N+1 urls

### before changes:
- `N` dmrs
- `N` dap urls (downloads `time` for every granule )
- `M` dap urls (downloads 1 dap url per dimension for given `M` dimensions, for a single granule - reuses this info)

### after changes in this PR
- `N` dmrs
- `N` dap urls (downloads `time` for every granule )
- `1` dap url ( includes all `M` dimensions in single dap response, will be reused for all granules) # <-------- different behavior
- `1` dap url for all Maps  in the 1st granule, to be reused

if `set_maps=False`, then the same is True except the last dap url for Maps is not downloaded. 


```python
print(session.cache.urls())
>>> ['https://opendap.earthdata.nasa.gov/collections/C2098858642-POCLOUD/granules/oscar_currents_final_20200101.dap?dap4.ce=lat%5B0%3A1%3A718%5D%3Blon%5B0%3A1%3A1439%5D&dap4.checksum=true',
 'https://opendap.earthdata.nasa.gov/collections/C2098858642-POCLOUD/granules/oscar_currents_final_20200101.dap?dap4.ce=time%5B0%3A1%3A0%5D&dap4.checksum=true',
 'https://opendap.earthdata.nasa.gov/collections/C2098858642-POCLOUD/granules/oscar_currents_final_20200101.dmr',
 'https://opendap.earthdata.nasa.gov/collections/C2098858642-POCLOUD/granules/oscar_currents_final_20200102.dap?dap4.ce=time%5B0%3A1%3A0%5D&dap4.checksum=true',
 'https://opendap.earthdata.nasa.gov/collections/C2098858642-POCLOUD/granules/oscar_currents_final_20200102.dmr']
```


### why matter:

When using xarray, the if the maps are not downloaded, xarray triggers their download per granule, potentially downloading `N` dap urls (and potentially even worse `N*M` when `M` is the number of Map variables, in this case `M=2`).

### with `set_maps=True`
```python
%%time
ds = xr.open_mfdataset(urls, engine='pydap', session=session, parallel=True, combine='nested', concat_dim="time", batch=True)
>>> CPU times: user 20.8 ms, sys: 3.13 ms, total: 23.9 ms
Wall time: 21.8 ms

```
 ### with `set_maps=False`
```python
%%time
ds = xr.open_mfdataset(urls, engine='pydap', session=session, parallel=True, combine='nested', concat_dim="time", batch=True)
```
Triggers the download of all `lat` and `lon` per granule