### PR TITLE
remove global url definitions - make tests self contained

### DIFF
--- a/.github/workflows/run_tests_macos.yml
+++ b/.github/workflows/run_tests_macos.yml
@@ -31,6 +31,10 @@ jobs:
           conda
         cache-environment: true
 
+    - name: Clean requests-cache (debug.sqlite)
+      run: |
+        rm -f debug.sqlite debug.sqlite-wal debug.sqlite-shm
+
     - name: Install pydap and dependencies for testing
       run: |
         python -m pip install -e .

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -31,6 +31,10 @@ jobs:
           conda
         cache-environment: true
 
+    - name: Clean requests-cache (debug.sqlite)
+      run: |
+        rm -f debug.sqlite debug.sqlite-wal debug.sqlite-shm
+
     - name: Install pydap and dependencies for testing
       run: |
         python -m pip install -e .

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -146,6 +146,7 @@ def open_url(
             session_kwargs=session_kwargs,
             cache_kwargs=cache_kwargs,
         )
+
     handler = DAPHandler(
         url,
         application,

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -1200,7 +1200,8 @@ class DatasetType(StructureType):
             - slices are not validated, so user must ensure they make sense.
             - Intended only when in batch mode.
         """
-        dims = [var for var in var.dims if isinstance(self[var], BaseType)]
+        dataset = var.dataset
+        dims = [vdim for vdim in var.dims if isinstance(dataset[var.id], BaseType)]
         var._pending_batch_slice = slice(key) if not key else key
         slice_elements = var.build_ce().split(var.name)[-1]
         dim_slices = dict(zip(dims, [sli + "]" for sli in slice_elements.split("]")]))

--- a/src/pydap/model.py
+++ b/src/pydap/model.py
@@ -1208,7 +1208,7 @@ class DatasetType(StructureType):
 
         # the next check is to see if all dimensions lie within the variable hierarchy
         uniformity_check = len(dims) * [True] == [
-            self[dims[i]].parent == var.parent for i in range(len(dims))
+            dataset[dims[i]].parent == var.parent for i in range(len(dims))
         ]  # it is True only when all dims a share hierarchy with data
         if not key or not uniformity_check:
             self.clear_dim_slices()

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -289,7 +289,7 @@ def create_session(
             }
             # Create a new session with cache
         session = CachedSession(**{**session_kwargs, **cache_kwargs})
-        session.cache.clear()
+        session.cache.clear()  # removes any previous data associated with cache_name
     else:
         if len(cache_kwargs) > 0:
             warnings.warn(

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -289,6 +289,7 @@ def create_session(
             }
             # Create a new session with cache
         session = CachedSession(**{**session_kwargs, **cache_kwargs})
+        session.cache.clear()
     else:
         if len(cache_kwargs) > 0:
             warnings.warn(

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -984,4 +984,5 @@ def test_register_dim_slices_dimension_different_hierarchy(var, slice_, expected
     session = requests.Session()
     pyds = open_url(url, session=session, batch=True)
     pyds.register_dim_slices(pyds[var], key=slice_)
-    assert pyds._slices == expected
+    slices = pyds._slices
+    assert slices == expected

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -493,6 +493,7 @@ def test_cached_consolidate_metadata_matching_dims(urls, safe_mode):
     ce_dims = cached_session.cache.urls()[0].split("=")[1].split("&")[0].split("%3B")
 
     assert [item.split("%5B")[0] for item in ce_dims] == dims
+    cached_session.cache.clear()
 
 
 ce1 = "?dap4.ce=/i;/j;/bears"
@@ -535,6 +536,7 @@ def test_cached_consolidate_metadata_inconsistent_dims(urls, safe_mode):
         # caches all DMRs and caches the dap responses of the dimensions
         # of the first URL
         assert len(cached_session.cache.urls()) == len(urls) + len(dims)
+    cached_session.cache.clear()
 
 
 # @pytest.mark.skipif(
@@ -584,6 +586,7 @@ def test_consolidate_metadata_concat_dim(urls, concat_dim):
             len(cached_session.cache.urls())
             == N_dmr_urls + N_concat_dims + N_non_concat_dims
         )
+    cached_session.cache.clear()
 
 
 @pytest.mark.parametrize(
@@ -911,6 +914,7 @@ bbox2 = "bounding_box%5B%5D=-11%2C-6%2C11%2C6"
 def test_get_cmr_urls(param, expected):
     """Test that get_cmr_urls returns the correct urls."""
     session = create_session(use_cache=True, cache_kwargs={"backend": "memory"})
+    session.cache.clear()
     cmr_urls = get_cmr_urls(**param, session=session)
     assert isinstance(cmr_urls, list)
     assert len(cmr_urls) > 0
@@ -929,6 +933,7 @@ def test_get_cmr_urls(param, expected):
         # if page_size is not specified, it defaults to 50
         expected += "&page_size=50"
     assert set(expected.split("&")) == set(cached_urls.split("&"))
+    cached_session.cache.clear()
 
 
 @pytest.mark.parametrize("var", ["SST"])

--- a/src/pydap/tests/test_lib.py
+++ b/src/pydap/tests/test_lib.py
@@ -448,6 +448,7 @@ def test_fetched_batched(group):
     for var in dims:
         assert isinstance(pyds[var].data, np.ndarray)
     assert len(session.cache.urls()) == 1  # single dap url
+    session.cache.clear()
 
 
 @pytest.mark.parametrize("dims", [True, False])
@@ -482,6 +483,7 @@ def test_get_batch_data(dims, group):
                 pyds[group][name], BaseType
             ):
                 assert pyds[group][name]._is_data_loaded()
+    session.cache.clear()
 
 
 @pytest.mark.parametrize(
@@ -562,6 +564,7 @@ def test_get_batch_data_sliced_nondims(
     assert (
         query.replace("%5B", "[").replace("%5D", "]").replace("%3A", ":") == expected_ce
     )
+    session.cache.clear()
 
 
 @pytest.mark.parametrize(

--- a/src/pydap/tests/test_lib.py
+++ b/src/pydap/tests/test_lib.py
@@ -458,7 +458,9 @@ def test_get_batch_data(dims, group):
     Test that `get_batch_data` works as expected.
     """
     url = "dap4://test.opendap.org/opendap/dap4/SimpleGroup.nc4.h5"
-    session = create_session(use_cache=True, cache_kwargs={"cache_name": "debug"})
+    session = create_session(
+        use_cache=True, cache_kwargs={"cache_name": "debug", "backend": "memory"}
+    )
     session.cache.clear()
     pyds = open_url(url, session=session, batch=True)
     session.cache.clear()

--- a/src/pydap/tests/test_open_dap4_url.py
+++ b/src/pydap/tests/test_open_dap4_url.py
@@ -42,12 +42,14 @@ def test_dap4_slices(protocol):
         session.cache.urls()[0].split("lon")[-1].split("%5B")[1].split("%5D")[0]
     )
     assert query_string.replace("%3A", ":") == "179:1:179"
