### PR TITLE
Upgrade Webob dependency to version 1.8.10 to fix CVE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "requests",
   "requests-cache",
   "scipy",
-  "Webob",
+  "webob>=1.8.10",
   "beautifulsoup4",
   "lxml",
   "Jinja2"


### PR DESCRIPTION
This PR adds a minimum required version pin to `Webob` in pyproject.toml to exclude versions of tornado that contain CVE-2026-44889

To reproduce the audit, after cloning and installing the requirements run
```
uv audit --preview --locked
Resolved 98 packages in 3ms
Found 7 known vulnerabilities and no adverse project statuses in 97 packages

Vulnerabilities:

bleach 6.3.0 has 3 known vulnerabilities:

- GHSA-8rfp-98v4-mmr6: Bleach: URI sanitization allows disallowed URI schemes with Unicode > U+00A0 in output

  Fixed in: 6.4.0

  Advisory information: https://github.com/mozilla/bleach/security/advisories/GHSA-8rfp-98v4-mmr6

- GHSA-gj48-438w-jh9v: Bleach clean() / Cleaner() fails to sanitize dangerous URI schemes in allowed formaction attributes

  Fixed in: 6.4.0

  Advisory information: https://github.com/mozilla/bleach/security/advisories/GHSA-gj48-438w-jh9v

- GHSA-g75f-g53v-794x: Bleach linkify(parse_email=True) CPU exhaustion via unbounded email regex scanning

  No fix versions available

  Advisory information: https://github.com/mozilla/bleach/security/advisories/GHSA-g75f-g53v-794x

cryptography 48.0.0 has 1 known vulnerability:

- GHSA-537c-gmf6-5ccf: Vulnerable OpenSSL included in cryptography wheels

  Fixed in: 48.0.1

  Advisory information: https://github.com/pyca/cryptography/security/advisories/GHSA-537c-gmf6-5ccf

tornado 6.5.6 has 1 known vulnerability:

- GHSA-pw6j-qg29-8w7f: Tornado: CurlAsyncHTTPClient leaks per-request credentials on handle reuse

  Fixed in: 6.5.7

  Advisory information: https://github.com/tornadoweb/tornado/security/advisories/GHSA-pw6j-qg29-8w7f

ujson 5.12.1 has 1 known vulnerability:

- GHSA-3j69-69wj-xqx2: UltraJSON: Malformed/Truncated UTF-8 Accepted and Silently Rewritten in ujson.dumps()

  Fixed in: 5.13.0

  Advisory information: https://github.com/ultrajson/ultrajson/security/advisories/GHSA-3j69-69wj-xqx2

webob 1.8.9 has 1 known vulnerability:

- GHSA-fh3h-vg37-cc95: WebOb: Location header normalization during redirect leads to open redirect - again

  Fixed in: 1.8.10

  Advisory information: https://github.com/Pylons/webob/security/advisories/GHSA-fh3h-vg37-cc95
```


This PR is to fix the bottom CVE https://github.com/Pylons/webob/security/advisories/GHSA-fh3h-vg37-cc95

N.B. To install the requirements after pulling, I had to modify the `pyproject.toml` replacing `requires-python = ">=3.11"` with `requires-python = ">=3.12"`


