### PR TITLE
Add an extra conditiona to `get_cmr_urls` to use if previous returns None

### DIFF
--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -1068,12 +1068,22 @@ def get_cmr_urls(
     ]
     granules_urls = []
     for item in items:
+        granule_1, granule_2 = None, None
         for i in range(len(item)):
             if (
                 item[i].get("Description") == "OPeNDAP request URL"
                 or item[i].get("Subtype") == "OPENDAP DATA"
             ):
-                granules_urls.append(item[i]["URL"])
+                granule_1 = item[i]["URL"]
+
+            if (
+                item[i].get("Type") == "VIEW RELATED INFORMATION"
+                and item[i]["URL"].startswith("https")
+                and not item[i]["URL"].endswith(".iso.xml")
+            ):
+                granule_2 = item[i]["URL"]
+        granule = granule_1 if granule_1 else granule_2
+        granules_urls.append(granule)
 
     return granules_urls
 


### PR DESCRIPTION
… explicitly mentions opendap fails

<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes #538 

With this, I can do:

```python

oscar_ccid = "C2098858642-POCLOUD"
atl06_ccid = "C2670138092-NSIDC_CPRD"

time_range=[dt.datetime(2020, 1, 1), dt.datetime(2020, 1, 31)] # One month of data

urls1 = get_cmr_urls(ccid=oscar_ccid,time_range=time_range, limit=100)
urls2 = get_cmr_urls(ccid=atl06_ccid, time_range=time_range, limit=100)

len(urls1), len(urls2)
>>> (31, 100)
```
That result is correct. THis means it is preserving the initial logic, and it is finding the ATL06 urls fine

