### PR TITLE
Enable `shared dimensions` option on when consolidated data

### DIFF
--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -1075,7 +1075,7 @@ def get_cmr_urls(
                 or item[i].get("Subtype") == "OPENDAP DATA"
             ):
                 granule_1 = item[i]["URL"]
-                break
+                # break
 
             if (
                 item[i].get("Type") == "VIEW RELATED INFORMATION"
@@ -1090,7 +1090,7 @@ def get_cmr_urls(
                     > 1
                 ):
                     granule_2 = item[i]["URL"]
-                    break
+                    # break
         granule = granule_1 if granule_1 else granule_2
         if granule:
             granules_urls.append(granule)

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -863,7 +863,7 @@ def get_count(variable):
     return count
 
 
-def decode_variable(buffer, start, stop, variable, endian):
+def decode_variable(buffer, start, stop, variable, endian, remote=True):
     dtype = variable.dtype
     dtype = dtype.newbyteorder(endian)
     if dtype.kind == "S":
@@ -873,7 +873,10 @@ def decode_variable(buffer, start, stop, variable, endian):
     else:
         data = numpy.frombuffer(buffer[start:stop], dtype=dtype)
         data = data.reshape(variable.shape)
-        return DapDecodedArray(data)
+        if remote:
+            return DapDecodedArray(data)
+        else:
+            return data
 
 
 def decode_utf8_string_array(buffer):
@@ -958,10 +961,11 @@ class UNPACKDAP4DATA(object):
             See `pydap.net.get.open_dap_file`
     """
 
-    def __init__(self, r, checksums=True, user_charset="ascii"):
+    def __init__(self, r, checksums=True, user_charset="ascii", remote=True):
         self.user_charset = user_charset
         self.checksums = checksums
         self.r = r
+        self.remote = remote
         try:
             iterator = self.iter_body()
             CHUNK_SIZE = 1048576
@@ -1057,6 +1061,7 @@ class UNPACKDAP4DATA(object):
                 stop=stop,
                 variable=variable,
                 endian=self.endianness,
+                remote=self.remote,
             )
             variable._set_data(data)
 

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -863,7 +863,7 @@ def get_count(variable):
     return count
 
 
-def decode_variable(buffer, start, stop, variable, endian, remote=True):
+def decode_variable(buffer, start, stop, variable, endian):
     dtype = variable.dtype
     dtype = dtype.newbyteorder(endian)
     if dtype.kind == "S":
@@ -873,10 +873,7 @@ def decode_variable(buffer, start, stop, variable, endian, remote=True):
     else:
         data = numpy.frombuffer(buffer[start:stop], dtype=dtype)
         data = data.reshape(variable.shape)
-        if remote:
-            return DapDecodedArray(data)
-        else:
-            return data
+        return DapDecodedArray(data)
 
 
 def decode_utf8_string_array(buffer):
@@ -961,11 +958,10 @@ class UNPACKDAP4DATA(object):
             See `pydap.net.get.open_dap_file`
     """
 
-    def __init__(self, r, checksums=True, user_charset="ascii", remote=True):
+    def __init__(self, r, checksums=True, user_charset="ascii"):
         self.user_charset = user_charset
         self.checksums = checksums
         self.r = r
-        self.remote = remote
         try:
             iterator = self.iter_body()
             CHUNK_SIZE = 1048576
@@ -1061,7 +1057,6 @@ class UNPACKDAP4DATA(object):
                 stop=stop,
                 variable=variable,
                 endian=self.endianness,
-                remote=self.remote,
             )
             variable._set_data(data)
 

--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -443,10 +443,10 @@ def fetch_batched_dimensions(ds, Variables, cache=None):
 
     for name in Variables:
         data = promise.wait_for_result(ds[name].id)
-        cache[ds[name].id] = np.asarray(data)
+        ds[ds[name].id].data = np.asarray(data)
 
     ds.dataset._current_batch_promise = None
-    return cache
+    # return cache
 
 
 def fetch_consolidated_dimensions(ds, cache, checksums=True) -> {}:

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -407,7 +407,10 @@ class BaseType(DapType):
     @property
     def dtype(self):
         """Property that returns the data dtype."""
-        return self._data.dtype
+        if isinstance(self._data, SelfClearingArray):
+            return self._dtype
+        else:
+            return self._data.dtype
 
     @property
     def shape(self):
@@ -435,7 +438,7 @@ class BaseType(DapType):
 
     @property
     def ndim(self):
-        return len(self.shape)
+        return len(self.dims)
 
     @property
     def size(self):
@@ -572,8 +575,12 @@ class BaseType(DapType):
         return self._data
 
     def _set_data(self, data):
+        # print(data)
         if isinstance(data, DapDecodedArray):
-            self._data = SelfClearingArray(data.array)
+            _array = data.array
+            self._shape = tuple(_array.shape)
+            self._dtype = _array.dtype
+            self._data = SelfClearingArray(_array)
         else:
             self._data = data
             if np.isscalar(data):

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -407,10 +407,7 @@ class BaseType(DapType):
     @property
     def dtype(self):
         """Property that returns the data dtype."""
-        if isinstance(self._data, SelfClearingArray):
-            return self._dtype
-        else:
-            return self._data.dtype
+        return self._data.dtype
 
     @property
     def shape(self):
@@ -438,7 +435,7 @@ class BaseType(DapType):
 
     @property
     def ndim(self):
-        return len(self.dims)
+        return len(self.shape)
 
     @property
     def size(self):
@@ -577,10 +574,7 @@ class BaseType(DapType):
     def _set_data(self, data):
         # print(data)
         if isinstance(data, DapDecodedArray):
-            _array = data.array
-            self._shape = tuple(_array.shape)
-            self._dtype = _array.dtype
-            self._data = SelfClearingArray(_array)
+            self._data = SelfClearingArray(data.array)
         else:
             self._data = data
             if np.isscalar(data):


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

This will enable to

- Construct dap urls following the shared-dimensions spec (knowledge of dimensions slices, and all variables in the metadata dmr) from the original provided url (which already may contain a constraint expression).
-  Download in parallel all the dap responses

