### PR TITLE
remove python v310 from workflows

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -25,10 +25,10 @@ jobs:
     - name: Checkout pydap repository
       uses: actions/checkout@v6
 
-    - name: Setup Python 3.10
+    - name: Setup Python 3.11
       uses: actions/setup-python@v6
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Get tags
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*

--- a/.github/workflows/run_tests_macos.yml
+++ b/.github/workflows/run_tests_macos.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13']
     name: macos-latest Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13']
     name: ubuntu-latest Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -36,7 +35,7 @@ license = {file = "LICENSE"}
 maintainers = [{name = 'Miguel Jimenez-Urias', email = 'mjimenez@opendap.org'}]
 name = "pydap"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [project.entry-points."console_scripts"]
 dods = "pydap.handlers.dap:dump"


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Removes python v 3.10 from workflows, as it nears the end of its lifecycle.
- [x] Tests pass locally (no added tests)
