### PR TITLE
fix CE construction when url points to Sequence

### DIFF
--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -131,7 +131,6 @@ class DAPHandler(BaseHandler):
             self.protocol = self.determine_protocol()
 
         self.projection, self.selection = parse_ce(self.query, self.protocol)
-        print("parse: ", self.selection)
         arg = (
             self.scheme,
             self.netloc,
@@ -297,7 +296,6 @@ class DAPHandler(BaseHandler):
         for var in walk(self.dataset, SequenceType):
 
             template = copy.copy(var)
-            print(f"proxy {self.selection}")
             var.data = SequenceDAP4Proxy(
                 self.base_url,
                 template,

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -839,19 +839,27 @@ class SequenceDAP4Proxy(SequenceProxy):
 
     @property
     def url(self):
-        """Return url from where data is fetched.
-        TO: needs testing that CE is properly generated
-        acorting to the dap4 spec, which is different from dap2.
-
-        """
+        """Return url from where data is fetched."""
         scheme, netloc, path, params, query, fragment = urlparse(self.baseurl)
+
+        _id = self.id
+        if len(self.id.split(".")) == 1:
+            # a) either the entire sequence is requested, or b) more than a one element.
+            # To remove any ambiguity - construct a CE that has all elements in sequence
+            children = list(self.sequence.keys())
+            _id += "{" + ";".join(children) + "}"
+
+        dap4query = "dap4.ce=" + _id + hyperslab(self.slice)
+        if len(self.selection) > 0:
+            dap4query += "|" + "&".join(self.selection)
+
         url = urlunparse(
             (
                 scheme,
                 netloc,
                 path + ".dap",
                 "",
-                "dap4.ce=" + self.id + hyperslab(self.slice) + "&".join(self.selection),
+                dap4query,
                 fragment,
             )
         ).rstrip("&")

--- a/src/pydap/handlers/dap.py
+++ b/src/pydap/handlers/dap.py
@@ -131,6 +131,7 @@ class DAPHandler(BaseHandler):
             self.protocol = self.determine_protocol()
 
         self.projection, self.selection = parse_ce(self.query, self.protocol)
+        print("parse: ", self.selection)
         arg = (
             self.scheme,
             self.netloc,
@@ -296,6 +297,7 @@ class DAPHandler(BaseHandler):
         for var in walk(self.dataset, SequenceType):
 
             template = copy.copy(var)
+            print(f"proxy {self.selection}")
             var.data = SequenceDAP4Proxy(
                 self.base_url,
                 template,
@@ -827,7 +829,10 @@ class SequenceDAP4Proxy(SequenceProxy):
 
         # return a copy with the added constraints
         elif isinstance(key, ConstraintExpression):
-            out.selection.extend(str(key).split("&"))
+            ce = str(key).split("&")[0]
+            ce_var = [ce.split(out.sequence.id + ".")[-1]]
+            # need to assert that ce_var is in sequence?
+            out.selection.extend(ce_var)
 
         # # slice data
         else:

--- a/src/pydap/tests/test_open_dap4_url.py
+++ b/src/pydap/tests/test_open_dap4_url.py
@@ -242,8 +242,16 @@ def test_sequence_dap4():
 
     # check that data is correct for the first two rows of the sequence
     new_seq = pyds["URI_GSO-Dock"][("Depth", "Sea_Temp")]
-    result = [data for data in new_seq.iterdata()][:2]
-    assert result == [(0.0, 7.037628), (1.95, 17.62)]
+    result = [data for data in new_seq.iterdata()][:6]
+    values = [
+        (1.95, 17.62),
+        (1.89, 17.76),
+        (1.84, 18.01),
+        (1.76, 17.99),
+        (1.73, 17.95),
+        (1.68, 18.01),
+    ]
+    assert result == values
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you very much for your hard work and contribution! -->

The following Pull Request:

- [x] Closes #718  
- [x] Tests are added to demonstrate the new or fixed behavior, and all tests pass
on a local environment.


### Example of feature
```python
from pydap.client import open_url
from pydap.net import create_session

url1 = 'http://test.opendap.org/opendap/hyrax/data/ff/gsodock.dat'
my_session = create_session()

# url with sequence URI_GSO-Dock
pyds = open_url(url1, session=my_session, protocol="dap4")
seq = pyds["URI_GSO-Dock"]

## This is new
seq = seq[("Time", "Depth", "Sea_Temp")][seq["Depth"].data<2.5]
```
The expression on the second square bracket is new. It requests data from the columns Time, Depth, and Sea_Temp that satisfy the filtering condition: `Depth<2.5`

### TODO for this PR to be ready

~Pydap should support multiple filtering conditions, as long as these involve variables currently present in the Sequence Object. ~ PR is ready

EDIT:

This PR  enabled pydap, in principle, to correctly deserialize a remote dap4 sequence by filtering via columns and by column value. The `dap4.ce` is constructed correctly, however the remote resource produces what appear to be an incorrect serialized dap response see [OPENDAP/libdap/#363](https://github.com/OPENDAP/libdap4/issues/363). As a result, the dap4.ce cannot be accurately tested.