+    session.cache.clear()
 
 
 def test_dap4_unaligned_check_dims():
     """ """
     url = "dap4://test.opendap.org/opendap/dap4/unaligned_simple_datatree.nc.h5"
-    pyds = open_url(url)
+    session = create_session()
+    pyds = open_url(url, session=session)
     assert pyds.dimensions == {"lat": 1, "lon": 2}
     assert pyds["Group1"].dimensions == {"lat": 1, "lon": 2}
     assert pyds["Group1/subgroup1"].dimensions == {"lat": 2, "lon": 2}
@@ -62,7 +64,9 @@ def test_dap4_unaligned_check_dims():
 def test_dap4_unaligned2_check_dims():
     """ """
     url = "dap4://test.opendap.org/opendap/dap4/unaligned_simple_datatree2.nc4.h5"
-    pyds = open_url(url)
+    session = create_session()
+    pyds = open_url(url, session=session)
+
     assert pyds.dimensions == {"lat": 1, "lon": 2}
     assert pyds["Group1"].dimensions == {"lat": 1, "lon": 2}
     assert pyds["Group1/subgroup1"].dimensions == {"lat": 2, "lon": 2}
@@ -98,35 +102,9 @@ def test_batch_mode_downloads():
     # check that the data is correct
     assert np.mean(salt) == 30.0
 
