### PR TITLE
Update documentation

### DIFF
--- a/docs/en/_toc.yml
+++ b/docs/en/_toc.yml
@@ -16,10 +16,12 @@ parts:
   - file: notebooks/Authentication
     sections:
     - file: notebooks/netrc
+  - file: notebooks/GetCMRURLS
   - file: notebooks/ECCO
   - file: notebooks/PACE
   - file: notebooks/SWOT
   - file: notebooks/CMIP6
+  - file: notebooks/MERRA2
 - caption: Frequently Asked Questions
   chapters:
   - file: faqs/faqs

--- a/docs/en/notebooks/GetCMRURLS.ipynb
+++ b/docs/en/notebooks/GetCMRURLS.ipynb
@@ -1,0 +1,209 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b0d61b63-a776-4e09-9437-ac2cf5170e26",
+   "metadata": {},
+   "source": [
+    "# Discovering OPeNDAP URLs from NASA's Earthdata\n",
+    "\n",
+    "This tutorial demonstrates how to find OPeNDAP URLs from the [Common Metadata Repository](https://cmr.earthdata.nasa.gov/search) (CMR). The CMR is NASA's Earthdata API to query datasets available through many download and subset services, including OPeNDAP. The [CMR API](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html) is complex and broad on its scope, but PyDAP contains a new module called `get_cmr_urls` that enables users to query and retrieve OPeNDAP urls.\n",
+    "\n",
+    "**Requirements to run this notebook**\n",
+    "1. Have an Earth Data Login account\n",
+    "2. Knowledge of the Collection Concept ID (CCID), or Digital Object Identifier (DOI) of the collection of interest. \n",
+    "\n",
+    "NOTE: A collection in NASA's perspective is a dataset (this, as opposed to a granule which can be thought of as an individual file and, all in aggregation describe the collection). And so the CCID or DOI are unique identifiers to that archive dataset.\n",
+    "\n",
+    "**Objectives**\n",
+    " \n",
+    "Use [PyDAP](https://pydap.github.io/pydap/) to **discover all opendap urls in two simple case studies**\n",
+    "\n",
+    "1. Discover all possible OPeNDAP urls associated with a specific Collection Concept ID (and DOI).\n",
+    "2. Discover all possible OPeNDAP urls from a collection, that **match a time range and spatial bounding box of interest**. These parameters, and others, are widely used by the CMR (and Earthdata search) to filter the number of possible returns from querying the CMR, therefore narrowing the search.\n",
+    "\n",
+    "\n",
+    "`Author`: Miguel Jimenez-Urias, '25"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36c372c7-13b7-496c-91db-cf4780e5943a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydap.client import get_cmr_urls\n",
+    "import pydap\n",
+    "import datetime as dt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da8b82a4-7198-4f5b-a6d5-6df9b9cc669e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"pydap version: \", pydap.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a11ddf3e-fd01-41bf-865d-870fcb237f92",
+   "metadata": {},
+   "source": [
+    "## 1) Discoverying daily, 4km cholophyll data from PACE (Level 3)\n",
+    "\n",
+    "In this example, we are interested in retrieving ALL Granule URLs from OPeNDAP, associated with a collection from PACE. For this collection, the CMR returns various versions of the data\n",
+    "\n",
+    "- Gridded Chlorophyll A\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00e3175f-bc30-421e-b4c4-b07a1cfd9fb4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Pace_doi = \"10.5067/PACE/OCI/L3M/CHL/3.0\" # DOI for this specific collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d6db877-e8c4-4af7-8e84-4162f9338a3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = get_cmr_urls(doi=Pace_doi, limit=1000) # limit by default = 50"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97de65dd-3809-4cc7-bfc8-9e9872c0b3fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "734a67f4-bd08-4f90-897f-8ca6f43b9371",
+   "metadata": {},
+   "source": [
+    "### Identify the granules of interest\n",
+    "Not all urls above can be aggregated into a single collection. These describe the same variables, interpolated over different time ranges. We want daily data at 4kmn resolution. This information is encoded into the URL. We can use a list comprehension to further filter our results.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "127dcfe9-fe58-40a6-aa93-86ae9a46178d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pace_urls = [url for url in urls if '4km' in url and \"DAY\" in url]\n",
+    "pace_urls[:4]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01904ec1-8899-466f-8c4f-6063f71c2d68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"We found \", len(pace_urls), \" relevant OPeNDAP urls from PACE\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8acd0726-30a1-43bc-b6f5-42598f247b89",
+   "metadata": {},
+   "source": [
+    "## 2) Accessing swath data from ECOSTRESS (Level 2 data)\n",
+    "\n",
+    "In this example, we will filter the CMR result to only return granules URLs that have data in a specific area of interest. \n",
+    "\n",
+    "- Land Surface Temperature\n",
+    "- Swath of data during the period of March 2025, in a bounding box defined below:\n",
+    "\n",
+    "```python\n",
+    "bounding_box = [-128.847656,41.112469,-107.050781,46.679594]\n",
+    "```\n",
+    "\n",
+    "```{note}\n",
+    "You can use a web application, such as [bbox finder](http://bboxfinder.com), [geojson](https://geojson.io), or [Earthdata Search](https://search.earthdata.nasa.gov) to construct polygons. Note that the CMR API requires, in the case of a bounding box, the following pattern: [West_Longitude, South_Latitude, East_Longitude, North_Latitude]\n",
+    "```\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e39cf2a0-1abe-4884-ab11-4c6c24ee3df5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ECOSTRESS_ccid = \"C2076114664-LPCLOUD\"\n",
+    "bounding_box = [-128.847656,41.112469,-107.050781,46.679594]\n",
+    "time_range = [dt.datetime(2025, 3, 1), dt.datetime(2025, 3, 31)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05feecf2-f544-40e9-b51a-26c3bec3b992",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = get_cmr_urls(ccid=ECOSTRESS_ccid, bounding_box=bounding_box, time_range=time_range, limit=500)\n",
+    "print(\"Found \", len(urls), \"relevant opendap urls for ECOSTRESS data\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90f06b1e-eebb-4a1f-8c5e-3180577f3e45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls[:6]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe6f4670-33f0-4539-9e62-f870f6e8d827",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/en/notebooks/MERRA2.ipynb
+++ b/docs/en/notebooks/MERRA2.ipynb
@@ -1,0 +1,57 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "91ff2edf-9dd2-47e2-943c-3fd616014ce5",
+   "metadata": {},
+   "source": [
+    "# Accessing MERRA-2 Data via OPeNDAP \n",
+    "\n",
+    "**Requirements to run this notebook**\n",
+    "\n",
+    "1. Have an Earth Data Login account\n",
+    "2. Preferred method of authentication.\n",
+    "\n",
+    "**Objectives**\n",
+    " \n",
+    "Use best practices from OPeNDAP, [pydap](https://pydap.github.io/pydap/), and xarray, to\n",
+    "\n",
+    "- Discover all OPeNDAP URLs associated with a MERRA-2 collection.\n",
+    "- \n",
+    "\n",
+    "\n",
+    "\n",
+    "`Author`: Miguel Jimenez-Urias, '25"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f7498eb-4a64-43a5-b915-3ae56ae4d758",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request: Closes #568 by improving the following documentation:

- [x] Adds a new tutorial demonstrating how to search for granules and opendap urls from the CMR records.
- [ ] How to use consolidate metadata to create a single, metadata (sqlite) cache object that can be reused, and the different use cases [pydap specific, but performance gain on xarray end]. Demonstrate two cases:
  - [ ] MERRA 2: Dimensions, coordinates may be different.
  - [ ] ECCOv4: Dimensions and coordinates are different.
- [ ] Add an "earthaccess interoperability" that demonstrate how to create a session that inherits EDL token credentials (hides abstraction) [pydap end]
- [ ] Create collection level databases, add them into a directory (e.g. Datasets) in the documentation, and use them for tutorials demonstrating workflows (spatial,temporal selections) that download data as efficiently as possible.
- [ ] A new release note that describes performance boost enabled by the new changes in pydap, and pydap's backend in xarray (last one still not merged).
- [ ] Add performance benchmark with all new changes to the [Why Pydap intro](https://pydap.github.io/pydap/en/intro.html#why-pydap) section. Split it into two parts:
  - [ ] Metadata (consolidation vs no consolidation)
  - [ ] Download (via xarray). Chunking, batch=True | False.
