### PR TITLE
use `GET` instead of shared session

### DIFF
--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -262,11 +262,10 @@ def consolidate_metadata(
         url + ".dmr" if "?" not in url else url.replace("?", ".dmr?") for url in URLs
     ]
     if safe_mode:
-        with session as _Session:  # Authenticate once
-            with ThreadPoolExecutor(max_workers=ncores) as executor:
-                results = list(
-                    executor.map(lambda url: open_dmr(url, session=_Session), dmr_urls)
-                )
+        with ThreadPoolExecutor(max_workers=ncores) as executor:
+            results = list(
+                executor.map(lambda url: open_dmr(url, session=session), dmr_urls)
+            )
         _dim_check = list(results[0].dimensions)
         if not all(d == _dim_check for d in [list(ds.dimensions) for ds in results]):
             warnings.warn(
@@ -483,7 +482,7 @@ def open_dmr(path, session=None):
         if session is None:
             session = create_session()
         try:
-            r = session.get(path)
+            r = GET(path, session=session)
         except (ConnectionError, SSLError) as e:
             parsed = urlparse(path)
             if parsed.scheme == "https":

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -525,7 +525,7 @@ class BaseProxyDap4(BaseProxyDap2):
 
         if (
             isinstance(self.session, requests_cache.CachedSession)
-            and self.session.cache.cache_name != "debug"
+            and "debug" not in self.session.cache.cache_name
         ):
             cache_kwargs = {"skip": True}
         else:

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -489,7 +489,7 @@ def test_cached_consolidate_metadata_matching_dims(cache_tmp_dir, urls, safe_mod
     """
     cached_session = create_session(
         use_cache=True,
-        cache_kwargs={"backend": "memory", "cache_name": cache_tmp_dir / "test3"},
+        cache_kwargs={"cache_name": cache_tmp_dir / "test3"},
     )
     cached_session.cache.clear()
     pyds = open_dmr(urls[0].replace("dap4", "http") + ".dmr")
@@ -537,7 +537,7 @@ def test_cached_consolidate_metadata_inconsistent_dims(cache_tmp_dir, urls, safe
     """
     cached_session = create_session(
         use_cache=True,
-        cache_kwargs={"backend": "memory", "cache_name": cache_tmp_dir / "test4"},
+        cache_kwargs={"cache_name": cache_tmp_dir / "test4"},
     )
     cached_session.cache.clear()
     pyds = open_dmr(urls[0].replace("dap4", "http") + ".dmr")
@@ -582,7 +582,7 @@ def test_consolidate_metadata_concat_dim(cache_tmp_dir, urls, concat_dim):
     """
     cached_session = create_session(
         use_cache=True,
-        cache_kwargs={"backend": "memory", "cache_name": cache_tmp_dir / "test5"},
+        cache_kwargs={"cache_name": cache_tmp_dir / "test5"},
     )
     cached_session.cache.clear()
     # download all dmr for testing - not most performant
@@ -709,7 +709,7 @@ def test_patch_session_for_shared_dap_cache(cache_tmp_dir, urls):
     # Clear any existing cache
     my_session = create_session(
         use_cache=True,
-        cache_kwargs={"cache_name": cache_tmp_dir / "test_debug", "backend": "memory"},
+        cache_kwargs={"cache_name": cache_tmp_dir / "test_debug"},
     )
     my_session.cache.clear()
     # Create custom cache key for each of the dimensions
@@ -938,7 +938,8 @@ bbox2 = "bounding_box%5B%5D=-11%2C-6%2C11%2C6"
 def test_get_cmr_urls(cache_tmp_dir, param, expected):
     """Test that get_cmr_urls returns the correct urls."""
     session = create_session(
-        use_cache=True, cache_kwargs={"backend": cache_tmp_dir / "memory"}
+        use_cache=True,
+        cache_kwargs={"cache_name": cache_tmp_dir / "debug_get_cmr_urls"},
     )
     session.cache.clear()
     cmr_urls = get_cmr_urls(**param, session=session)


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes #571 
- [x] Some tests were modified to use the default backend of requests_cache: `sqlite3` further proof caching works as it should with `sqlite3`.

This now again works smoothly (database construction) 
```python
consolidate_metadata(urls, concat_dim='time', session=session)
```
where len(urls)=217. It took 1 min and 30 secs. It downloaded ~400 urls (mostly all dmrs).
And now
```python
ds = xr.open_mfdataset(
    urls,
    engine='pydap',
    session=session, # reuse database as session
    parallel=True,
    combine='nested',
    concat_dim='time',
)
```
Takes ~ 2-5 sec every time, all or it parsing and reusing the database. There is no longer any download at this point.

Without `consolidate_metadata` it took 40 minutes before a TimeOut Error (never completed), during which time it requested upwards ~ 1500 requests, the vast majority of which were individual dap responses (repeated / identical dimensions, one per granule)