### PR TITLE
Include pydap/version as User-Agent in headers when streaming dap responses

### DIFF
--- a/src/pydap/net.py
+++ b/src/pydap/net.py
@@ -485,6 +485,8 @@ def extract_session_state(session):
         backend=None,
         cache_kwargs={},
     )
+    state["headers"].pop("User-Agent", None)
+    state["headers"]["User-Agent"] = "pydap/" + __version__
 
     if isinstance(session, CachedSession):
         cache = session.cache

--- a/src/pydap/tests/test_net.py
+++ b/src/pydap/tests/test_net.py
@@ -14,6 +14,7 @@ from pydap.net import (
     create_request,
     create_session,
     detect_backend,
+    extract_session_state,
     get_response,
     inherit_bearer_header,
 )
@@ -117,3 +118,10 @@ def test_inherit_bearer_header():
     session_no_header = requests.Session()
     inherit_bearer_header(session_no_header, session)
     assert session_no_header.headers == session.headers
+
+
+def test_extract_session_state():
+    session = requests.Session()
+    state = extract_session_state(session)
+    assert "User-Agent" in state["headers"]
+    assert state["headers"]["User-Agent"].startswith("pydap/")

--- a/src/pydap/tests/test_net.py
+++ b/src/pydap/tests/test_net.py
@@ -125,3 +125,8 @@ def test_extract_session_state():
     state = extract_session_state(session)
     assert "User-Agent" in state["headers"]
     assert state["headers"]["User-Agent"].startswith("pydap/")
+
+
+@pytest.mark.parametrize("session", [create_session(), create_session(use_cache=True)])
+def test_pydap_user_agent_headers(session):
+    assert session.headers["User-Agent"].startswith("pydap/")

--- a/src/pydap/tests/test_net.py
+++ b/src/pydap/tests/test_net.py
@@ -127,6 +127,13 @@ def test_extract_session_state():
     assert state["headers"]["User-Agent"].startswith("pydap/")
 
 
-@pytest.mark.parametrize("session", [create_session(), create_session(use_cache=True)])
+@pytest.mark.parametrize(
+    "session",
+    [
+        create_session(),
+        create_session(use_cache=True),
+        create_session(session=requests.Session()),
+    ],
+)
 def test_pydap_user_agent_headers(session):
     assert session.headers["User-Agent"].startswith("pydap/")


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes #675 
- [x] Tests is added

### Example
Pydap has overall 2 ways in which it fetches data using a request session object: 

1) Using pydap's internal logic to instantiate a session object, which may or may not cache the responses.

```python
from pydap.net import create_session
import requests

my_session = create_session(use_cache=True) # use_cache = True | False
```


2) Inherit a requests session object.
```python
session = create_session(session=requests.Session())
```
of via the new streaming dap API:
```python
pydap.client.to_netcdf(urls, session=requests.Session())
```

In the last one, the internals inherit the session state (headers, auth, etc etc) only avoid threading issues when making requests in parallel.


All these cases are now tested, and pydap appears in the headers always.


@ndp-opendap 


