### PR TITLE
No need to specify user_charset as `encoding` is part of dmr content

### DIFF
--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -1060,7 +1060,7 @@ class UNPACKDAP4DATA(object):
         else:
             dmr = self.raw.read(dmr_length)
             # figure out encoding defined in the xml header
-            match = re.search(br'encoding=["\']([^"\']+)["\']', dmr)
+            match = re.search(rb'encoding=["\']([^"\']+)["\']', dmr)
             if match:
                 encoding = match.group(1).decode("ascii")
             else:


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The change removes a user-defined encoding for decoing  the metadata (dmr) part of the dap binary. This appears to be inherited from the user via `open_url` and used in:

https://github.com/pydap/pydap/blob/87b48b2f4f4a584e283273528e7722c988cebab1/src/pydap/handlers/dap.py#L985-L986

and, importantly

https://github.com/pydap/pydap/blob/87b48b2f4f4a584e283273528e7722c988cebab1/src/pydap/handlers/dap.py#L1061


In dap4 the encoding appears explicit in the header of the response (dmr part of dap). For example:

```python
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
```

and requests can automatically discover encodings from content headers. So, not only it is no longer needed for a user to specify it (in dap4), it can lead to decoding errors when downloading data if the incorrect encoding is used
(see [pydata/xarray/#10879](https://github.com/pydata/xarray/issues/10879) which defaults to `user_charset = 'ascii'`).

It appears

```python
dmr = self.raw.read(dmr_length).decode()
```
works without specifying encoding explicitly. However, a complete solution would be to extract the encoding from the DMR (parse this element from the xml) and use that always, when present (dap4)










