### PR TITLE
enable updating the session credentials from a different session

### DIFF
--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -13,7 +13,8 @@ from requests_cache import CachedSession
 from urllib3 import Retry
 from webob.request import Request as webob_Request
 
-from pydap.lib import DEFAULT_TIMEOUT, _quote, __version__
+from pydap.lib import DEFAULT_TIMEOUT, __version__, _quote
+
 
 def GET(
     url,
@@ -261,9 +262,9 @@ def create_session(
     token = session_kwargs.pop("token", None)
     cache_kwargs = cache_kwargs or {}
     if isinstance(session, requests.Session):
-        token_auth=session.headers.get("Authorization", None)
+        token_auth = session.headers.get("Authorization", None)
     else:
-        token_auth=None
+        token_auth = None
 
     if use_cache:
         expire_after = cache_kwargs.pop("expire_after", None)
@@ -322,5 +323,5 @@ def create_session(
         session.headers.update({"Authorization": f"{token_auth}"})
     elif token:
         session.headers.update({"Authorization": f"Bearer {token}"})
-    session.headers.update({"User-Agent": 'pydap/'+f"{__version__}"})
+    session.headers.update({"User-Agent": "pydap/" + f"{__version__}"})
     return session

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -13,8 +13,7 @@ from requests_cache import CachedSession
 from urllib3 import Retry
 from webob.request import Request as webob_Request
 
-from .lib import DEFAULT_TIMEOUT, _quote
-
+from pydap.lib import DEFAULT_TIMEOUT, _quote, __version__
 
 def GET(
     url,
@@ -232,6 +231,7 @@ def create_session(
     use_cache=False,
     session_kwargs=None,
     cache_kwargs=None,
+    session=None,
 ):
     """
     Creates a request.Session object with the specified parameters.
@@ -260,6 +260,11 @@ def create_session(
     session_kwargs = session_kwargs or {}
     token = session_kwargs.pop("token", None)
     cache_kwargs = cache_kwargs or {}
+    if isinstance(session, requests.Session):
+        token_auth=session.headers.get("Authorization", None)
+    else:
+        token_auth=None
+
     if use_cache:
         expire_after = cache_kwargs.pop("expire_after", None)
         if not expire_after:
@@ -313,7 +318,9 @@ def create_session(
     # Mount the adapter to the session
     session.mount("http://", adapter)
     session.mount("https://", adapter)
-
-    if token:
+    if token_auth:
+        session.headers.update({"Authorization": f"{token_auth}"})
+    elif token:
         session.headers.update({"Authorization": f"Bearer {token}"})
+    session.headers.update({"User-Agent": 'pydap/'+f"{__version__}"})
     return session


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes #536 

With this, the following works

```python
import earthaccess
from pydap.net import create_session

auth = earthaccess.login(strategy="interactive", persist=True)
_session = earthaccess.get_requests_https_session()

session = create_session(session=_session)

```


And so a user can make of of `earthaccess` for token extraction from NASA in the background rather than manually having to store across session as previously described in the documentation or jupyter notebooks on the binder


