### PR TITLE
Enable batch=False|True when consolidating metadata

### DIFF
--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -455,6 +455,29 @@ def consolidate_metadata(
                 concat_dim=concat_dim,
                 url_list=URLs,
             )
+            if results[0].dimensions[concat_dim[0]] > 1:
+                size = results[0].dimensions[concat_dim[0]] - 1
+                add_urls = [
+                    url.split("?")[0]
+                    + ".dap?dap4.ce=/"
+                    + concat_dim[0]
+                    + "%5B0:1:0%5D"
+                    + _check
+                    for url in URLs
+                ]
+                add_urls += [
+                    url.split("?")[0]
+                    + ".dap?dap4.ce=/"
+                    + concat_dim[0]
+                    + "%5B"
+                    + str(size)
+                    + ":1:"
+                    + str(size)
+                    + "%5D"
+                    + _check
+                    for url in URLs
+                ]
+                new_urls += add_urls
             session.settings.key_fn = key_fn
         _ = download_all_urls(session, new_urls, ncores=ncores)
     return None

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -277,8 +277,11 @@ def consolidate_metadata(
             results = list(
                 executor.map(lambda url: open_dmr(url, session=session), dmr_urls)
             )
-        _dim_check = results[0].dimensions
-        if not all(d == _dim_check for d in [ds.dimensions for ds in results]):
+        _dim_check = {k: v for k, v in results[0].dimensions.items() if k != concat_dim}
+        if not all(
+            {k: v for k, v in d.dimensions.items() if k != concat_dim} == _dim_check
+            for d in results
+        ):
             warnings.warn(
                 "The dimensions of the datasets are not identical across all datasets"
                 ". Please check the URLs and try again."

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -348,21 +348,35 @@ def consolidate_metadata(
         concat_dim_urls = []
 
     # check for named dimensions
-    pyds = open_url(dmr_urls[0], session=session, protocol="dap4", batch=False)
+    pyds = open_url(dmr_urls[0], session=session, protocol="dap4")
     var_names = list(pyds.variables())
     new_dims = set.intersection(dims, var_names)
     named_dims = set.difference(dims, new_dims)
     dims = sorted(list(new_dims))
 
-    constrains_dims = [
-        dim + "%5B0%3A1%3A" + str(results[0].dimensions[dim] - 1) + "%5D"
-        for dim in dims
-        if dim != concat_dim
-    ]
-    if len(constrains_dims) > 0:
-        new_urls = [base_url + ".dap?dap4.ce=" + "%3B".join(constrains_dims) + _check]
+    if batch:
+        constrains_dims = [
+            dim + "%5B0%3A1%3A" + str(results[0].dimensions[dim] - 1) + "%5D"
+            for dim in dims
+            if dim != concat_dim
+        ]
+        if len(constrains_dims) > 0:
+            new_urls = [
+                base_url + ".dap?dap4.ce=" + "%3B".join(constrains_dims) + _check
+            ]
+        else:
+            new_urls = []
     else:
-        new_urls = []
+        new_urls = [
+            base_url
+            + ".dap?dap4.ce="
+            + dim
+            + "%5B0%3A1%3A"
+            + str(results[0].dimensions[dim] - 1)
+            + "%5D"
+            + _check
+            for dim in dims
+        ]
     new_urls.extend(concat_dim_urls)
     dim_ces = set(
         [

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -188,6 +188,7 @@ def consolidate_metadata(
     verbose=False,
     shared_dimensions=False,
     checksums=True,
+    batch=False,
 ):
     """Consolidates the metadata of a collection of OPeNDAP DAP4 URLs belonging to
     data cube, i.e. urls share identical variables and dimensions. This is done
@@ -228,7 +229,13 @@ def consolidate_metadata(
     verbose: bool, optional (default=False)
         For debugging purposes. If `True`, prints various URLs, normalized
         cache-keys, and other information.
-
+    checksums: bool, optional (default=True)
+        Whether to request checksums in the DAP4 request. This is currently
+        required for ALL NASA datasets, but will be optional in a future release.
+    batch: bool (default: False)
+        Whether to enable batch mode when downloading the dap responses. When False,
+        each dimension of a granule is downloaded with a separate dap response. When
+        True, all dimensions are downloaded with a single dap response.
     """
 
     if not isinstance(session, CachedSession):

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -455,7 +455,7 @@ def consolidate_metadata(
                 concat_dim=concat_dim,
                 url_list=URLs,
             )
-            if results[0].dimensions[concat_dim[0]] > 1:
+            if concat_dim and results[0].dimensions[concat_dim[0]] > 1:
                 size = results[0].dimensions[concat_dim[0]] - 1
                 add_urls = [
                     url.split("?")[0]

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -332,8 +332,8 @@ def consolidate_metadata(
         with session as Session:
             _ = download_all_urls(Session, shared_dimension_urls, ncores=ncores)
         return shared_dimension_urls
-    if concat_dim:
-        session.headers["consolidated"] = "True"
+
+    session.headers["consolidated"] = "True"
 
     if concat_dim and isinstance(concat_dim, str):
         concat_dim = [concat_dim]

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -277,11 +277,11 @@ def consolidate_metadata(
             results = list(
                 executor.map(lambda url: open_dmr(url, session=session), dmr_urls)
             )
-        _dim_check = list(results[0].dimensions)
-        if not all(d == _dim_check for d in [list(ds.dimensions) for ds in results]):
+        _dim_check = results[0].dimensions
+        if not all(d == _dim_check for d in [ds.dimensions for ds in results]):
             warnings.warn(
-                "The dimensions of the datasets are not identical across all remote "
-                "dataset. Please check the URLs and try again."
+                "The dimensions of the datasets are not identical across all datasets"
+                ". Please check the URLs and try again."
             )
             return None
     else:

--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -400,6 +400,8 @@ def build_session(
     if isinstance(base_session, CachedSession):
 
         s: requests.Session = new_session_with_same_store(base_session, **cache_kwargs)
+        if base_session.settings.key_fn:
+            s.settings.key_fn = base_session.settings.key_fn
     else:
         s = requests.Session(**session_kwargs)
 

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -1323,3 +1323,26 @@ def test_data_check(var_batch, key_batch, var_name, var_key, expected_shape):
     data = data_check(var, var_key)
 
     assert data.shape == expected_shape
+
+
+def test_consolidate_metadata_non_batch(cache_tmp_dir):
+    """Test that consolidate_metadata raises an error when batch=False"""
+    urls = [
+        "dap4://test.opendap.org/opendap/hyrax/data/nc/coads_climatology.nc",
+        "dap4://test.opendap.org/opendap/hyrax/data/nc/coads_climatology2.nc",
+    ]
+    cache_name = cache_tmp_dir / "test_consolidate_metadata_non_batch"
+    cached_session = create_session(
+        use_cache=True,
+        cache_kwargs={"cache_name": cache_name},
+    )
+    cached_session.cache.clear()
+    consolidate_metadata(
+        urls,
+        session=cached_session,
+        concat_dim="TIME",
+        batch=False,
+    )
+
+    assert cached_session.settings.key_fn._concat_dim == ["TIME"]
+    assert cached_session.settings.key_fn._collapse_vars == {"COADSX", "COADSY"}

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -1348,6 +1348,26 @@ def test_consolidate_metadata_non_batch(cache_tmp_dir):
     assert cached_session.settings.key_fn._collapse_vars == {"COADSX", "COADSY"}
 
     N = len(urls)  # N of DMRS
-    N_repeated_dims = 2  # COADSX, COADSY
+    N_non_concat_dims = 2  # COADSX, COADSY
     N_concat_dims = len(urls)  # TIME
-    assert len(cached_session.cache.urls()) == N + N_repeated_dims + N_concat_dims
+    assert len(cached_session.cache.urls()) == N + N_non_concat_dims + N_concat_dims
+
+    # ============ ONLY WORKS FOR CLOUD OPENDAP URLS - SKIPPED FOR NOW
+    # # check that all URLS from COADSX and COADSY are cached, even when only 1 of each
+    # # was downloaded
+    # map1 = _quote("/COADSX[0:1:179]").replace("/", "%2F")
+    # map2 = _quote("/COADSY[0:1:89]").replace("/", "%2F")
+
+    # dap_urls = [
+    #     url.replace("dap4", "https") + ".dap?dap4.ce=" + map1 + "&dap4.checksum=true"
+    #     for url in urls
+    # ]
+    # dap_urls += [
+    #     url.replace("dap4", "https") + ".dap?dap4.ce=" + map2 + "&dap4.checksum=true"
+    #     for url in urls
+    # ]
+
+    # for url in dap_urls:
+    #     if url not in cached_session.cache.urls():
+    #         r = cached_session.get(url)
+    #         assert r.from_cache

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -1370,3 +1370,28 @@ def test_consolidate_metadata_non_batch(cache_tmp_dir):
         if url not in cached_session.cache.urls():
             r = cached_session.get(url)
             assert r.from_cache
+
+
+def test_consolidate_non_matching_dims(cache_tmp_dir):
+    """Test that consolidate warns when dmrs have non matching dimensions"""
+    urls = [
+        "dap4://test.opendap.org/opendap/hyrax/data/nc/coads_climatology.nc",
+        "dap4://test.opendap.org/opendap/dap4/SimpleGroup.nc4.h5",
+    ]
+    cache_name = cache_tmp_dir / "test_consolidate_non_matching_dims"
+    cached_session = create_session(
+        use_cache=True,
+        cache_kwargs={"cache_name": cache_name},
+    )
+    cached_session.cache.clear()
+    with pytest.warns(
+        UserWarning,
+        match="The dimensions of the datasets are not identical across all datasets",
+    ):
+        consolidate_metadata(
+            urls,
+            session=cached_session,
+            concat_dim="TIME",
+        )
+    assert "consolidated" not in cached_session.headers
+    cached_session.cache.clear()

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -1346,3 +1346,8 @@ def test_consolidate_metadata_non_batch(cache_tmp_dir):
 
     assert cached_session.settings.key_fn._concat_dim == ["TIME"]
     assert cached_session.settings.key_fn._collapse_vars == {"COADSX", "COADSY"}
+
+    N = len(urls)  # N of DMRS
+    N_repeated_dims = 2  # COADSX, COADSY
+    N_concat_dims = len(urls)  # TIME
+    assert len(cached_session.cache.urls()) == N + N_repeated_dims + N_concat_dims

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -463,6 +463,7 @@ def test_warning_nondap4urls_consolidate_metadata(cache_tmp_dir, urls):
 # @pytest.mark.skipif(
 #     os.getenv("LOCAL_DEV") != "1", reason="This test only runs on local development"
 # )
+@pytest.mark.parametrize("batch", [True])
 @pytest.mark.parametrize(
     "urls",
     [
@@ -476,7 +477,9 @@ def test_warning_nondap4urls_consolidate_metadata(cache_tmp_dir, urls):
     ],
 )
 @pytest.mark.parametrize("safe_mode", [True])
-def test_cached_consolidate_metadata_matching_dims(cache_tmp_dir, urls, safe_mode):
+def test_cached_consolidate_metadata_matching_dims(
+    cache_tmp_dir, urls, safe_mode, batch
+):
     """Test the behavior of the chaching implemented in `consolidate_metadata`.
     the `safe_mode` parameter means that all dmr urls are cached, and
     the dimensions of each dmr_url are checked for consistency.
@@ -494,7 +497,7 @@ def test_cached_consolidate_metadata_matching_dims(cache_tmp_dir, urls, safe_mod
     cached_session.cache.clear()
     pyds = open_dmr(urls[0].replace("dap4", "http") + ".dmr")
     dims = sorted(list(pyds.dimensions))  # dimensions of full dataset
-    consolidate_metadata(urls, session=cached_session, safe_mode=safe_mode)
+    consolidate_metadata(urls, session=cached_session, safe_mode=safe_mode, batch=batch)
 
     # check that the cached session has all the dmr urls and
     # caches the dap response of the dimensions only once
@@ -511,6 +514,7 @@ def test_cached_consolidate_metadata_matching_dims(cache_tmp_dir, urls, safe_mod
     cached_session.cache.clear()
 
 
+@pytest.mark.parametrize("batch", [True])
 @pytest.mark.parametrize(
     "urls",
     [
@@ -524,7 +528,9 @@ def test_cached_consolidate_metadata_matching_dims(cache_tmp_dir, urls, safe_mod
     ],
 )
 @pytest.mark.parametrize("safe_mode", [True])
-def test_cached_consolidate_metadata_inconsistent_dims(cache_tmp_dir, urls, safe_mode):
+def test_cached_consolidate_metadata_inconsistent_dims(
+    cache_tmp_dir, urls, safe_mode, batch
+):
     """Test the behavior of the chaching implemented in `consolidate_metadata`.
     the `safe_mode` parameter means that all dmr urls are cached, and
     the dimensions of each dmr_url are checked for consistency.
@@ -544,11 +550,15 @@ def test_cached_consolidate_metadata_inconsistent_dims(cache_tmp_dir, urls, safe
     dims = list(pyds.dimensions)  # here there are 3 dimensions
     if safe_mode:
         with pytest.warns(UserWarning):
-            consolidate_metadata(urls, session=cached_session, safe_mode=safe_mode)
+            consolidate_metadata(
+                urls, session=cached_session, safe_mode=safe_mode, batch=batch
+            )
         assert len(cached_session.cache.urls()) == len(urls)
         # dmrs where cached, but not the dimensions
     else:
-        consolidate_metadata(urls, session=cached_session, safe_mode=safe_mode)
+        consolidate_metadata(
+            urls, session=cached_session, safe_mode=safe_mode, batch=batch
+        )
         # caches all DMRs and caches the dap responses of the dimensions
         # of the first URL
         assert len(cached_session.cache.urls()) == len(urls) + len(dims)
@@ -558,6 +568,7 @@ def test_cached_consolidate_metadata_inconsistent_dims(cache_tmp_dir, urls, safe
 # @pytest.mark.skipif(
 #     os.getenv("LOCAL_DEV") != "1", reason="This test only runs on local development"
 # )
+@pytest.mark.parametrize("batch", [True])
 @pytest.mark.parametrize(
     "urls",
     [
@@ -568,7 +579,7 @@ def test_cached_consolidate_metadata_inconsistent_dims(cache_tmp_dir, urls, safe
     ],
 )
 @pytest.mark.parametrize("concat_dim", [None, "TIME"])
-def test_consolidate_metadata_concat_dim(cache_tmp_dir, urls, concat_dim):
+def test_consolidate_metadata_concat_dim(cache_tmp_dir, urls, concat_dim, batch):
     """Test the behavior of the chaching implemented in `consolidate_metadata`
     when there is a concat dimension, and (extra) this concat_dim may be an array
     of length >= 1.
@@ -587,7 +598,11 @@ def test_consolidate_metadata_concat_dim(cache_tmp_dir, urls, concat_dim):
     cached_session.cache.clear()
     # download all dmr for testing - not most performant
     consolidate_metadata(
-        urls, session=cached_session, safe_mode=True, concat_dim=concat_dim
+        urls,
+        session=cached_session,
+        safe_mode=True,
+        concat_dim=concat_dim,
+        batch=batch,
     )
 
     N_dmr_urls = len(urls)  # Since `safe_mode=False`, only 1 DMR is downloaded

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -1349,7 +1349,7 @@ def test_consolidate_metadata_non_batch(cache_tmp_dir):
 
     N = len(urls)  # N of DMRS
     N_non_concat_dims = 2  # COADSX, COADSY
-    N_concat_dims = len(urls)  # TIME
+    N_concat_dims = 3*len(urls)  # TIME
     assert len(cached_session.cache.urls()) == N + N_non_concat_dims + N_concat_dims
 
     # check that all URLS from COADSX and COADSY are cached, even when only 1 of each

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -1349,7 +1349,7 @@ def test_consolidate_metadata_non_batch(cache_tmp_dir):
 
     N = len(urls)  # N of DMRS
     N_non_concat_dims = 2  # COADSX, COADSY
-    N_concat_dims = 3*len(urls)  # TIME
+    N_concat_dims = 3 * len(urls)  # TIME
     assert len(cached_session.cache.urls()) == N + N_non_concat_dims + N_concat_dims
 
     # check that all URLS from COADSX and COADSY are cached, even when only 1 of each

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -1352,22 +1352,21 @@ def test_consolidate_metadata_non_batch(cache_tmp_dir):
     N_concat_dims = len(urls)  # TIME
     assert len(cached_session.cache.urls()) == N + N_non_concat_dims + N_concat_dims
 
-    # ============ ONLY WORKS FOR CLOUD OPENDAP URLS - SKIPPED FOR NOW
-    # # check that all URLS from COADSX and COADSY are cached, even when only 1 of each
-    # # was downloaded
-    # map1 = _quote("/COADSX[0:1:179]").replace("/", "%2F")
-    # map2 = _quote("/COADSY[0:1:89]").replace("/", "%2F")
+    # check that all URLS from COADSX and COADSY are cached, even when only 1 of each
+    # was downloaded
+    map1 = _quote("/COADSX[0:1:179]").replace("/", "%2F")
+    map2 = _quote("/COADSY[0:1:89]").replace("/", "%2F")
 
-    # dap_urls = [
-    #     url.replace("dap4", "https") + ".dap?dap4.ce=" + map1 + "&dap4.checksum=true"
-    #     for url in urls
-    # ]
-    # dap_urls += [
-    #     url.replace("dap4", "https") + ".dap?dap4.ce=" + map2 + "&dap4.checksum=true"
-    #     for url in urls
-    # ]
+    dap_urls = [
+        url.replace("dap4", "http") + ".dap?dap4.ce=" + map1 + "&dap4.checksum=true"
+        for url in urls
+    ]
+    dap_urls += [
+        url.replace("dap4", "http") + ".dap?dap4.ce=" + map2 + "&dap4.checksum=true"
+        for url in urls
+    ]
 
-    # for url in dap_urls:
-    #     if url not in cached_session.cache.urls():
-    #         r = cached_session.get(url)
-    #         assert r.from_cache
+    for url in dap_urls:
+        if url not in cached_session.cache.urls():
+            r = cached_session.get(url)
+            assert r.from_cache


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes #573 , setting batch=False as default (until the PR on xarray is merged, this is the alternative).
- [x] Closes #575  
- [x] Tests are added to demonstrate the new or fixed behavior, and all tests pass
on a local environment.


@jgallagher59701  Ready for review. The following example works well:

### example

consider the following list of dap4 urls of the form
```python
dap4://opendap.earthdata.nasa.gov/providers/POCLOUD/collections/ECCO%20Ocean%20Temperature%20and%20Salinity%20-%20Monthly%20Mean%20llc90%20Grid%20(Version%204%20Release%204)/granules/OCEAN_TEMPERATURE_SALINITY_mon_mean_1999-12_ECCO_V4r4_native_llc0090?dap4.ce=/THETA;/SALT;/k;/tile;/j;/i;/time
```
This granule has 5 dimension, and consider the case where I want to aggregate a list of 217 such granules along the time dimension. So URLS is a list of 217 elements


```python
%%time
consolidate_metadata(URLs, concat_dim='time', session=session) # batch=False by default
>>> CPU times: user 2.66 s, sys: 955 ms, total: 3.62 s
Wall time: 34.1 s
```
It downloads all dms, the time dimension for each granule, and the rest of the dimensions but for only a single granule . These are:
```
non_concat_dims = ['tile', 'k', 'i', 'j']
```

NOTE that `batch=False` implies that each dimension gets its own dap request.




Now, I use xarray to aggregated these in parallel:
```python
%%time
ds = xr.open_mfdataset(
    Temp_2017,
    engine='pydap',
    session=session,
    parallel=True,
    combine='nested',
    concat_dim='time',
)
>>> CPU times: user 7.58 s, sys: 1.25 s, total: 8.83 s
Wall time: 32.6 s
```

<img width="906" height="416" alt="Screenshot 2025-10-01 at 11 10 21 PM" src="https://github.com/user-attachments/assets/7b362776-30f0-4589-8513-38d961e5d78a" />




This means that `session`, which is a CachedSession object correctly uses the cache_key generated in `consolidate_metadata`, to avoid repeated data N times.

