### PR TITLE
Make sure workers are `spawn` as in macos and not `forked` as in Linu…

### DIFF
--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -46,6 +46,7 @@ lazy mechanism for function call, supporting any function. Eg, to call the
 
 import datetime as dt
 import hashlib
+import multiprocessing as mp
 import os
 import re
 import sqlite3
@@ -1291,6 +1292,7 @@ def get_batch_data(array, cache_urls=None, checksums=True, key=None):
                 register_all_for_batch(dataset, Variables, checksums=checksums)
                 fetch_batched(dataset, Variables)
             except KeyError:
+                print(Variables)
                 print(f"Failed to fetch data: {e}")
 
 
@@ -1738,7 +1740,8 @@ def stream_parallel(
     dim_slices=None,
     max_workers=4,
 ):
-    with ProcessPoolExecutor(max_workers=max_workers) as pool:
+    ctx = mp.get_context("spawn")  # <- IMPORTANT on Linux
+    with ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx) as pool:
         futures = [
             pool.submit(
                 stream, url, session_state, output_path, keep_variables, dim_slices


### PR DESCRIPTION
…x systens for running multiple processes with ProcessPoolExecutor

<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Enables streaming, deserializing and storing as nc files multiple dap responses in parallel with pydap in Linux Systems.

### explanation
The issue is that in Linux "ProcessPoolExecutor uses the "fork" start method by default.". On MacOS it uses the spawn method. Pydap when run in MacOS can stream in parallel multiple dap responses and store them as nc files. But in Linux data gets corrupted.

Without this change, in Linux systems the stored data as netcdf files only contain Fill Values. Without this change, the code for streaming dap responses and de-serialize them into netcdf4 files does not works in Linux systems. This changes enables the code to work.


Another alternative is to force (say in a jupyter notebook) this by executing:

```python
import multiprocessing as mp
mp.set_start_method("spawn", force=True)

```






