### PR TITLE
Fix DODS response parsing to tolerate \r\n line endings

### DIFF
--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -627,8 +627,8 @@ def open_dods_url(
     """Open a `.dods` response directly, returning a dataset."""
 
     r = GET(url, application, session, timeout=timeout)
-
-    dds, data = r.body.split(b"\nData:\n", 1)
+    from pydap.handlers.dap import _split_dds_data
+    dds, data = _split_dds_data(r.body)
     dds = dds.decode(r.content_encoding or "ascii")
     dataset = dds_to_dataset(dds)
     stream = StreamReader(BytesIO(data))

--- a/src/pydap/client.py
+++ b/src/pydap/client.py
@@ -628,6 +628,7 @@ def open_dods_url(
 
     r = GET(url, application, session, timeout=timeout)
     from pydap.handlers.dap import _split_dds_data
+
     dds, data = _split_dds_data(r.body)
     dds = dds.decode(r.content_encoding or "ascii")
     dataset = dds_to_dataset(dds)

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -401,6 +401,17 @@ def safe_charset_text(r, user_charset):
             r.charset = get_charset(r, user_charset)
     return r.text
 
+def _split_dds_data(raw):
+    """Split raw DODS bytes into (dds_bytes, data_bytes), tolerating \\r\\n."""
+    sep = b"\nData:\n"
+    idx = raw.find(sep)
+    if idx == -1:
+        sep = b"\nData:\r\n"
+        idx = raw.find(sep)
+    if idx == -1:
+        raise ValueError("Could not find Data separator in DODS response")
+    return raw[:idx], raw[idx + len(sep):]
+
 
 def safe_dds_and_data(r, user_charset):
     """
@@ -915,7 +926,7 @@ def dump():  # pragma: no cover
 
     """
     dods = sys.stdin.read()
-    dds, xdrdata = dods.split(b"\nData:\n", 1)
+    dds, xdrdata = _split_dds_data(dods)
     dataset = dds_to_dataset(dds)
     xdr_stream = io.BytesIO(xdrdata)
     data = unpack_dap2_data(xdr_stream, dataset)

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -401,6 +401,7 @@ def safe_charset_text(r, user_charset):
             r.charset = get_charset(r, user_charset)
     return r.text
 
+
 def _split_dds_data(raw):
     """Split raw DODS bytes into (dds_bytes, data_bytes), tolerating \\r\\n."""
     sep = b"\nData:\n"
@@ -410,7 +411,7 @@ def _split_dds_data(raw):
         idx = raw.find(sep)
     if idx == -1:
         raise ValueError("Could not find Data separator in DODS response")
-    return raw[:idx], raw[idx + len(sep):]
+    return raw[:idx], raw[idx + len(sep) :]
 
 
 def safe_dds_and_data(r, user_charset):


### PR DESCRIPTION
Fix DODS response parsing to tolerate \r\n line endings

The Data separator split in safe_dds_and_data, client.py, and dump()
used a strict b"\nData:\n" split which fails against servers that send
b"\nData:\r\n" (e.g. opendap-protocol). Use a find-based approach that
tries both separators without corrupting the binary data payload.
