### PR TITLE
Enable passing `keep_variables` with no `dim_slices` defined

### DIFF
--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -1682,7 +1682,7 @@ def stream(
         ce += ";".join(shared_dim)
 
     if keep_variables is not None:
-        if not set(dim_slices).issubset(keep_variables):
+        if dim_slices and not set(dim_slices).issubset(keep_variables):
             keep_variables += list(set(dim_slices.keys()) - set(keep_variables))
         if dim_slices is not None:
             ce += ";"

--- a/src/pydap/tests/test_client.py
+++ b/src/pydap/tests/test_client.py
@@ -1413,12 +1413,16 @@ def test_consolidate_non_matching_dims(cache_tmp_dir):
     cached_session.cache.clear()
 
 
-def test_stream():
+@pytest.mark.parametrize("dim_slices", [None, {"TIME": (0, 1)}])
+def test_stream(dim_slices):
+    keep_variables = ["TIME", "COADSX", "COADSY", "SST"]
     url = "http://test.opendap.org/opendap/hyrax/data/nc/coads_climatology.nc"
     with tempfile.TemporaryDirectory() as tmp_dir:
         _ = stream(
             url,
             output_path=tmp_dir,
+            keep_variables=keep_variables,
+            dim_slices=dim_slices,
         )
 
 


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes #614 
- [x] Tests are added to demonstrate the new or fixed behavior, and all tests pass
on a local environment.


The following works now

```python
stream(cmr_urls[0], keep_variables=keep_variables)
```
where