-    # check that cached urls are correct
-
     # Check that there is only 1 URL cached: the DMR. The DAP url us no longer cached
     assert len(session.cache.urls()) == 2
-
-    # # check dap url (assume it is the 0th one of the cached urls)
-    # cached_dap_url_query = session.cache.urls()[0].split("?dap4.ce=")[1]
-
-    # # Checksum query parameter was set to False (default)
-    # # but the currently always set to `checksum=true` when batching
-    # # this will change later
-
-    # data_requests, checksum_query = cached_dap_url_query.split("&")
-
-    # assert checksum_query == "dap4.checksum=true"
-
-    # Now take the rest, and check that the two variable data requests are correct
-
-    # # expected:
-    # expected_CE_temp = (
-    #     "%2FSimpleGroup%2FTemperature%5B0%3A1%3A0%5D%5B0%3A1%3A39%5D%5B0%3A1%3A39%5D"
-    # )
-    # expected_CE_salt = (
-    #     "%2FSimpleGroup%2FSalinity%5B0%3A1%3A0%5D%5B0%3A1%3A39%5D%5B0%3A1%3A39%5D"
-    # )
-
-    # observed_CEs = data_requests.split("%3B")  # `;` scaped is %3B
-
-    # assert set(observed_CEs) == set([expected_CE_temp, expected_CE_salt])
+    session.cache.clear()
 
 
 if __name__ == "__main__":

--- a/src/pydap/tests/test_open_dap4_url.py
+++ b/src/pydap/tests/test_open_dap4_url.py
@@ -32,7 +32,9 @@ def test_dap4_slices(protocol):
     """Also tests dap2"""
     url = "https://test.opendap.org/opendap/netcdf/examples/tos_O1_2001-2002.nc"
 
-    session = create_session(use_cache=True, cache_kwargs={"cache_name": "debug"})
+    session = create_session(
+        use_cache=True, cache_kwargs={"cache_name": "debug", "backend": "memory"}
+    )
     pyds = open_url(url, protocol=protocol, session=session)
     session.cache.clear()  # Clear cache before testing
     lon = np.asarray(pyds["lon"][-1:].data)
@@ -82,7 +84,9 @@ def test_batch_mode_downloads():
     """
     Test that batch mode downloads data correctly.
     """
-    session = create_session(use_cache=True, cache_kwargs={"cache_name": "debug"})
+    session = create_session(
+        use_cache=True, cache_kwargs={"cache_name": "debug", "backend": "memory"}
+    )
     session.cache.clear()  # Clear cache before testing
 
     url = "http://test.opendap.org/opendap/dap4/SimpleGroup.nc4.h5"


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:
- This PR attempts to address the failures that arise in on github workflows, for example :
```python
for name, variable in variables.items():
            for dim in variable["dims"]:
                if dim in variables.items():
                    variable["shape"] += (variables[dim]["size"],)
                else:
>                   variable["shape"] += (named_dimensions[dim],)
                                          ^^^^^^^^^^^^^^^^^^^^^
E                   KeyError: '/SLP/'

src/pydap/parsers/dmr.py:274: KeyError
=========================== short test summary info ============================
FAILED src/pydap/tests/test_lib.py::test_get_batch_data_sliced_nondims[[http://test.opendap.org/opendap/dap4/SimpleGroup.nc4.h5-/SimpleGroup-/SimpleGroup/Salinity-Temperature-key3-/SimpleGroup/Salinity[0:1:0][0:1:39][0:1:39]-expected_shape3](http://test.opendap.org/opendap/dap4/SimpleGroup.nc4.h5-/SimpleGroup-/SimpleGroup/Salinity-Temperature-key3-/SimpleGroup/Salinity[0:1:0[0:1:39][0:1:39]-expected_shape3])] - KeyError: '/SLP/'
============= 1 failed, 528 passed, 25 skipped in 93.35s (0:01:33) =============
``` 

The problem is in that KeyError is that `SLP` is NOT a variable in the `SimpleGroup` test file, but it is on the Climatology test file. THis is an odd problem...
