### PR TITLE
Remove warnings about how structures may be escaped/accessed in tree …

### DIFF
--- a/src/pydap/parsers/dmr.py
+++ b/src/pydap/parsers/dmr.py
@@ -336,12 +336,6 @@ def dmr_to_dataset(dmr, flat=True):
             parent_type = variable["parent"]
             if flat:
                 # Flat Access
-                warnings.warn(
-                    f"The remote dataset contains a variable named `{name[1:]}` inside"
-                    f" a `{parent_type}`, and its access is flattened. The variable"
-                    " can be safely accessed by replacing the `dot` in the variable "
-                    "name with `%2E`."
-                )
                 var_kwargs.update({"name": pydap.lib._quote(name)})
             else:
                 parent_name = name.split(".")

--- a/src/pydap/tests/test_open_dap4_url.py
+++ b/src/pydap/tests/test_open_dap4_url.py
@@ -224,9 +224,8 @@ def test_dmrpp_open_dataset():
     ],
 )
 def test_structs_and_sequences_warns(url, var, expected_value):
-    with pytest.warns(UserWarning):
-        pyds = open_url(url)
-        np.testing.assert_array_equal(pyds[var][:].data, expected_value)
+    pyds = open_url(url)
+    np.testing.assert_array_equal(pyds[var][:].data, expected_value)
 
 
 @pytest.mark.parametrize(
@@ -255,8 +254,7 @@ def test_structs_and_sequences_unflat(url, var, ContainerType, val):
 
 def test_sequence_warns():
     url = "dap4://test.opendap.org/opendap/data/ff/avhrr.dat"
-    with pytest.warns(UserWarning):
-        open_url(url, flat=False)
+    open_url(url, flat=False)
 
 
 def tests_structure_unflatted_unescaped(capsys):
@@ -265,8 +263,7 @@ def tests_structure_unflatted_unescaped(capsys):
     This is necessary for improved interoperatbility with Xarray
     """
     url = "dap4://test.opendap.org/opendap/dap4/d4ts/test_struct1.nc.h5"
-    with pytest.warns(UserWarning):
-        pyds = open_url(url)
+    pyds = open_url(url)
     # assert flattened access
     assert repr(pyds) == "<DatasetType with children 's%2Ex', 's%2Ey'>"
     assert pyds.variables() == {


### PR DESCRIPTION
…representation. These are no longer escaped when representing them in tree method

<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Removes Userwarnings when dmr / dataset has structures flattened. This was only necessary so that the user could access them with Xarray. Warnings are no longer needed since #622 
