### PR TITLE
get_cmr url: enable seaching using version and shortname

### DIFF
--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -885,7 +885,9 @@ def patch_session_for_shared_dap_cache(
 def get_cmr_urls(
     ccid=None,
     doi=None,
+    short_name: str | None = None,
     time_range=None,
+    version: str | None = None,
     bounding_box: list | dict | None = None,
     point: list | dict | None = None,
     polygon: list | dict | None = None,
@@ -929,12 +931,21 @@ def get_cmr_urls(
         doi : str
             The DOI of the collection to search for. This is an alternative to using
             the ccid parameter.
+        short_name : str | None
+            The short name of the collection to search for. This is an alternative to
+            using the ccid or doi parameter.
+            If multiple of ccid, doi, and short_name are provided, ccid is used,
+            then doi, then short_name.
         time_range : list | None
             The time range to filter by. The time range is a list of two elements,
             each element a datetime.datetime object, of a string in the format
             YYYY-MM-DDTHH:MM:SSZ.
             Example1: ["2023-01-01T00:00:00Z", "2023-12-31T23:59:59Z"]
             Example2: [datetime.datetime(2023, 1, 1), datetime.datetime(2023, 12, 31)]
+
+        version : str | None
+            The version of the collection to search for. If None, the latest version
+            is used.
 
         bounding_box : list | dict | None
             The bounding box to filter by, in the format [west, south, east, north].
@@ -1025,6 +1036,12 @@ def get_cmr_urls(
     if doi:
         doisearch = "https://cmr.earthdata.nasa.gov/search/collections.json?doi=" + doi
         ccid = session.get(doisearch).json()["feed"]["entry"][0]["id"]
+
+    if short_name and not version:
+        raise ValueError(
+            "Both `short_name` and `version` must be provided together to identify a "
+            "specific collection."
+        )
 
     params["concept_id"] = ccid
 

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -1025,7 +1025,7 @@ def get_cmr_urls(
     """
 
     if not ccid and not doi:
-        if not short_name and not version:
+        if not (short_name and version):
             raise ValueError(
                 "Either `ccid`, `doi`, or `short_name` and `version` must be provided."
             )
@@ -1042,7 +1042,7 @@ def get_cmr_urls(
         doisearch = "https://cmr.earthdata.nasa.gov/search/collections.json?doi=" + doi
         ccid = session.get(doisearch).json()["feed"]["entry"][0]["id"]
 
-    if short_name and not version or (version and not short_name):
+    if not (short_name and version):
         raise ValueError(
             "Both `short_name` and `version` must be provided together to identify a "
             "specific collection."

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -883,11 +883,11 @@ def patch_session_for_shared_dap_cache(
 
 
 def get_cmr_urls(
-    ccid=None,
+    ccid: str | None = None,
     doi: str | None = None,
-    short_name: list | int | None = None,
+    short_name: str | None = None,
     time_range: list | None = None,
-    version: str | None = None,
+    version: list | str | None = None,
     bounding_box: list | dict | None = None,
     point: list | dict | None = None,
     polygon: list | dict | None = None,

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -978,6 +978,17 @@ def test_get_cmr_urls(cache_tmp_dir, param, expected):
     session.cache.clear()
 
 
+def test_error_get_cmr_urls():
+    """Test that get_cmr_urls raises an error when no concept_id, no doi, and only
+    one of short_name and version is provided."""
+    with pytest.raises(ValueError):
+        get_cmr_urls()
+    with pytest.raises(ValueError):
+        get_cmr_urls(short_name="MODIS_Aqua_L3_SST")
+    with pytest.raises(ValueError):
+        get_cmr_urls(version="61")
+
+
 @pytest.mark.parametrize("var", ["SST"])
 @pytest.mark.parametrize(
     "slice, expected",


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes #578 
- [x] Tests are added to demonstrate the new or fixed behavior, and all tests pass
on a local environment.

### current behavior
```python
get_cmr_urls(ccid = "concept_collection_id")
# or
get_cmr_urls(doi = "doi_of_collection")
```
### New behavior
In addition to the options below, the following is possible
```python
get_cmr_urls(short_name="short_name_collection", version=["v01", "v02",  "v04"])
```
searches for various versions of the same collection, returning all possible urls. This is nice, because it enables the user to filter a collection based on its version. This is equivalent to searching 3 different collections.

